### PR TITLE
GF-13210: Make 'selected' property usable.

### DIFF
--- a/samples/SelectableItemSample.js
+++ b/samples/SelectableItemSample.js
@@ -8,30 +8,18 @@ enyo.kind({
 			{classes: "moon-hspacing", controlClasses:"moon-4h", components: [
 				{components: [
 					{kind: "moon.Divider", content: "Selectable Items"},
-<<<<<<< HEAD
-					{kind: "moon.SelectableItem", content: "Option 1", onActivate: "itemChanged"},
-					{kind: "moon.SelectableItem", content: "Option 2", onActivate: "itemChanged"},
-					{kind: "moon.SelectableItem", disabled: true, content: "Deactivated", onActivate: "itemChanged"},
-					{kind: "moon.SelectableItem", content: "Option 4", onActivate: "itemChanged"},
-=======
-					{kind: "moon.SelectableItem", content: "Option 1", active: true, onActivate: "itemChanged"},
+					{kind: "moon.SelectableItem", content: "Option 1", selected: true, onActivate: "itemChanged"},
 					{kind: "moon.SelectableItem", content: "Option 2", onActivate: "itemChanged"},
 					{kind: "moon.SelectableItem", disabled: true, content: "Disabled", onActivate: "itemChanged"},
-					{kind: "moon.SelectableItem", content: "Option 4", active: true, onActivate: "itemChanged"},
->>>>>>> master
+					{kind: "moon.SelectableItem", content: "Option 4", selected: true, onActivate: "itemChanged"},
 					{kind: "moon.SelectableItem", content: "Option 5", onActivate: "itemChanged"}
 				]},
 				{components: [
 					{kind: "moon.Divider", content: "Selectable Item Group"},
 					{kind: "Group", onActivate: "groupChanged", components: [
 						{kind: "moon.SelectableItem", content: "Group Option 1"},
-<<<<<<< HEAD
 						{kind: "moon.SelectableItem", content: "Group Option 2"},
-						{kind: "moon.SelectableItem", disabled: true, content: "Deactivated"},
-=======
-						{kind: "moon.SelectableItem", content: "Group Option 2", active: true},
 						{kind: "moon.SelectableItem", disabled: true, content: "Disabled"},
->>>>>>> master
 						{kind: "moon.SelectableItem", content: "Group Option 4"},
 						{kind: "moon.SelectableItem", content: "Group Option 5", selected: true}
 					]}
@@ -39,17 +27,10 @@ enyo.kind({
 				{components: [
 					{kind: "Group", onActivate: "groupChanged", components: [
 						{kind: "moon.Divider", content: "Selectable Items with long text truncation"},
-<<<<<<< HEAD
-						{kind: "moon.SelectableItem", content: "Option 1 with long text truncation", selected: true, onActivate: "itemChanged"},
-						{kind: "moon.SelectableItem", content: "Option 2 with long text truncation", onActivate: "itemChanged"},
-						{kind: "moon.SelectableItem", disabled: true, content: "Deactivated", onActivate: "itemChanged"},
-						{kind: "moon.SelectableItem", content: "Option 4 with long text truncation", selected: true, onActivate: "itemChanged"},
-=======
 						{kind: "moon.SelectableItem", content: "Option 1 with long text truncation", onActivate: "itemChanged"},
 						{kind: "moon.SelectableItem", content: "Option 2 with long text truncation", onActivate: "itemChanged"},
 						{kind: "moon.SelectableItem", disabled: true, content: "Disabled", onActivate: "itemChanged"},
-						{kind: "moon.SelectableItem", content: "Option 4 with long text truncation", active: true, onActivate: "itemChanged"},
->>>>>>> master
+						{kind: "moon.SelectableItem", content: "Option 4 with long text truncation", selected: true, onActivate: "itemChanged"},
 						{kind: "moon.SelectableItem", content: "Option 5 with long text truncation", onActivate: "itemChanged"}
 					]}
 				]}

--- a/source/SelectableItem.js
+++ b/source/SelectableItem.js
@@ -32,16 +32,10 @@ enyo.kind({
 		{name: "indicator", classes: "moon-selectable-item-indicator"},
 		{name: "client", classes: "moon-selectable-item-client"}
 	],
-<<<<<<< HEAD
 	//@protected
 	rendered: function() {
 		this.inherited(arguments);
 		this.selectedChanged();
-=======
-	rendered: function() {
-		this.inherited(arguments);
-		this.activeChanged();
->>>>>>> master
 	},
 	shouldDoTransition: function(inSelected) {
 		return inSelected === true;
@@ -55,20 +49,12 @@ enyo.kind({
 		this.bubble("onchange");
 	},
 	selectedChanged: function() {
-<<<<<<< HEAD
-		this.$.client.removeClass("moon-overlay");
-		this.setNodeProperty("selected", this.selected);
-		this.setAttribute("selected", this.selected ? "selected" : "");
-		this.setActive(this.selected);
-		this.$.client.addRemoveClass("moon-underline", this.selected);
-=======
 		var selected = this.getSelected();
 		this.stopMarquee();
 		this.addRemoveClass("selected", selected);
 		this.setNodeProperty("selected", selected);
 		this.setAttribute("selected", selected ? "selected" : "");
 		this.setActive(selected);
->>>>>>> master
 	},
 	/**
 		For use with the Enyo Group API, which is supported by this object. Called


### PR DESCRIPTION
Use 'selected' property rather than 'checked' to make some SelectedItem
selected.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
