### PR TITLE
Replace calls to _clientIndexInContainer_ with _indexInContainer_ to fix...

### DIFF
--- a/source/Panel.js
+++ b/source/Panel.js
@@ -70,7 +70,7 @@ enyo.kind({
 	
 	autoNumberChanged: function() {
 		if (this.getAutoNumber() == true && this.container) {
-			this.setTitleAbove(this.clientIndexInContainer() + 1);
+			this.setTitleAbove(this.indexInContainer() + 1);
 		}
 	},
 	//* Updates _this.header_ when _title_ changes.
@@ -184,14 +184,14 @@ enyo.kind({
 		this.doPostTransitionComplete();
 	},
 	preTransition: function(inFromIndex, inToIndex) {
-		if (this.container && !this.isBreadcrumb && this.container.layout.isBreadcrumb(this.clientIndexInContainer(), inToIndex)) {
+		if (this.container && !this.isBreadcrumb && this.container.layout.isBreadcrumb(this.indexInContainer(), inToIndex)) {
 			this.shrinkPanel();
 			return true;
 		}
 		return false;
 	},
 	postTransition: function(inFromIndex, inToIndex) {
-		if (this.container && this.isBreadcrumb && !this.container.layout.isBreadcrumb(this.clientIndexInContainer(), inToIndex)) {
+		if (this.container && this.isBreadcrumb && !this.container.layout.isBreadcrumb(this.indexInContainer(), inToIndex)) {
 			this.growPanel();
 			return true;
 		}


### PR DESCRIPTION
... problem with subclassing moon.Panels (in which case individual moon.Panel instances are created as chrome).

Enyo-DCO-1.1-Signed-off-by: Chris Patalano christopher.patalano@lge.com
