### PR TITLE
GF-12189: moon.ExpandableInput - Allow use with no noneText (make shorter)

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -74,6 +74,7 @@ enyo.kind({
 		} else if(this.value != this.$.currentValue.content) {
 			this.$.currentValue.setContent(this.value);
 		}
+		this.$.currentValue.setShowing(!this.open && (this.$.currentValue.content !== ""));
 	},
 	//* Updates _value_ and _content_ when _this.value_ changes. 
 	valueChanged: function(inOld) {


### PR DESCRIPTION
Hide 'current value' component when its value is empty (it means nonetext value is empty and there is no input value)

Enyo-DCO-1.1-Signed-off-by: Juhyun Yun yunju123@gmail.com
