### PR TITLE
GF-5124: edit expandablePicker.less

### DIFF
--- a/css/ExpandablePicker.less
+++ b/css/ExpandablePicker.less
@@ -36,3 +36,7 @@
 	line-height: 14px;
 	font-weight: normal;
 }
+
+.moon-expandable-picker-help-text {
+  color: gray;
+}

--- a/css/moonstone.css
+++ b/css/moonstone.css
@@ -1386,6 +1386,23 @@ PageControl's use of IconButtons
 .moon-input-decorator.moon-disabled .moon-richtext {
   cursor: default;
 }
+/*ContextualPopupButton.css*/
+.contextual-popup-button {
+  background-image: url(../images/contextual-arrow.png);
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-right: 50px;
+}
+.contextual-popup-button.spotlight {
+  background-image: url(../images/contextual-arrow-spotlight.png);
+  background-repeat: no-repeat;
+  background-position: right center;
+  padding-right: 50px;
+}
+.contextual-popup-button.pressed,
+.contextual-popup-button:active {
+  background-image: url(../images/contextual-arrow.png);
+}
 /* ContextualPopupDecorator.css */
 .moon-contextual-popup-decorator {
   position: relative;


### PR DESCRIPTION
I moved my changes to ExpandablePicker.less and re-compile the CSS.
I checked that contextualPopup Classes is added again and
"moon-expandable-picker-help-text" which I created is added in moonstone.css through recompling.

Enyo-DCO-1.1-Signed-off-by: Dajung Chung dajung.chung@lge.com
