### PR TITLE
GF-10278: Disable arrow button when there are no more selctable items.

### DIFF
--- a/css/SimplePicker.less
+++ b/css/SimplePicker.less
@@ -24,7 +24,8 @@
 	background: transparent @moon-caret-black-large-up-icon no-repeat center center;
 }
 .moon-simple-picker-button.hidden {
-	opacity: 0;
+	opacity: @moon-disabled-opacity;
+	filter: alpha(opacity=@moon-disabled-opacity-ie);
 }
 
 .moon-simple-picker-button.spotlight {

--- a/css/moonstone.css
+++ b/css/moonstone.css
@@ -447,7 +447,8 @@
   background: transparent url(../images/caret-black-large-up-icon.png) no-repeat center center;
 }
 .moon-simple-picker-button.hidden {
-  opacity: 0;
+  opacity: 0.4;
+  filter: alpha(opacity=40);
 }
 .moon-simple-picker-button.spotlight {
   background-color: #ffb80d;

--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -191,6 +191,7 @@ enyo.kind({
 	//* Hide _inControl_ and disable spotlight functionality
 	hideNavButton: function(inControl) {
 		inControl.addClass("hidden");
+		enyo.Spotlight.unspot();
 		inControl.spotlight = false;
 	},
 	//* Show _inControl_ and enable spotlight functionality


### PR DESCRIPTION
Previously arrow buttons for both direction are always enabled even
though there are no more items selectable.
From now on, arrow button will be hide when picker reachs to end of its
direction.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
