### PR TITLE
GF-38209: Remove inappropriate use of JS Date object for decoding minute...

### DIFF
--- a/samples/ActivityPanelsWithVideoSample.html
+++ b/samples/ActivityPanelsWithVideoSample.html
@@ -6,10 +6,10 @@
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.3.3.min.js"></script>
-	-->
+	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.3.3.min.js"></script>-->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
+	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
 	<script src="../../moonstone/package.js" type="text/javascript"></script>
 	<script src="../../spotlight/package.js" type="text/javascript"></script>

--- a/samples/AlwaysViewingPanelsWithVideoSample.html
+++ b/samples/AlwaysViewingPanelsWithVideoSample.html
@@ -9,6 +9,7 @@
 	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.3.3.min.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
+	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
 	<script src="../../moonstone/package.js" type="text/javascript"></script>
 	<script src="../../spotlight/package.js" type="text/javascript"></script>

--- a/samples/VideoPlayerInlineSample.html
+++ b/samples/VideoPlayerInlineSample.html
@@ -5,17 +5,17 @@
 	<title>Inline Video Player Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
+	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.3.3.min.js"></script> -->
 	<!-- -->
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.3.3.min.js"></script>
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
+	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
 	<script src="../../moonstone/package.js" type="text/javascript"></script>
-	<script src="../../spotlight/package.js" type="text/javascript"></script>
-	
-	<link rel="stylesheet" href="VideoPlayerInlineSample.css" />
-	
+	<script src="../../spotlight/package.js" type="text/javascript"></script>	
 	<!-- -->
-	<script src="package.js" type="text/javascript"></script>
+	<link href="VideoPlayerInlineSample.css" rel="stylesheet">
+	<script src="VideoPlayerInlineSample.js" type="text/javascript"></script>
 	<!-- -->
 </head>
 <body>

--- a/samples/VideoPlayerSample.html
+++ b/samples/VideoPlayerSample.html
@@ -5,17 +5,17 @@
 	<title>Video Player Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
+	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.3.3.min.js"></script>-->
 	<!-- -->
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.3.3.min.js"></script>
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
+	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
 	<script src="../../moonstone/package.js" type="text/javascript"></script>
 	<script src="../../spotlight/package.js" type="text/javascript"></script>
-
-	<link rel="stylesheet" href="VideoPlayerSample.css" />
-
 	<!-- -->
-	<script src="package.js" type="text/javascript"></script>
+	<link href="VideoPlayerSample.css" rel="stylesheet">
+	<script src="VideoPlayerSample.js" type="text/javascript"></script>
 	<!-- -->
 </head>
 <body>

--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -779,6 +779,7 @@ enyo.kind({
 
 		this.updatePosition();
 
+		delete inEvent.delegate;
 		this.waterfall("onTimeupdate", inEvent);
 	},
 	//* Called when video successfully loads video metadata.


### PR DESCRIPTION
...s/seconds from currentTime (it's a duration, and Date stores time in UTC+0 time zone but API's retrieve fields in the current timezone- very dangerous).  Use ilib duration format to format duration strings.  Also need to remove delegate field when forwarding time update event via waterfall.

Enyo-DCO-1.1-Signed-Off-By: Kevin Schaaf (kevin.schaaf@lge.com)
