### PR TITLE
GF-9659: Prevent to colect garbage value in duration

### DIFF
--- a/source/AudioPlayback.js
+++ b/source/AudioPlayback.js
@@ -109,10 +109,11 @@ enyo.kind({
 		this.owner.$.drawers.$.drawerHandle.setContent(a.trackName + " by " + a.artistName);
 	},
 	updatePlayhead: function() {
-		var totalTime = this.$.audio.getDuration();
+		var duration = this.$.audio.getDuration();
+		var totalTime = isNaN(duration) ? 0 : duration;
 		var currentTime = this.$.audio.getCurrentTime();
 		var playheadPos = (currentTime * 100) / totalTime;
-		this.updatePlayTime(this.toReadableTime(currentTime), this.toReadableTime(isNaN(totalTime) ? 0 : totalTime));
+		this.updatePlayTime(this.toReadableTime(currentTime), this.toReadableTime(totalTime));
 		this.$.slider.updateKnobPosition(playheadPos);
 		this.$.slider.setProgress(playheadPos);
 	},


### PR DESCRIPTION
When we play once then move to next or previous audio, getDuration()
could return NaN.
That is only occurred from gap betw'n end of first audio & begining of
second.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
