### PR TITLE
Fix growing height when moon.Panel is breadcrumb

### DIFF
--- a/source/Panel.js
+++ b/source/Panel.js
@@ -329,7 +329,7 @@ enyo.kind({
 		});
 	},
 	createGrowingHeightAnimation: function() {
-		var growingHeight = this.get("owner").hasNode().innerHeight + "px";
+		var growingHeight = this.get("owner").hasNode().offsetHeight + "px";
 		return this.$.animator.newAnimation({
 			name: "growHeight",
 			duration: 400,


### PR DESCRIPTION
A bus was reported on Enyo QnA forum.
http://nebula.palm.com/support/forums/general-chat/moonpanel-transition-problem-pilot6-release/

When panel is changed to breadcrumb, their height is shrank by shrinking animation. Two or more breadcrumbs has node.offsetHeight as 160 pixels. So panel do not grow to their initial height.

In pilot 5, growing animation use "auto". In pilot 6, growing animation use this.initialHeight that is changed 160 px.

I changed createGrowingHeightAnimation function to use their owner's height.

Enyo-DCO-1.1-Signed-off-by: Youngduke Koh youngduke.koh@lge.com
