### PR TITLE
Fix TimePicker to use leading zero for minute values ("00" instead of "0...

### DIFF
--- a/source/IntegerScrollPicker.js
+++ b/source/IntegerScrollPicker.js
@@ -16,7 +16,9 @@ enyo.kind({
 	published: {
 		value: null,
 		min: 0,
-		max: 9
+		max: 9,
+		//* if specified, show value as this many zero-filled digits
+		digits: null
 	},
 	handlers: {
 		// onScrollStart:"scrollStart",
@@ -71,7 +73,11 @@ enyo.kind({
 	},
 	setupItem: function(inSender, inEvent) {
 		var index = inEvent.index;
-		this.$.item.setContent(index+this.min);
+		var content = index + this.min;
+		if (this.digits) {
+			content = ("00000000000000000000" + content).slice(-this.digits);
+		}
+		this.$.item.setContent(content);
 	},
 	rangeChanged: function() {
 		this.value = this.value >= this.min && this.value <= this.max ? this.value : this.min;

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -110,7 +110,7 @@ enyo.kind({
 				}
 				break;
 			case 'm': {
-					this.createComponent({kind:"moon.IntegerScrollPicker", name:"minute", classes:"moon-date-picker-month", min:0,max:59, value: this.value.getMinutes()});
+					this.createComponent({kind:"moon.IntegerScrollPicker", name:"minute", classes:"moon-date-picker-month", min:0,max:59, digits: 2, value: this.value.getMinutes()});
 				}
 				break;
 			case 'a': {
@@ -138,7 +138,7 @@ enyo.kind({
 			} else {
 				dateStr += this.value.getHours();
 			}
-			dateStr += ":" + this.value.getMinutes() + " ";
+			dateStr += ":" + ("00" + this.value.getMinutes()).slice(-2) + " ";
 			dateStr += this.meridiemEnable ? this.$.meridiem.getMeridiems()[this.$.meridiem.getValue()] : "";
 			return dateStr;
 		}


### PR DESCRIPTION
Fix TimePicker to use leading zero for minute values ("00" instead of "0")

Add "digits" property to IntegerScrollPicker to facilitate TimePicker minutes use.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
