### PR TITLE
GF-39996: ExpandableText uses wrong spotlight image.

### DIFF
--- a/css/ExpandableText.less
+++ b/css/ExpandableText.less
@@ -29,7 +29,7 @@
 .moon-expandable-text .moon-item.moon-expandable-text-button.collapsed {
 	background-image: @moon-expandable-text-down-arrow;
 }
-.moon-expandable-text .moon-item.moon-expandable-text-button.expanded.collapsed {
+.moon-expandable-text .moon-item.moon-expandable-text-button.collapsed.spotlight {
 	background-image: @moon-expandable-text-down-arrow-spotlight;
 }
 

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3965,7 +3965,7 @@
 .moon-expandable-text .moon-item.moon-expandable-text-button.collapsed {
   background-image: url(../images/DarkTheme_Icons/SmallCarat_down1.png);
 }
-.moon-expandable-text .moon-item.moon-expandable-text-button.expanded.collapsed {
+.moon-expandable-text .moon-item.moon-expandable-text-button.collapsed.spotlight {
   background-image: url(../images/DarkTheme_Icons/SmallCarat_down2.png);
 }
 .moon-expandable-text .moon-item.moon-expandable-text-button.hidden {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3959,7 +3959,7 @@
 .moon-expandable-text .moon-item.moon-expandable-text-button.collapsed {
   background-image: url(../images/DarkTheme_Icons/SmallCarat_down1.png);
 }
-.moon-expandable-text .moon-item.moon-expandable-text-button.expanded.collapsed {
+.moon-expandable-text .moon-item.moon-expandable-text-button.collapsed.spotlight {
   background-image: url(../images/DarkTheme_Icons/SmallCarat_down2.png);
 }
 .moon-expandable-text .moon-item.moon-expandable-text-button.hidden {


### PR DESCRIPTION
Change CSS to show spotlight image when ExpandableInput is collapsed and focused

Enyo-DCO-1.1-Signed-off-by: Joohyun Yoon joohyun.yoon@lge.com
