### PR TITLE
Sample Fix : InputDecorator

### DIFF
--- a/source/InputDecorator.js
+++ b/source/InputDecorator.js
@@ -108,7 +108,7 @@ enyo.kind({
 
 	onFocus: function(oSender, oEvent) {
 		enyo.Spotlight.spot(this);
-		enyo.Spotlight.disablePointerMode();
+	//	enyo.Spotlight.disablePointerMode();
 		this.updateFocus(true);
 	},
 


### PR DESCRIPTION
In ‘InputSample.html’, when I select a input control and type a text,
then other moon controls doesn’t selected by mouse. It is only possible
to move the spotlight using keyboard. And I push Enter key, It also
disable the pointer mode. It make sense that spotlight is focused only
selected input control which typing. After typing some sentence and
punch the enter key, it also disable the spotlight pointer mode. So,
line 111 in InputDecorator.js is commented.

Enyo-DCO-1.1-Singed-off-by: Jungchae Kim jungchae.kim@lge.com
