### PR TITLE
GF-10212 Sample 'text' Drag & Select Defect Fixed

### DIFF
--- a/patterns-samples/ListActions/MultiSelectAndFilter/ListActions.MultiSelectAndFilterSample.js
+++ b/patterns-samples/ListActions/MultiSelectAndFilter/ListActions.MultiSelectAndFilterSample.js
@@ -2,7 +2,7 @@ enyo.kind({
 	name: "moon.sample.listactions.MultiSelectAndFilterSample",
 	fit: true,
 	kind:"FittableRows",
-	classes: "multi-select-and-filter-pattern moon",
+	classes: "multi-select-and-filter-pattern moon enyo-unselectable",
 	published: {
 		sortAction: null,
 		filterAction: null


### PR DESCRIPTION
Issue: MultiSelectAndFilter: When drag on title, can select that text.
Soultion: Added "enyo-unselectable" css to the kind, so now drag of
title and select of title, and other similar text drag and select are disabled.

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
