### PR TITLE
GF-5689 : Update requestScrollIntoView feature

### DIFF
--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -79,9 +79,9 @@ enyo.kind({
 	bindings: [
 		{from: ".disabled", to: ".$.headerWrapper.disabled"}
 	],
-	
+
 	//* @protected
-	
+
 	create: function() {
 		this.inherited(arguments);
 		enyo.dom.accelerate(this, "auto");
@@ -101,7 +101,7 @@ enyo.kind({
 	},
 	disabledChanged: function() {
 		var disabled = this.getDisabled();
-		
+
 		this.addRemoveClass("disabled", disabled);
 		if (disabled) {
 			this.setOpen(false);
@@ -116,9 +116,9 @@ enyo.kind({
 		if (this.disabled) {
 			return true;
 		}
-		
+
 		this.toggleActive();
-		
+
 		if (this.getActive()) {
 			enyo.Spotlight.spot(enyo.Spotlight.getFirstChild(this.$.drawer));
 		}
@@ -146,7 +146,7 @@ enyo.kind({
 		}
 	},
 	drawerAnimationEnd: function() {
-		this.bubble("onRequestScrollIntoView", {side: "top"});
+		this.bubble("onRequestScrollIntoView", {side: "top", scrollInPointerMode:true});
 		return true;
 	},
 	spotlightFocused: function(inSender, inEvent) {

--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -338,7 +338,7 @@ enyo.kind({
 	},
 	//* Responds to child components' requests to be scrolled into view.
 	requestScrollIntoView: function(inSender, inEvent) {
-		if (!enyo.Spotlight.getPointerMode()) {
+		if (!enyo.Spotlight.getPointerMode() || inEvent.scrollInPointerMode === true) {
 			this.scrollBounds = this._getScrollBounds();
 			this.setupBounds();
 			if (this.showVertical() || this.showHorizontal()) {
@@ -424,13 +424,13 @@ enyo.kind({
 	},
 	//* Determines whether we should be showing the vertical scroll column.
 	showVertical: function() {
-		return (this.getVertical() == "scroll" || 
+		return (this.getVertical() == "scroll" ||
 				(this.getVertical() !== "hidden" &&
 				((-1 * this.$.scrollMath.bottomBoundary > 0) || this.container.spotlightPagingControls)));
 	},
 	//* Determines whether we should be showing the horizontal scroll column.
 	showHorizontal: function() {
-		return (this.getHorizontal() == "scroll" || 
+		return (this.getHorizontal() == "scroll" ||
 				(this.getHorizontal() !== "hidden" &&
 				((-1 * this.$.scrollMath.rightBoundary > 0) || this.container.spotlightPagingControls)));
 	},


### PR DESCRIPTION
GF-5689 :  ScrollerVerticalSample: when language menu is extended, the
page doesn't adjusted
This is work when 5way key button is pressed, but it is not work in case
of pointer mode.
So I updated ExtendableListItem and MoonScrollStrategy to works well in
pointer mode.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
