### PR TITLE
GF-9123: Disable autoDismiss to reduce confusing

### DIFF
--- a/samples/ContextualPopupSample.js
+++ b/samples/ContextualPopupSample.js
@@ -66,7 +66,7 @@ enyo.kind({
 		]},
 		{kind: "moon.ContextualPopupDecorator", style: "position: absolute; left: 0px; bottom: 0px;", components: [
 			{content: "Spotlight Modal"},
-			{kind: "moon.ContextualPopup", name: "buttonPopup", classes: "moon-6h moon-2v", spotlightModal: true,
+			{kind: "moon.ContextualPopup", name: "buttonPopup", classes: "moon-6h moon-2v", modal: true, autoDismiss: false, spotlightModal: true,
 				components: [
 					{kind: "Scroller", horizontal: "auto", touch: true, thumb: false, classes: "enyo-fill", components: [
 						{kind: "moon.Button", content: "Button"},


### PR DESCRIPTION
In contextualPopup use case, there could be confusing at Spotlight modal
On/Off button.
To prevent it, add two properties.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
