### PR TITLE
GF-12756: Eng: Show more / Show less button - issue fix

### DIFF
--- a/source/ExpandableText.js
+++ b/source/ExpandableText.js
@@ -38,11 +38,11 @@ enyo.kind({
 	lineHeight: 32,
 
 	//*@protected
-    rendered: function() {
-        this.inherited(arguments);
+	rendered: function() {
+		this.inherited(arguments);
 		this.calcLineHeight();
 		this.collapsedChanged();
-    },
+	},
 	reflow: function() {
 		this.inherited(arguments);
 		this.updateContentHeight();
@@ -53,9 +53,9 @@ enyo.kind({
 	lineHeightChanged: function() {
 		this.updateButtonVisibility();
 	},
-    maxLinesChanged: function() {
-        this.updateButtonVisibility();
-    },
+	maxLinesChanged: function() {
+		this.updateButtonVisibility();
+	},
 	moreContentChanged: function() {
 		if(this.collapsed) {
 			this.set("buttonContent", this.moreContent);
@@ -66,17 +66,17 @@ enyo.kind({
 			this.set("buttonContent", this.lessContent);
 		}
 	},
-    collapsedChanged: function() {
-        if (this.collapsed) {
-            this.$.client.applyStyle("-webkit-line-clamp", this.maxLines);
-            this.removeClass('expanded');
+	collapsedChanged: function() {
+		if (this.collapsed) {
+			this.$.client.applyStyle("-webkit-line-clamp", this.maxLines);
+			this.removeClass('expanded');
 			this.set("buttonContent", this.moreContent);
-        } else {
-            this.$.client.applyStyle("-webkit-line-clamp", null);
-            this.addClass('expanded');
+		} else {
+			this.$.client.applyStyle("-webkit-line-clamp", null);
+			this.addClass('expanded');
 			this.set("buttonContent", this.lessContent);
-        }
-    },
+		}
+	},
 	//* When _expandContract_ button is tapped, toggle _this.collapsed_ and fire _change_ event
 	expandContract: function() {
 		this.set("collapsed", !this.collapsed);
@@ -91,22 +91,27 @@ enyo.kind({
 		this.calcContentHeight();
 		this.updateButtonVisibility();
 	},
-    updateButtonVisibility: function() {
-        if (!this.hasNode()) {
+	updateButtonVisibility: function() {
+		if (!this.hasNode()) {
 			return;
 		}
-		
-        this.$.collapseButton.addRemoveClass("hidden", (this.contentHeight < this.calcMaxHeight()));
-    },
-    calcMaxHeight: function() {
-        return this.maxLines * this.lineHeight;
-    },
+		if(this.contentHeight - 1 > this.calcMaxHeight()) {
+			this.$.collapseButton.removeClass("hidden");
+			this.collapsedChanged();
+		} else {
+			this.$.collapseButton.addClass("hidden");
+			this.set("collapsed", false);
+		}
+	},
+	calcMaxHeight: function() {
+		return this.maxLines * this.lineHeight;
+	},
 	calcLineHeight: function() {
 		var lineHeight = parseInt(enyo.dom.getComputedStyleValue(this.$.client.hasNode(), "line-height"), 10);
 		this.set("lineHeight", (lineHeight > 0) ? lineHeight : null);
 	},
 	//* Calculate height of _this.$.client_. Strangely we have to add 1 px - when clamped the height is one less than line-height.
-    calcContentHeight: function() {
-        this.contentHeight = (this.$.client.hasNode()) ? this.$.client.hasNode().getBoundingClientRect().height + 1 : null;
-    }
+	calcContentHeight: function() {
+		this.contentHeight = (this.$.client.hasNode()) ? this.$.client.hasNode().getBoundingClientRect().height + 1 : null;
+	}
 });


### PR DESCRIPTION
1. Update `maxLines' programmatically.
   - In ExpandableTextSample, update `maxLines` to "5" programmatically.
         - Expected : Content is expanded. 
         - Actual : Content is still collapsed.
   - In ExpandableTextSample, update `maxLines` to "2" programmatically.
         - Expected : There are 2 lines with collapsed. 
         - Actual : There are still 3 lines in paragraph.
2. Update `content` programmatically.
   - In ExpandableTextSample, update content which has same lines as `maxLines'.
     
     ```
      - Expected : No collapseButton
      - Actual : collapseButton still there.
     ```
3. Update `moreContent`, `lessContent` programmatically
   - There is no function `updateCollapseButtonContent`

Enyo-DCO-1.1-Signed-off-by: Juhyun Yun yunju123@gmail.com
