### PR TITLE
GF-9653: Add min-width and height to prevent overlapping

### DIFF
--- a/patterns-samples/Audio/AudioPlaybackSample.css
+++ b/patterns-samples/Audio/AudioPlaybackSample.css
@@ -38,8 +38,8 @@
 }
 
 .sample-audio-item-image {
-  width: 126px;
-  height: 126px;
+  min-width: 126px;
+  min-height: 126px;
   display: table-cell;
   background-repeat: no-repeat;
 }


### PR DESCRIPTION
Sometimes item image is overlapped with adjacent text.
To prevent overlapping, min-value for height and width are added.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
