### PR TITLE
ENYO-3222: Ares can create app from the local bootplate-moonstone zip file

### DIFF
--- a/project-templates/ActivityPanels/ActivityPanels.json
+++ b/project-templates/ActivityPanels/ActivityPanels.json
@@ -4,7 +4,7 @@
     "id": "bootplate-moonstone-ActivityPanels",
     "type": "template",
     "description": "Moonstone ActivityPanels",
-	"deps": ["webos-app-config"],
+    "deps": ["webos-app-config"],
     "files": [
       {
         "url": "@PLUGINDIR@/templates/bootplate-moonstone.zip"

--- a/project-templates/AlwaysViewingPanels/AlwaysViewingPanels.json
+++ b/project-templates/AlwaysViewingPanels/AlwaysViewingPanels.json
@@ -4,7 +4,7 @@
     "id": "bootplate-moonstone-AlwaysViewingPanels",
     "type": "template",
     "description": "Moonstone AlwaysViewingPanels",
-	"deps": ["webos-app-config"],
+    "deps": ["webos-app-config"],
     "files": [
       {
         "url": "@PLUGINDIR@/templates/bootplate-moonstone.zip"


### PR DESCRIPTION
Since https://enyojs.atlassian.net/browse/ENYO-2935, ares/cli can create app from local zip files.

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
