### PR TITLE
ENYO-3097: fixed template json file for ares

### DIFF
--- a/project-templates/ActivityPanels/ActivityPanels.json
+++ b/project-templates/ActivityPanels/ActivityPanels.json
@@ -2,19 +2,14 @@
 "source": [
   {
     "id": "bootplate-moonstone-ActivityPanels",
+    "type": "template",
     "files": [
       {
-        "url": "templates/bootplate-moonstone.zip",
-        "alternateUrl": "http://nebula.lgsvl.com/enyojs/templates/bootplate-moonstone.zip",
+        "url": "http://nebula.lgsvl.com/enyojs/templates/bootplate-moonstone.zip",
         "prefixToRemove": "bootplate"
       },
       {
-        "url": "webos-app-config.zip",
-        "alternateUrl": "http://enyojs.com/webos/webos-app-config.zip"
-      },
-      {
-        "url": "templates/template-ActivityPanels.zip",
-        "alternateUrl": "http://nebula.lgsvl.com/enyojs/templates/template-ActivityPanels.zip"
+        "url": "http://nebula.lgsvl.com/enyojs/templates/template-ActivityPanels.zip"
       }
     ],
     "description": "Moonstone ActivityPanels"

--- a/project-templates/AlwaysViewingPanels/AlwaysViewingPanels.json
+++ b/project-templates/AlwaysViewingPanels/AlwaysViewingPanels.json
@@ -2,19 +2,14 @@
 "source": [
   {
     "id": "bootplate-moonstone-AlwaysViewingPanels",
+    "type": "template",
     "files": [
       {
-        "url": "templates/bootplate-moonstone.zip",
-        "alternateUrl": "http://nebula.lgsvl.com/enyojs/templates/bootplate-moonstone.zip",
+        "url": "http://nebula.lgsvl.com/enyojs/templates/bootplate-moonstone.zip",
         "prefixToRemove": "bootplate"
       },
       {
-        "url": "webos-app-config.zip",
-        "alternateUrl": "http://enyojs.com/webos/webos-app-config.zip"
-      },
-      {
-        "url": "templates/template-AlwaysViewingPanels.zip",
-        "alternateUrl": "http://nebula.lgsvl.com/enyojs/templates/template-AlwaysViewingPanels.zip"
+        "url": "http://nebula.lgsvl.com/enyojs/templates/template-AlwaysViewingPanels.zip"
       }
     ],
     "description": "Moonstone AlwaysViewingPanels"


### PR DESCRIPTION
- fixed template json file for ares

changes
- ares use `type` property to classify the source repositories.
- ares no longer use `alternateUrl` property.

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
