### PR TITLE
GF-7249 allowHtml to title in moon.Header using facade pattern

### DIFF
--- a/patterns-samples/Login/Login.FrontDoorViaPanelSample.js
+++ b/patterns-samples/Login/Login.FrontDoorViaPanelSample.js
@@ -5,7 +5,8 @@ enyo.kind({
     name: "moon.sample.login.FrontDoorViaPanelSample",
     kind: "moon.Panel",
     //* @protected
-    title: "3rd PARTY APP NAME",
+    allowHtmlTitle: true,
+    title: "3<sup>rd</sup> PARTY APP NAME",
     components: [
         {kind: "FittableColumns", components: [
             {name: "appInfo", kind: "enyo.DataRepeater", components: [

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -43,7 +43,9 @@ enyo.kind({
 		//* control must have 'overflow:hidden' set, and the marquee text will clip at the parent's border
 		clipInsidePadding: true,
 		//* When disabled, marqueeing will not occur
-		disabled: false
+		disabled: false,
+		//* _allowHtml_ property of Marquee text
+		allowHtmlText: false
 	},
 	events: {
 		onMarqueeStarted:"",
@@ -84,6 +86,11 @@ enyo.kind({
         return true;
 	},
 	//*@protected
+	allowHtmlTextChanged: function() {
+		if(this.marqueeControl) {
+			this.marqueeControl.setAllowHtml(this.allowHtmlText);
+		}
+	},
 	contentChanged: function() {
 		if (this.$.client) {
 			this.$.client.setContent(this.content);

--- a/source/Panel.js
+++ b/source/Panel.js
@@ -27,7 +27,9 @@ enyo.kind({
 		//* Facade for the header's _small_ property
 		smallHeader: false,
 		//* If true, the header collapses when the panel body is scrolled down
-		collapsingHeader: false
+		collapsingHeader: false,
+		//* Title's _allowHtml_ property
+		allowHtmlTitle: false
 	},
 	events : {
 		//* Fires when this panel has completed its pre-arrangement transition.
@@ -37,7 +39,7 @@ enyo.kind({
 	},
 	handlers: {
 		onScroll: "scroll",
-		onPanelsPostTransitionFinished: "panelsTransitionFinishHandler",
+		onPanelsPostTransitionFinished: "panelsTransitionFinishHandler"
 	},
 
 	//* @protected
@@ -64,6 +66,7 @@ enyo.kind({
 		this.titleBelowChanged();
 		this.subTitleBelowChanged();
 		this.smallHeaderChanged();
+		this.allowHtmlControl();
 	},
 	initComponents: function() {
 		this.createTools();
@@ -228,6 +231,9 @@ enyo.kind({
 	},
 
 	//* @protected
+	allowHtmlControl: function() {
+		this.$.header.$.title.setAllowHtmlText(this.allowHtmlTitle);
+	},
 	panelsTransitionFinishHandler: function(inSender, inEvent) {
 		if(inEvent.active >= inEvent.index) {
 			this.$.header.startMarquee();


### PR DESCRIPTION
New branch of GF-7249 is pulled request for merge with master. 
- moon.Panel
- allowHtmlTitle is related to allowHtmlText in moon.MarqueeText

Enyo-DCO-1.1-Singed-off-by: Jungchae Kim jungchae.kim@lge.com
