### PR TITLE
GF-9997: TypeError fixed

### DIFF
--- a/patterns-samples/Wizard/Wizard.ActionMenuSample.js
+++ b/patterns-samples/Wizard/Wizard.ActionMenuSample.js
@@ -77,7 +77,7 @@ enyo.kind({
     onTap: function(oSender, oEvent) {
         //* override from panels
         // no action for Carosel Arranger using button
-        var target = oEvent.dispatchTarget.kind;
+        var target = oEvent.dispatchTarget ? oEvent.dispatchTarget.kind : undefined;
         switch(target)
         {
         case "moon.Item":


### PR DESCRIPTION
Uncaught TypeError: Cannot read property 'kind' of undefined -
Wizard.ActionMenuSample.js:80

Enyo-DCO-1.1-Signed-Off-By: Yunbum Sung yb.sung@lge.com
