### PR TITLE
Defect fix GF-10224

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -431,6 +431,8 @@ enyo.kind({
 		this.$.pageDownControl.addClass("hidden");
 	},
 	_getScrollBounds: function() {
+		var vBounds = this.$.vthumbContainer.getBounds(),
+			hBounds = this.$.hthumbContainer.getBounds();
 		var containerBounds = this.$.clientContainer.getBounds(),
 			s = this.getScrollSize(),
 			b = {
@@ -443,8 +445,8 @@ enyo.kind({
 			}
 		;
 
-		b.maxLeft = Math.max(0, b.width - b.clientWidth);
-		b.maxTop = Math.max(0, b.height - b.clientHeight);
+		b.maxLeft = Math.max(0, b.width - b.clientWidth + vBounds.width);
+		b.maxTop = Math.max(0, b.height - b.clientHeight + hBounds.height);
 		
 		enyo.mixin(b, this.getOverScrollBounds());
 		
@@ -460,6 +462,8 @@ enyo.kind({
 	animateToControl: function(inControl, inScrollFullPage) {
 		var controlBounds  = enyo.Spotlight.Util.getAbsoluteBounds(inControl),
 			absoluteBounds = enyo.Spotlight.Util.getAbsoluteBounds(this.container),
+			vBounds = enyo.Spotlight.Util.getAbsoluteBounds(this.$.vthumbContainer),
+			hBounds = enyo.Spotlight.Util.getAbsoluteBounds(this.$.hthumbContainer),
 			scrollBounds   = this.getScrollBounds(),
 			offsetTop      = controlBounds.top - absoluteBounds.top,
 			offsetLeft     = controlBounds.left - absoluteBounds.left,
@@ -503,7 +507,7 @@ enyo.kind({
 			if (inScrollFullPage || offsetWidth > scrollBounds.clientWidth) {
 				x = offsetLeft;
 			} else {
-				x = offsetLeft - scrollBounds.clientWidth + offsetWidth;
+				x = offsetLeft - scrollBounds.clientWidth + offsetWidth + hBounds.right;
 				// If nodeStyle exists, add the _marginRight_ to the scroll value.
 				x += enyo.dom.getComputedBoxValue(inControl.hasNode(), "margin", "right");
 			}
@@ -513,7 +517,7 @@ enyo.kind({
 			// is larger than the viewport, scroll to the control's right edge. Otherwise, scroll just
 			// far enough to get the control into view.
 			if (inScrollFullPage || offsetWidth > scrollBounds.clientWidth) {
-				x = offsetLeft - scrollBounds.clientWidth + offsetWidth;
+				x = offsetLeft - scrollBounds.clientWidth + offsetWidth + hBounds.right;
 			} else {
 				x = offsetLeft;
 				// If nodeStyle exists, subtract the _marginLeft_ to the scroll value.
@@ -535,7 +539,7 @@ enyo.kind({
 				// If nodeStyle exists, add the _marginBottom_ to the scroll value.
 				y -= enyo.dom.getComputedBoxValue(inControl.hasNode(), "margin", "top");
 			} else {
-				y = offsetTop - scrollBounds.clientHeight + offsetHeight;
+				y = offsetTop - scrollBounds.clientHeight + offsetHeight + vBounds.top;
 				// If nodeStyle exists, add the _marginBottom_ to the scroll value.
 				y += enyo.dom.getComputedBoxValue(inControl.hasNode(), "margin", "bottom");
 			}
@@ -545,7 +549,7 @@ enyo.kind({
 			// is larger than the viewport, scroll to the control's bottom edge. Otherwise, scroll just
 			// far enough to get the control into view.
 			if (inScrollFullPage || offsetHeight > scrollBounds.clientHeight) {
-				y = offsetTop - scrollBounds.clientHeight + offsetHeight;
+				y = offsetTop - scrollBounds.clientHeight + offsetHeight + vBounds.top;
 			} else {
 				y = offsetTop;
 				// If nodeStyle exists, subtract the _marginTop_ to the scroll value.


### PR DESCRIPTION
Reason: The scroll bounds dint consider the vertical and horizontal
thumb containers.
Fix: Took vertical and horizontal bars into consideration so that rest
of the area behind it is also visible while scrolling or by moving with
directions.

Enyo-DCO-1.1-Signed-off-by: Anish Ramesan anish.ramesan@lge.com
