### PR TITLE
GF-6540 Music.AlbumDetailNarrowSample Update

### DIFF
--- a/patterns-samples/Music/Music.AlbumDetailNarrowSample.js
+++ b/patterns-samples/Music/Music.AlbumDetailNarrowSample.js
@@ -11,7 +11,7 @@ enyo.kind({
 			{name: "cover", kind: "enyo.Image", style: "height: 200px; width: 200px;"},
 			{name: "albumInfo", fit: true, kind: "moon.Table", components: [
 				{components: [
-					{name: "album", attributes: {colspan: "2"}, classes: "moon-header-font moon-super-header-text"}
+					{name: "album", attributes: {colspan: "2"}, classes: "moon-large-text"}
 				]},
 				{components: [
 					{content: "Artist", classes: "moon-sub-header-text"},


### PR DESCRIPTION
Issue: Music Album Detail Narrow Sample - needs visual styling update.
Fixes:
Added moonstone css classes to get similar UX design.
Added change events for identifying tap on items.

---

moon-superheader-bold-text

---

This css class can be added in moonstone-css to make header text bold.

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
