### PR TITLE
Defect Fix - GF-28163 -BreadcrumArranger

### DIFF
--- a/source/BreadcrumbArranger.js
+++ b/source/BreadcrumbArranger.js
@@ -224,7 +224,14 @@ enyo.kind({
 			}
 
 			diff = inContainerWidth - totalWidth;
-			panels[i].actualWidth = panels[i].width + diff;
+			//width checking based on joinToPrev flag.
+			if((i+1) <= inJoinedPanels.length-1){
+				if(panels[i+1].joinToPrev){
+					panels[i].actualWidth = panels[i].width ;
+				} else {
+					panels[i].actualWidth = (inJoinedPanels[i+1])? panels[i].width :(panels[i].width + diff);
+				}
+			}
 
 			if (this.debug) {
 				enyo.log(i, panels[i].width, "-->", panels[i].actualWidth);


### PR DESCRIPTION
Cause:   Consecutive  joinToPrev  flag causes panel header overlapping.
Solution: The initial calculation takes the remaining container width
which is adjusted now.
explicitly calculated  the panel widths based on the joinToPrev flag

Enyo-DCO-1.1-Signed-off-by:Sreelatha Kodali sreelatha.kodali@lge.com
