### PR TITLE
GF-5022 : New component: moon.ToggleButton (subclass of moon.Button, instead of moon.Item)

### DIFF
--- a/css/ToggleButton.less
+++ b/css/ToggleButton.less
@@ -1,32 +1,18 @@
 /* Toggle.css */
 
-.moon-checkbox.moon-toggle-button {
-	line-height: @moon-checkbox-image-height;
-	text-align: left;
+.moon-button.moon-toggle-button {
+	text-align: center;
 	text-transform: uppercase;
-	background: inherit;
-	opacity: 1;
-	background: transparent none no-repeat 0 0;
 	position: relative;
 }
-.moon-checkbox.moon-toggle-button[disabled] {
-	opacity: 0.4;
-}
-.moon-checkbox.moon-toggle-button[checked] {
-	background: transparent none no-repeat 0px 0px;
-}
 
-.moon-checkbox.moon-toggle-button .moon-overlay {
-	background: transparent;
-	position: absolute;
-	right: 0px;
-	text-align: right;
-	color: @moon-orange;
+.moon-toggle-button.moon-overlay {
+	border: 5px solid #A2A2A2;
 }
 
 .moon-toggle-button-text {
-	position: absolute;
+	position: relative;
 	right: 0px;
-	text-align: right;
+	text-align: center;
 	color: #A9A9A9;
 }

--- a/css/ToggleItem.less
+++ b/css/ToggleItem.less
@@ -1,25 +1,25 @@
-.moon-labeled-toggle-button {
+.moon-toggle-item {
 	display: block;
 	position:relative;
 }
-.moon-labeled-toggle-button .moon-labeled-toggle-button-label-wrapper {
+.moon-toggle-item .moon-toggle-item-label-wrapper {
 	height: 24px;
 	-webkit-mask-image: -webkit-linear-gradient(right, transparent 50px, white 75px);
 	padding: 2px 0px 0px 0px;
 }
-.moon-labeled-toggle-button.spotlight .moon-labeled-toggle-button-label-wrapper {
+.moon-toggle-item.spotlight .moon-toggle-item-label-wrapper {
 	-webkit-mask-image: -webkit-linear-gradient(right, transparent (@moon-no-spotlight-padding-right + 45), white (@moon-no-spotlight-padding-right + 60));
 }
-.moon-labeled-toggle-button .moon-labeled-toggle-button-label {
+.moon-toggle-item .moon-toggle-item-label {
 	float: left;
 	white-space: nowrap;
 }
-.moon-labeled-toggle-button .moon-toggle-button-text {
+.moon-toggle-item .moon-toggle-item-text {
 	margin-top: -1px;
 }
-.moon-labeled-toggle-button.disabled .moon-toggle-button-text {
+.moon-toggle-item.disabled .moon-toggle-item-text {
 	color: inherit;
 }
-.moon-labeled-toggle-button.disabled .moon-toggle-button {
+.moon-toggle-item.disabled .moon-toggle-item {
 	opacity: 1;
 }

--- a/css/ToggleText.less
+++ b/css/ToggleText.less
@@ -1,0 +1,32 @@
+/* Toggle.css */
+
+.moon-checkbox.moon-toggle-text {
+	line-height: @moon-checkbox-image-height;
+	text-align: left;
+	text-transform: uppercase;
+	background: inherit;
+	opacity: 1;
+	background: transparent none no-repeat 0 0;
+	position: relative;
+}
+.moon-checkbox.moon-toggle-text[disabled] {
+	opacity: 0.4;
+}
+.moon-checkbox.moon-toggle-text[checked] {
+	background: transparent none no-repeat 0px 0px;
+}
+
+.moon-checkbox.moon-toggle-text .moon-overlay {
+	background: transparent;
+	position: absolute;
+	right: 0px;
+	text-align: right;
+	color: @moon-orange;
+}
+
+.moon-toggle-text-text {
+	position: absolute;
+	right: 0px;
+	text-align: right;
+	color: #A9A9A9;
+}

--- a/css/moonstone-rules.less
+++ b/css/moonstone-rules.less
@@ -78,8 +78,9 @@
 @import "SimpleIntegerPicker.less";
 @import "Checkbox.less";
 @import "Divider.less";
-@import "ToggleButton.less";
 @import "CheckboxItem.less";
+@import "ToggleButton.less";
+@import "ToggleText.less";
 @import "ToggleItem.less";
 @import "Item.less";
 @import "SelectableItem.less";

--- a/css/moonstone.css
+++ b/css/moonstone.css
@@ -429,35 +429,6 @@
   text-transform: uppercase;
   font-weight: bold;
 }
-/* Toggle.css */
-.moon-checkbox.moon-toggle-button {
-  line-height: 36px;
-  text-align: left;
-  text-transform: uppercase;
-  background: inherit;
-  opacity: 1;
-  background: transparent none no-repeat 0 0;
-  position: relative;
-}
-.moon-checkbox.moon-toggle-button[disabled] {
-  opacity: 0.4;
-}
-.moon-checkbox.moon-toggle-button[checked] {
-  background: transparent none no-repeat 0px 0px;
-}
-.moon-checkbox.moon-toggle-button .moon-overlay {
-  background: transparent;
-  position: absolute;
-  right: 0px;
-  text-align: right;
-  color: #ffb80d;
-}
-.moon-toggle-button-text {
-  position: absolute;
-  right: 0px;
-  text-align: right;
-  color: #A9A9A9;
-}
 .moon-checkbox-item {
   display: block;
   position: relative;
@@ -491,29 +462,73 @@
   opacity: 0.4;
   filter: alpha(opacity=40);
 }
-.moon-labeled-toggle-button {
+/* Toggle.css */
+.moon-button.moon-toggle-button {
+  text-align: center;
+  text-transform: uppercase;
+  position: relative;
+}
+.moon-toggle-button.moon-overlay {
+  border: 5px solid #A2A2A2;
+}
+.moon-toggle-button-text {
+  position: relative;
+  right: 0px;
+  text-align: center;
+  color: #A9A9A9;
+}
+/* Toggle.css */
+.moon-checkbox.moon-toggle-text {
+  line-height: 36px;
+  text-align: left;
+  text-transform: uppercase;
+  background: inherit;
+  opacity: 1;
+  background: transparent none no-repeat 0 0;
+  position: relative;
+}
+.moon-checkbox.moon-toggle-text[disabled] {
+  opacity: 0.4;
+}
+.moon-checkbox.moon-toggle-text[checked] {
+  background: transparent none no-repeat 0px 0px;
+}
+.moon-checkbox.moon-toggle-text .moon-overlay {
+  background: transparent;
+  position: absolute;
+  right: 0px;
+  text-align: right;
+  color: #ffb80d;
+}
+.moon-toggle-text-text {
+  position: absolute;
+  right: 0px;
+  text-align: right;
+  color: #A9A9A9;
+}
+.moon-toggle-item {
   display: block;
   position: relative;
 }
-.moon-labeled-toggle-button .moon-labeled-toggle-button-label-wrapper {
+.moon-toggle-item .moon-toggle-item-label-wrapper {
   height: 24px;
   -webkit-mask-image: -webkit-linear-gradient(right, transparent 50px, #ffffff 75px);
   padding: 2px 0px 0px 0px;
 }
-.moon-labeled-toggle-button.spotlight .moon-labeled-toggle-button-label-wrapper {
+.moon-toggle-item.spotlight .moon-toggle-item-label-wrapper {
   -webkit-mask-image: -webkit-linear-gradient(right, transparent 69px, #ffffff 84px);
 }
-.moon-labeled-toggle-button .moon-labeled-toggle-button-label {
+.moon-toggle-item .moon-toggle-item-label {
   float: left;
   white-space: nowrap;
 }
-.moon-labeled-toggle-button .moon-toggle-button-text {
+.moon-toggle-item .moon-toggle-item-text {
   margin-top: -1px;
 }
-.moon-labeled-toggle-button.disabled .moon-toggle-button-text {
+.moon-toggle-item.disabled .moon-toggle-item-text {
   color: inherit;
 }
-.moon-labeled-toggle-button.disabled .moon-toggle-button {
+.moon-toggle-item.disabled .moon-toggle-item {
   opacity: 1;
 }
 /* Item.css */

--- a/source/ToggleButton.js
+++ b/source/ToggleButton.js
@@ -1,5 +1,5 @@
 /**
-	_moon.ToggleButton_, which extends <a href="#moon.Checkbox">moon.Checkbox</a>,
+	_moon.ToggleButton_, which extends <a href="#moon.Button">moon.Button</a>,
 	is a control that looks like a switch with labels for two states, an "on"
 	state and an "off" state.  When the ToggleButton is tapped, it switches its
 	state and fires an _onChange_ event.
@@ -7,31 +7,113 @@
 
 enyo.kind({
 	name: "moon.ToggleButton",
-	kind: "moon.Checkbox",
+	kind: "moon.Button",
+
 	published: {
+		//* to indicate that this is the active button of the group, false otherwise.
+		active: false,
+		//* Boolean indicating whether toggle button is currently in the "on"
+		//* state
+		value: false,
 		//* Label for toggle button's "on" state
-		onContent: $L("on"),
+		onContent: $L("On"),
 		//* Label for toggle button's "off" state
-		offContent: $L("off")
+		offContent: $L("Off"),
+		//* Label for seperator
+		labelSeperator: $L(":"), 
+		//* If true, toggle button cannot be tapped and thus will not generate
+		//* any events
+		disabled: false
+	},
+	events: {
+		/**
+ 			Fires when the user changes the value of the toggle button,	but not
+ 			when the value is changed programmatically.
+
+ 			_inEvent.value_ contains the value of the toggle button.
+ 		*/
+		onChange: ""
 	},
 	//* @protected
 	classes: "moon-toggle-button",
+	handlers: {
+		ondragstart: "dragstart",
+		ondrag: "drag",
+		ondragfinish: "dragfinish"
+	},
 	components: [
-		{name: "label", classes: "moon-toggle-button-text"}
+		{name: "contentOn", classes: "moon-toggle-button-text"},
+		{name: "contentOff", classes: "moon-toggle-button-text"}
 	],
 	create: function() {
 		this.inherited(arguments);
-		this.checkedChanged();
+		this.value = Boolean(this.value || this.active);
+		this.onContentChanged();
+		this.offContentChanged();
+		this.disabledChanged();
 	},
-	checkedChanged: function() {
+	rendered: function() {
 		this.inherited(arguments);
-		this.$.label.setContent(this.getChecked() ? this.onContent : this.offContent);
+		this.updateVisualState();
 	},
-	shouldDoTransition: function(inChecked) {
-		return true;
+	updateVisualState: function() {
+		this.addRemoveClass("moon-overlay", this.value);
+		this.$.contentOn.setShowing(this.value);
+		this.$.contentOff.setShowing(!this.value);
+		this.setActive(this.value);
 	},
-	createOverlayComponent: function() {
-		var content = this.getChecked() ? this.getOnContent() : this.getOffContent();
-		return this.createComponent({name: "overlay", classes: "moon-overlay", content: content});
+	valueChanged: function() {
+		this.updateVisualState();
+		this.doChange({value: this.value});
+	},
+	activeChanged: function() {
+		this.setValue(this.active);
+		this.bubble("onActivate");
+	},
+	labelSeperatorChanged: function() {
+		this.onContentChanged();
+		this.offContentChanged();	
+		this.updateVisualState();
+	},
+	onContentChanged: function() {
+		this.$.contentOn.setContent((this.content || "") + (this.labelSeperator || " ") + (this.onContent || ""));
+	}, 
+	offContentChanged: function() {
+		this.$.contentOff.setContent((this.content || "") + (this.labelSeperator || " ") + (this.offContent || ""));
+	},
+	disabledChanged: function() {
+		this.setAttribute("disabled", this.disabled);
+	},
+	updateValue: function(inValue) {
+		if (!this.disabled) {
+			this.setValue(inValue);
+		}
+	},
+	tap: function() {
+ 		this.updateValue(!this.value);
+	},
+	dragstart: function(inSenser, inEvent) {
+		if (inEvent.horizontal) {
+			inEvent.preventDefault();
+			this.dragging = true;
+			this.dragged = false;
+			return true;
+		}
+	},
+	drag: function(inSender, inEvnet) {
+		if (this.dragging) {
+			var d = inEvent.dx;
+			if (Math.abs(d) > 10) {
+				this.updateValue(d > 0);
+				this.dragged = true;
+			}
+			return true;
+		}
+	},
+	dragfinish: function(inSender, inEvent) {
+		this.dragging = false;
+		if (this.dragged) {
+			inEvent.preventTap();
+		}
 	}
 });

--- a/source/ToggleItem.js
+++ b/source/ToggleItem.js
@@ -1,16 +1,16 @@
 /**
 	_moon.ToggleItem_ is a control that combines a
-	<a href="#moon.ToggleButton">moon.ToggleButton</a> with a text label.
+	<a href="#moon.ToggleText">moon.ToggleText</a> with a text label.
 */
 enyo.kind({
 	name: "moon.ToggleItem",
 	kind: "moon.CheckboxItem",
 	//* @protected
-	classes: "moon-labeled-toggle-button",
+	classes: "moon-toggle-item",
 	components: [
-		{classes: "moon-labeled-toggle-button-label-wrapper", components: [
-			{name: "label", classes: "moon-labeled-toggle-button-label"}
+		{classes: "moon-toggle-item-label-wrapper", components: [
+			{name: "label", classes: "moon-toggle-item-label"}
 		]},
-		{name: "input", kind: "moon.ToggleButton", spotlight: false}
+		{name: "input", kind: "moon.ToggleText", spotlight: false}
 	]
 });

--- a/source/ToggleText.js
+++ b/source/ToggleText.js
@@ -1,0 +1,37 @@
+/**
+	_moon.ToggleText_, which extends <a href="#moon.Checkbox">moon.Checkbox</a>,
+	is a control that looks like a switch with labels for two states, an "on"
+	state and an "off" state.  When the ToggleText is tapped, it switches its
+	state and fires an _onChange_ event.
+*/
+
+enyo.kind({
+	name: "moon.ToggleText",
+	kind: "moon.Checkbox",
+	published: {
+		//* Label for toggle text's "on" state
+		onContent: $L("on"),
+		//* Label for toggle text's "off" state
+		offContent: $L("off")
+	},
+	//* @protected
+	classes: "moon-toggle-text",
+	components: [
+		{name: "label", classes: "moon-toggle-text-text"}
+	],
+	create: function() {
+		this.inherited(arguments);
+		this.checkedChanged();
+	},
+	checkedChanged: function() {
+		this.inherited(arguments);
+		this.$.label.setContent(this.getChecked() ? this.onContent : this.offContent);
+	},
+	shouldDoTransition: function(inChecked) {
+		return true;
+	},
+	createOverlayComponent: function() {
+		var content = this.getChecked() ? this.getOnContent() : this.getOffContent();
+		return this.createComponent({name: "overlay", classes: "moon-overlay", content: content});
+	}
+});

--- a/source/package.js
+++ b/source/package.js
@@ -11,6 +11,7 @@ enyo.depends(
 	"CheckboxItem.js",
 	"ToggleButton.js",
 	"ToggleItem.js",
+	"ToggleText.js",
 	"RadioItem.js",
 	"RadioItemGroup.js",
 	"ExpandableListItem.js",


### PR DESCRIPTION
Renamed old moon.ToggleButton to moon.ToggleText, and added new moon.ToggleButton. Also, related less files was modified. 

---

Description

Task to create new moon.ToggleButton.  Note, per GF-4999, moon.ToggleButton and moon.LabeledToggleButton will be renamed to moon.ToggleText and moon.ToggleItem, respectively.  As such, this task is to create a new moon.ToggleButton, which should sub-class moon.Button and provide toggling support, with visuals as per attached.

API should match onyx.ToggleButton, with this addition:
- label - if truthy, this (static) label should prefix the ON/OFF text, separated by a colon

The button should be designed such that the length of the button does not change when toggling on/off.

---

Enyo-DCO-1.1-Singed-off-by: Jungchae Kim jungchae.kim@lge.com
