### PR TITLE
GF-33990-on resizing drawers scrollHeight is incorrect

### DIFF
--- a/source/Drawer.js
+++ b/source/Drawer.js
@@ -106,12 +106,12 @@ enyo.kind({
 		}
 	},
 	drawersResized: function(inSender, inEvent) {
-		this.$.client.render();
 		this.$.controlDrawer.render();
 		this.$.controlDrawer.$.client.setShowing(true);
 		this.$.controlDrawer.$.client.resized();
 		this.$.client.setDrawerProps({height: this.calcDrawerHeight(inEvent.drawersHeight, inEvent.activatorHeight)});
 		this.$.controlDrawer.$.client.setShowing(false);
+		this.$.client.render();
 		this.setOpen(false);
 		this.setControlsOpen(false);
 	}


### PR DESCRIPTION
While resizing, the controlDrawer ScrollHeight is not calculated
correctly in moon.Drawer. This causes the drawer to draw some extra
height on resizing.

onresize handler, controlDrawer is rendered, which makes the improper
alignment of the client within it. This causes the controlDrawer to have
an incorrect ScrollHeight. So to fix the bug, the client is resized
after the controlDrawer is rendered.

Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P rajyavardhan.p@lge.com
