### PR TITLE
Fixes a bug where toggling the checkboxes off causes an activate event t...

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -102,12 +102,14 @@ enyo.kind({
 			index = -1;
 
 		for(var i=0;i<controls.length;i++) {
+			controls[i].silence();
 			if(controls[i] === selected) {
 				controls[i].setChecked(true);
 				index = i;
 			} else {
 				controls[i].setChecked(false);
 			}
+			controls[i].unsilence();
 		}
 
 		if(index > -1 && selected !== inOldValue) {


### PR DESCRIPTION
...o fire during changes triggered by setSelectedIndex().  Exacerbated by checkbox sending activate with checked true even though the checkbox was just set to checked false.  Enyo-DCO-1.1-Signed-off-by: Roy Sutton roy.sutton@lge.com
