### PR TITLE
Apply negative playbackRate on Video only in webOS

### DIFF
--- a/source/Video.js
+++ b/source/Video.js
@@ -320,8 +320,11 @@ enyo.kind({
 		// Set native playback rate
 		node.playbackRate = pbNumber;
 
-		if (pbNumber < 0) {
-			this.beginRewind();
+		if (!(enyo.platform.webos || window.PalmSystem)) {
+			// For supporting cross browser behavior
+			if (pbNumber < 0) {
+				this.beginRewind();
+			}
 		}
 	},
 	//* Return true if currently in paused state


### PR DESCRIPTION
- On desktop browser it will seek position

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi kunmyon.choi@lge.com
