### PR TITLE
Do not spot on active item of ExpandablePicker when it is not opened.

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -190,7 +190,7 @@ enyo.kind({
 		if (inEvent.checked && index >= 0) {
 			this.setSelected(inEvent.toggledControl);
 			
-			if (this.getAutoCollapseOnSelect() && this.isRendered) {
+			if (this.getAutoCollapseOnSelect() && this.isRendered && this.getOpen()) {
 				this.startJob("selectAndClose", "selectAndClose", this.selectAndCloseDelayMS);
 			}
 		}


### PR DESCRIPTION
- Fixing http://jira2.lgsvl.com/browse/GF-10241

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
