### PR TITLE
Fix regression in Drawers indirectly caused by change in enyo.Animator

### DIFF
--- a/source/Drawers.js
+++ b/source/Drawers.js
@@ -47,7 +47,7 @@ enyo.kind({
 		onSpotlightUp:"spotUp"
 	},
 	components: [
-		{name:"handleContainer", kind:"enyo.Drawer", spotlight:'container', open:false, onpostresize:"resizeHandleContainer", components:[
+		{name:"handleContainer", kind:"enyo.Drawer", resizeContainer:false, spotlight:'container', open:false, onpostresize:"resizeHandleContainer", components:[
 			{name:"handles", classes:"moon-drawers-handles"}
 		]},
 		{name:"activator", classes:"moon-drawers-activator", spotlight:true, ontap:"activatorHandler", components:[
@@ -188,13 +188,10 @@ enyo.kind({
 	},
 	resizeHandler: function() {
 		this.inherited(arguments);
-		if (this.$.handleContainer.$.animator.isAnimating()){
-			return true;
-		}
 		this.resizeDresser();		
-	    var dh = document.body.getBoundingClientRect().height;
-	    var ah = this.$.activator.hasNode().getBoundingClientRect().height;
-	    this.waterfall("onDrawersResized", {drawersHeight: dh, activatorHeight: ah});
+		var dh = document.body.getBoundingClientRect().height;
+		var ah = this.$.activator.hasNode().getBoundingClientRect().height;
+		this.waterfall("onDrawersResized", {drawersHeight: dh, activatorHeight: ah});
 		this.updateActivator(false);
 	},
 	//Updates the activator's style only when it is not animating so that there are no visual artifacts


### PR DESCRIPTION
...by using a new resizeContainer:false API on enyo.Drawer.  Since enyo.Animator no longer returns true from isAnimating() in the context of the onEnd event, there's no way to defeat resizing.  The new resizeContainer:false flag fixes that up.

Note, Enyo PR https://github.com/enyojs/enyo/pull/388 must be pulled for this fix to take effect.

Enyo-DCO-1.1-Signed-Off-By: Kevin Schaaf (kevin.schaaf@lge.com)
