### PR TITLE
GF-30500 Flicker after marquee animation end

### DIFF
--- a/css/Marquee.less
+++ b/css/Marquee.less
@@ -12,6 +12,7 @@
     width: auto;
     -webkit-animation-name: marquee;
     -webkit-animation-timing-function: linear;
+    -webkit-animation-fill-mode: forwards;
 }
 
 .moon-marquee-clip {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -409,6 +409,7 @@
   width: auto;
   -webkit-animation-name: marquee;
   -webkit-animation-timing-function: linear;
+  -webkit-animation-fill-mode: forwards;
 }
 .moon-marquee-clip {
   overflow: hidden;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -409,6 +409,7 @@
   width: auto;
   -webkit-animation-name: marquee;
   -webkit-animation-timing-function: linear;
+  -webkit-animation-fill-mode: forwards;
 }
 .moon-marquee-clip {
   overflow: hidden;


### PR DESCRIPTION
Issue:
After the marquee animation ends there is flicker before its holds on to
the current state. Observed in TV only.
Analysis:
Webit "marquee" animation is used for text scrolling animation. However
when the animation ends, as per the default behavior of an animation, it
moves to the starting frame. In this case also, when the animation ends
the frame moves to the starting position, but we have asked to hold for
some duration at last frame. So this results in a flicker, as frames are
moved from start to end.

Enyo-DCO-1.1-Signed-off-by: Anish Ramesan anish.ramesan@lge.com
