### PR TITLE
ENYO-2860, 2863, 2641: Bug fix - moonstone component on designer from palette 

### DIFF
--- a/moonstone.design
+++ b/moonstone.design
@@ -513,10 +513,16 @@
                     "description": "A grid list",
                     "config": {
                         "kind": "moon.GridList",
+                        "itemWidth": 100,
+                        "itemHeight": 100,
+                        "itemSpacing": 50,
+                        "count": 15,
                         "components": [
                             {
-                                "name": "item",
-                                "kind": "moon.GridListImageItem"
+                                "kind": "moon.GridListImageItem",
+                                "source": "$lib/moonstone/images/enyo-icon.png",
+                                "caption": "Sample",
+                                "subCaption": "item"
                             }
                         ]
                     }


### PR DESCRIPTION
When drag & drop "tooltip" component on designer, "tooltip decorator" will be add as well to improve visibility.

![tooltipcomponent](https://f.cloud.github.com/assets/3174770/945512/b5f3e900-0311-11e3-9c74-b627ae98b200.png)

When drag & drop "List (Horizontal)" component on designer, some sub items will be show as well so that developer can see list and list items.

![listhorizontal](https://f.cloud.github.com/assets/3174770/945864/53651e94-0320-11e3-9223-e5210982d57a.png)

When drag & drop "Grid List" component on designer, some sub items will be show as well so that developer can see list and list items.

![gridlist](https://f.cloud.github.com/assets/3174770/946088/816383f6-0327-11e3-9aad-43652a54a8ab.png)

Enyo-DCO-1.1-Signed-off-by : Juhyun Yoon yunju123@gmail.com
