### PR TITLE
Defect Fix - 38531 - Broken Picker Displays

### DIFF
--- a/source/SimpleIntegerPicker.js
+++ b/source/SimpleIntegerPicker.js
@@ -103,7 +103,9 @@ enyo.kind({
 		this.disabledChanged();
 	},
 	rendered: function() {
+		this.$.client.setAnimate(false);
 		this.valueChanged();
+		this.$.client.setAnimate(this.animate);
 		this.inherited(arguments);
 	},
 	populateIndexhash: function() {


### PR DESCRIPTION
Right Overlay is getting focus initially in TransitionStart Function.
TransitionStart is getting called initially when value is set.hence A broken picker displays.

Solution : Setting panel animation to false initially. and once the
initial value is set ,change the animator value to picker animator
value.

Enyo-DCO-1.1-Signed-off-by: Ashwini R ashwini13.r@lge.com
