### PR TITLE
ENYO-2639~2644,2649~2656 : I can add moonstone component on designer from palette

### DIFF
--- a/moonstone.design
+++ b/moonstone.design
@@ -419,19 +419,19 @@
                 {
                     "name": "moon.IconButton",
                     "kind": "moon.IconButton",
-                    "description": "A icon button",
+                    "description": "An icon button",
                     "config": {
                         "kind": "moon.IconButton",
-                        "src": "lib/moonstone/images/checkbox.png"
+                        "src": "$lib/moonstone/images/checkbox.png"
                     }
                 },
                 {
                     "name": "moon.ImageItem",
                     "kind": "moon.ImageItem",
-                    "description": "A image item",
+                    "description": "An image item",
                     "config": {
                         "kind": "moon.ImageItem",
-                        "source": "lib/moonstone/images/enyo-icon.png",
+                        "source": "$lib/moonstone/images/enyo-icon.png",
                         "label": "Image Item",
                         "text" : "This is a image item. This is an example for the text contents."
                     }
@@ -439,7 +439,7 @@
                 {
                     "name": "moon.IntegerScrollPicker",
                     "kind": "moon.IntegerScrollPicker",
-                    "description": "A integer scroll picker",
+                    "description": "An integer scroll picker",
                     "config": {
                         "kind": "moon.IntegerScrollPicker",
                         "value": 1,
@@ -476,7 +476,7 @@
                 {
                     "name": "moon.ExpandablePicker",
                     "kind": "moon.ExpandablePicker",
-                    "description": "A expandable picker",
+                    "description": "An expandable picker",
                     "config": {
                         "kind": "moon.ExpandablePicker",
                         "content": "Expandable Picker",


### PR DESCRIPTION
Add moonstone component on Ares designer palette
- DatePicker
- Drawers
- GridList
- IconButton
- ImageItem
- IntegerScrollPicker
- Popup
- ProgressBar
- Scroller
- ExpandablePicker
- SimplePicker
- Tooltip

Enyo-DCO-1.1-Signed-off-by : Juhyun Yun yunju123@gmail.com

![moonstonecomponent](https://f.cloud.github.com/assets/3174770/846261/f8b09260-f408-11e2-8876-ea091ebb1a7b.png)
