### PR TITLE
GF-35019 SimplePicker issue when parent not shown

### DIFF
--- a/samples/SimplePickerSample.js
+++ b/samples/SimplePickerSample.js
@@ -75,6 +75,19 @@ enyo.kind({
 					{kind:"moon.Divider", content:"Delete current item:"},
 					{kind:"moon.Button", content:"Delete", small:true, ontap:"destroyItem"}
 				]}
+			]},
+			{tag:"br"},{tag:"br"},
+			{name:"wrapper", style:"width:300px;height:100%;float:left", components:[
+					{kind:"moon.Button", small:true, content:"Show/Hide Picker", ontap:"showBtn"}
+			]},
+			{name:"pickerParent", showing:false, style:"width:300px;height:100%;float:left", components:[
+				{kind:"moon.SimplePicker", components:[
+					{content:"A"},
+					{content:"B"},
+					{content:"C"},
+					{content:"D"},
+					{content:"E"}
+				]}
 			]}
 		]},
 		{components: [
@@ -82,6 +95,12 @@ enyo.kind({
 			{kind: "moon.BodyText", name:"result", content:"No change yet"}
 		]}
 	],
+	showBtn:function(){
+		if(this.$.pickerParent.showing)
+			this.$.pickerParent.hide();
+		else
+			this.$.pickerParent.show();
+	},
 	changed: function(inSender, inEvent) {
 		this.$.result.setContent(inSender.name + " changed to " + inEvent.content + " (" + inEvent.index + ")");
 	},

--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -81,6 +81,7 @@ enyo.kind({
 	},
 	rendered: function() {
 		this.inherited(arguments);
+		this.parentShowing();
 		this._rendered = true;
 	},
 	createComponents: function(inC, inOpts) {
@@ -102,32 +103,10 @@ enyo.kind({
 		return inherited.call(this, inC, inOpts);
 	},
 	reflow: function() {
-		this.inherited(arguments);
-
-		var maxHeight = 0,
-			maxWidth = 0,
-			panels,
-			panel,
-			i;
 
 		// Find max width/height of all children
 		if (this.getAbsoluteShowing()) {
-			panels = this.$.client.getPanels();
-
-			for (i = 0; (panel = panels[i]); i++) {
-				if (panel.hasNode()) {
-					var bounds = panel.getBounds();
-					maxWidth = Math.max(maxWidth, bounds.width);
-					maxHeight = Math.max(maxHeight, bounds.height);
-				}
-			}
-			maxWidth = Math.min(maxWidth + 16, 250); // cushion up to the Marquee max-width of 250
-			this.$.client.setBounds({width: maxWidth, height: maxHeight});
-
-			for (i = 0; (panel = panels[i]); i++) {
-				panel.setBounds({width: maxWidth, height: maxHeight});
-			}
-
+			this._setPanelBounds();
 			this.$.client.reflow();
 		}
 
@@ -271,6 +250,36 @@ enyo.kind({
 		this.inherited(arguments);
 		if(this.showing && this.generated) {
 			this.reflow();
+		}
+	},
+	parentShowing: function() {
+		//To calculate proper bounds of panel, the parent should be visible.
+		if (!this.getAbsoluteShowing()) {
+			this.parent.show();
+			this._setPanelBounds();
+			this.$.client.reflow();
+			this.parent.hide();
+		}
+	},
+	_setPanelBounds: function() {
+		var maxHeight = 0,
+			maxWidth = 0,
+			panels = this.$.client.getPanels(),
+			panel,
+			i;
+
+		for (i = 0; (panel = panels[i]); i++) {
+			if (panel.hasNode()) {
+				var bounds = panel.getBounds();
+				maxWidth = Math.max(maxWidth, bounds.width);
+				maxHeight = Math.max(maxHeight, bounds.height);
+			}
+		}
+		maxWidth = Math.min(maxWidth + 16, 250); // cushion up to the Marquee max-width of 250
+
+		this.$.client.setBounds({width: maxWidth, height: maxHeight});
+		for (i = 0; (panel = panels[i]); i++) {
+			panel.setBounds({width: maxWidth, height: maxHeight});
 		}
 	}
 });


### PR DESCRIPTION
Issue: When parent component of SimplePicker is hidden(set display
none), and then shown again, SimplePicker inner components are getting
not proper bounds. This is due to the fact that bounds of inner divs
will not be proper when the parent div is invisible. So in this case
when the parent is again made visible, the child divs have to be
rendered again.
Solution: As SimplePicker depends on the visibility of parent component,
so added a check for that.

Updated the sample to have this implementation.

Enyo-DCO-1.1-Signed-off-by: Anish Ramesan anish.ramesan@lge.com
