### PR TITLE
Fix for GF-12211

### DIFF
--- a/source/Drawers.js
+++ b/source/Drawers.js
@@ -64,11 +64,11 @@ enyo.kind({
 		this.setupHandles();
 	},
 	rendered: function() {
-	    this.inherited(arguments);
+		this.inherited(arguments);
+		var dh = document.body.getBoundingClientRect().height;
+		var ah = this.$.activator.hasNode().getBoundingClientRect().height;
+		this.waterfall("onDrawersRendered", {drawersHeight: dh, activatorHeight: ah});
 		this.resizeDresser();
-	    var dh = document.body.getBoundingClientRect().height;
-	    var ah = this.$.activator.hasNode().getBoundingClientRect().height;
-	    this.waterfall("onDrawersRendered", {drawersHeight: dh, activatorHeight: ah});
 	},
 	resizeDresser: function() {
 		var client = this.getBounds();
@@ -85,9 +85,14 @@ enyo.kind({
 		this.$.drawers.applyStyle('top', (-client.top-10)+'px');
 		this.$.drawers.applyStyle('width',enyo.dom.getWindowWidth() + "px");
 
-		//Fix for GF-12211 
-		this.$.client.applyStyle('top', -client.top +'px');
-	},	
+		this.resizeClient();
+	},
+	resizeClient: function(){
+		var aHeight = this.$.activator.hasNode().getBoundingClientRect().height;
+		var hHeight = this.$.handleContainer.hasNode().getBoundingClientRect().height;
+		var dHeight = this.$.drawers.hasNode().getBoundingClientRect().height;
+		this.$.client.applyStyle('height', (this.getBounds().height - (aHeight + hHeight + dHeight)) + 'px');
+	},
 	setupHandles: function() {
 		var handles = [];
 		for (var index in this.drawers){


### PR DESCRIPTION
Defect reason: The "client" component  was exceeding beyond the
boundaries.
As all the other components were moved to top, to provide proper view
for the drawer, however the "client" component was not been moved and as
per the styles it was taking the height of the parent div.
Solution: provided top to "client"component also.

Enyo-DCO-1.1-Signed-off-by: Anish Ramesan anish.ramesan@lge.com
