### PR TITLE
Defect Fix - 37843 - onChange fires twice in Date/Time Picker

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -100,9 +100,6 @@ enyo.kind({
 		this.$.day.setValue(this.value.getDate());
 
 		this.$.currentValue.setContent(this.formatValue());
-		if (this.value) {
-			this.doChange({name:this.name, value:this.value});
-		}
 	},
 	getMonthName: function() {
 		return ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];

--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -121,6 +121,9 @@ enyo.kind({
 	},
 	valueChanged: function(inOld) {
 		this.setChildPickers(inOld);
+		if (this.value) {
+			this.doChange({name:this.name, value:this.value});
+		}
 	},
 	setChildPickers: function(inOld) {
 		// implement in subkind
@@ -169,7 +172,6 @@ enyo.kind({
 		//* If select/enter is pressed on any date picker item or the left key is pressed on the first item, close the drawer
 		if (inEvent.type == "onSpotlightSelect" ||
 			this.$.client.children[0].id == inEvent.originator.id) {
-			this.updateValue(inSender, inEvent);
 			this.expandContract();
 			this.noneTextChanged();
 			return true;

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -233,7 +233,6 @@ enyo.kind({
 		this.$.minute.setValue(this.value.getMinutes());
 
 		this.$.currentValue.setContent(this.formatValue());
-		this.doChange({name:this.name, value:this.value});
 	},
 	hourTextChanged: function (inOldvalue, inNewValue) {
 		this.$.hourLabel.setContent(inNewValue);


### PR DESCRIPTION
doChange() method is getting called twice.
this method is getting called inside setChildPickers() Implicitly to
change the value of picker to the new value.
It is called explicitly once again in valueChanged() unnecessarily after
setChildPickers().

Solution:
Removing doChange() method in valueChanged() method which is redundant.

Enyo-DCO-1.1-Signed-off-by: Ashwini R ashwini13.r@lge.com
