### PR TITLE
GF-12434: Video Player: Do not use animateTo on Transport Slider when there is small variation.

### DIFF
--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -44,7 +44,9 @@ enyo.kind({
 		//** Custom Popup width for video player
 		popupWidth: 200,
 		//* Popup offset in pixels
-		popupOffset: 25
+		popupOffset: 25,
+		//** threshold value(percentage) for using animation effect on slider progress change
+		smallVariation: 1
 	},
 	handlers: {
 		onTimeupdate: "timeUpdate",
@@ -202,6 +204,12 @@ enyo.kind({
 	_calcPercent: function(inValue) {
 		return this.calcRatio(inValue) * 100;
 	},
+	calcVariationRatio: function(inValue) {
+		return (inValue - this.value) / (this.max - this.min);
+	},
+	calcVariationPercent: function(inValue) {
+		return this.calcVariationRatio(inValue) * 100;
+	},	
 	updateKnobPosition: function(inValue) {
 		if (!this.dragging && this.isInPreview()) { return; }
 		this._updateKnobPosition(inValue);
@@ -250,6 +258,13 @@ enyo.kind({
 			return true;
 		}
 	},
+	setValue: function(inValue) {
+		if(Math.abs(this.calcVariationPercent(inValue)) > this.smallVariation) {
+			this.inherited(arguments);
+		} else {
+			this._setValue(inValue);
+		}
+	},	
 	//* If dragstart, bubble _onSeekStart_ event
 	dragstart: function(inSender, inEvent) {
 		if (this.disabled) {


### PR DESCRIPTION
This PR will replace #399.
Tested on TV and browser.

Enyo-DCO-1.1-Signed-off-by: Juhyun Yun yunju123@gmail.com
