### PR TITLE
GF-6319: Use small button

### DIFF
--- a/css/CalendarPicker.less
+++ b/css/CalendarPicker.less
@@ -6,9 +6,6 @@
 .moon-calendar-picker-block {
 	display: inline-block;
 }
-
-.moon-calendar-picker-simplepicker .picker-content {
-}
 .moon-calendar-picker .picker-button {
 	margin: 2px 0px;
 	font-size: @moon-picker-button-font-size;
@@ -23,9 +20,8 @@
 	white-space: nowrap;
 }
 .moon-calendar-picker-date {
-	.moon-sub-header-text;
 	width: @moon-picker-button-width;
-	min-width: @moon-picker-button-width;	
+	min-width: @moon-picker-button-width;
 	height: @moon-picker-button-width;
 	line-height: @moon-picker-button-width;
 	border: 0px;
@@ -36,13 +32,6 @@
 	margin: 10px;
 	text-align: center;
 	vertical-align: middle; 
-}
-.moon-calendar-picker-date.spotlight {
-	border: @moon-button-border-width - 4 solid @moon-spotlight-border-color;
-	background: @moon-spotlight-border-color;
-}
-.moon-calendar-picker-date.active {
-	background-color: @moon-spotlight-border-color;
 }
 .moon-calendar-picker-date-shadow {
 	color: #A2A2A2;

--- a/css/moonstone.css
+++ b/css/moonstone.css
@@ -2243,15 +2243,9 @@ body .enyo-fit.panels-50-percent-scrim,
   white-space: nowrap;
 }
 .moon-calendar-picker-date {
-  font-family: "MuseoSans 700";
-  font-size: 30px;
-  font-weight: normal;
-  font-style: normal;
-  letter-spacing: -0.04em;
   width: 40px;
   min-width: 40px;
   height: 40px;
-  line-height: 40px;
   border: 0px;
   border-radius: 9999px;
   background: inherit;
@@ -2260,13 +2254,6 @@ body .enyo-fit.panels-50-percent-scrim,
   margin: 10px;
   text-align: center;
   vertical-align: middle;
-}
-.moon-calendar-picker-date.spotlight {
-  border: 1px solid #ffb80d;
-  background: #ffb80d;
-}
-.moon-calendar-picker-date.active {
-  background-color: #ffb80d;
 }
 .moon-calendar-picker-date-shadow {
   color: #A2A2A2;

--- a/source/CalendarPicker.js
+++ b/source/CalendarPicker.js
@@ -9,9 +9,9 @@
 */
 enyo.kind({
 	name: "moon.CalendarPickerDate",
-	kind: "enyo.Button",
+	kind: "moon.Button",
+	small: true,
 	classes: "moon-calendar-picker-date enyo-unselectable",
-	spotlight: true,
 	published: {
 		value: null,
 		color: 0


### PR DESCRIPTION
Previous moon.CalendarPickerDate inherited enyo.Button.
In this commit, I replaced enyo.Button with moon.Button which small property enabled.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com

http://jira2.lgsvl.com/browse/GF-6319
