### PR TITLE
Defect Fix - GF-38377 -  Incomplete Month Displays in Calendar

### DIFF
--- a/source/CalendarPicker.js
+++ b/source/CalendarPicker.js
@@ -127,7 +127,7 @@ enyo.kind({
 		var months = this.months;
 		for (var i = 0; i < 12; i++) {
 			this.$.monthPicker.createComponent(
-				{content: months[i], classes: "picker-content", style: "width: 200px"}
+				{content: months[i], classes: "picker-content"}
 			);
 		}
 	},


### PR DESCRIPTION
Fixed width 200px is not required since width is getting calculated based on content.
fixed width is causing translate value mismatch when moving to next Month(so,Incomplete Month Displays) .
Removed Fixed width:200px from MonthPicker creation.

Enyo-DCO-1.1-Signed-off-by: Ashwini R ashwini13.r@lge.com
