### PR TITLE
GF-7533: removed "InputPanel.js" in package.js

### DIFF
--- a/source/package.js
+++ b/source/package.js
@@ -53,7 +53,6 @@ enyo.depends(
 	"MoonScrollStrategy.js",
 	"Thumb.js",
 	"InputHeader.js",
-	"InputPanel.js",
 	"Scrim.js",
 	"Popup.js",
 	"Dialog.js",


### PR DESCRIPTION
because InputPanel.js file was already removed

Enyo-DCO-1.1-Signed-Off-By: Yunbum Sung yb.sung@lge.com
