### PR TITLE
GF-11377: Update Moonstone to use system fonts

### DIFF
--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -60,7 +60,7 @@
 }
 @font-face {
   font-family: "Miso";
-  src: local("miso-regular"), url("../fonts/miso/miso-regular.woff") format("woff"), url("../fonts/miso/miso-regular.ttf") format("truetype");
+  src: local("Miso111"), url("../fonts/miso/miso-regular.woff") format("woff"), url("../fonts/miso/miso-regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
   unicode-range: U+00-FF;
@@ -73,7 +73,7 @@
 }
 @font-face {
   font-family: "Miso";
-  src: local("miso-bold"), url("../fonts/miso/miso-bold.woff") format("woff"), url("../fonts/miso/miso-bold.ttf") format("truetype");
+  src: local("Miso"), url("../fonts/miso/miso-bold.woff") format("woff"), url("../fonts/miso/miso-bold.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
   unicode-range: U+00-FF;
@@ -86,7 +86,7 @@
 }
 @font-face {
   font-family: "Miso";
-  src: local("miso-light"), url("../fonts/miso/miso-light.woff") format("woff"), url("../fonts/miso/miso-light.ttf") format("truetype");
+  src: local("Miso"), url("../fonts/miso/miso-light.woff") format("woff"), url("../fonts/miso/miso-light.ttf") format("truetype");
   font-weight: 100;
   font-style: normal;
   unicode-range: U+00-FF;

--- a/css/moonstone-fonts.less
+++ b/css/moonstone-fonts.less
@@ -8,7 +8,7 @@
 }
 @font-face {
   font-family: "Miso";
-  src: local("miso-regular"),
+  src: local("Miso111"),
     url("../fonts/miso/miso-regular.woff") format("woff"),
     url("../fonts/miso/miso-regular.ttf") format("truetype");
   font-weight: normal;
@@ -24,7 +24,7 @@
 }
 @font-face {
   font-family: "Miso";
-  src: local("miso-bold"),
+  src: local("Miso"),
     url("../fonts/miso/miso-bold.woff") format("woff"),
     url("../fonts/miso/miso-bold.ttf") format("truetype");
   font-weight: bold;
@@ -40,7 +40,7 @@
 }
 @font-face {
   font-family: "Miso";
-  src: local("miso-light"),
+  src: local("Miso"),
     url("../fonts/miso/miso-light.woff") format("woff"),
     url("../fonts/miso/miso-light.ttf") format("truetype");
   font-weight: 100;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -60,7 +60,7 @@
 }
 @font-face {
   font-family: "Miso";
-  src: local("miso-regular"), url("../fonts/miso/miso-regular.woff") format("woff"), url("../fonts/miso/miso-regular.ttf") format("truetype");
+  src: local("Miso111"), url("../fonts/miso/miso-regular.woff") format("woff"), url("../fonts/miso/miso-regular.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
   unicode-range: U+00-FF;
@@ -73,7 +73,7 @@
 }
 @font-face {
   font-family: "Miso";
-  src: local("miso-bold"), url("../fonts/miso/miso-bold.woff") format("woff"), url("../fonts/miso/miso-bold.ttf") format("truetype");
+  src: local("Miso"), url("../fonts/miso/miso-bold.woff") format("woff"), url("../fonts/miso/miso-bold.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
   unicode-range: U+00-FF;
@@ -86,7 +86,7 @@
 }
 @font-face {
   font-family: "Miso";
-  src: local("miso-light"), url("../fonts/miso/miso-light.woff") format("woff"), url("../fonts/miso/miso-light.ttf") format("truetype");
+  src: local("Miso"), url("../fonts/miso/miso-light.woff") format("woff"), url("../fonts/miso/miso-light.ttf") format("truetype");
   font-weight: 100;
   font-style: normal;
   unicode-range: U+00-FF;


### PR DESCRIPTION
This changes the Moonstone font look up rules to favor local fonts with those names
over the ones bundled in the Moonstone package.  The only font loaded from the 
Moonstone bundle on the TV now is the Moonstone Icons font.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
