### PR TITLE
GF-39932: Change active status if setOpen() is called directly

### DIFF
--- a/source/ExpandableIntegerPicker.js
+++ b/source/ExpandableIntegerPicker.js
@@ -81,6 +81,10 @@ enyo.kind({
 		}
 		this.setOpen(active);
 	},
+	openChanged: function() {
+		this.inherited(arguments);
+		this.setActive(this.getOpen());
+	},
 	
 	// Computed props
 	showCurrentValue: function() {

--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -151,9 +151,7 @@ enyo.kind({
 	openChanged: function() {
 		this.inherited(arguments);
 		this.$.currentValue.setShowing(!this.open);
-		if(this.getOpen() !== this.getActive()) {
-			this.setActive(this.getOpen());
-		}
+		this.setActive(this.getOpen());
 	},
 	//* When drawer is opened/closed, shows/hides _this.$.helpText.
 	helpTextChanged: function() {


### PR DESCRIPTION
Bug: When we collapse ExpandablePicker with direct calling of setOpen(false), it dose not expand again through tapping collapsed drawer. 
This is derived from inconsistency betw'n status of active and open property.
One hand, we tap collapsed one, it is activated and opened. The other hand it will deactivated and closed.
If active and open status are different, ExpandablePicker does not open again through tapping.
*setOpen(true) still works well

To fix this matter, when openChanged() is called compare open with active for consistence check.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
