### PR TITLE
Gf 37960 davidum

### DIFF
--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -138,7 +138,6 @@ enyo.kind({
 		// followed an item being added/removed
 		if (this.selected != this.$.client.getActive()) {
 			this.setSelected(this.$.client.getActive());
-			this.setSelectedIndex(this.$.client.getIndex());
 			this.fireChangedEvent();
 		}
 
@@ -147,7 +146,6 @@ enyo.kind({
 	transitionFinished: function(inSender, inEvent) {
 		var fp = (this.getSelected() === this.$.client.getActive()); // false positive
 		this.setSelected(this.$.client.getActive());
-		this.setSelectedIndex(this.$.client.getIndex());
 		if (!fp) {
 			this.fireChangedEvent();
 		}


### PR DESCRIPTION
Previously, selectedIndex of simplePicker was only changed by transitionFinish method.
However if animate property is set false, onTransitionFinish event is not triggered.
This is the reason why next/back button is enabled even though there is no selectable item.

To fix this matter, I bind a selectedIndex with client.index.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
