### PR TITLE
GF-36146 DatePicker Bottom Cut Defect Fixed

### DIFF
--- a/css/IntegerPicker.less
+++ b/css/IntegerPicker.less
@@ -36,7 +36,7 @@
 	position:absolute;
 	z-index: 1;
 	width: 100%;
-	height: @moon-integer-picker-radius;
+	height: @moon-integer-picker-overlay-height;
 	&.top {
 		top: 0;
 		background: @moon-carat-picker-up-icon center 6px no-repeat;
@@ -56,7 +56,7 @@
 .moon-scroll-picker-overlay {
 	display: none;
 	position:absolute;
-	height:@moon-integer-picker-radius + 5px;
+	height:@moon-integer-picker-overlay-height + 5px;
 	width:100%;
 	border-width: @moon-integer-picker-shadow-width;
 	border-color: rgba(0,0,0,0.2);

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1698,7 +1698,7 @@
   border-bottom-width: 30px;
   border-bottom-style: solid;
   border-bottom-color: transparent;
-  border-radius: 30px;
+  border-radius: 9999px;
 }
 .spotlight .moon-scroll-picker {
   background: #ff2f7d;
@@ -1746,13 +1746,13 @@
 .moon-scroll-picker-overlay.top {
   top: 0;
   border-top-style: solid;
-  border-radius: 30px 30px 0 0;
+  border-radius: 9999px 9999px 0 0;
   background: #ff2f7d url(../images/DarkTheme_Icons/CaratPickerUp_Icon.png) center -60px no-repeat;
 }
 .moon-scroll-picker-overlay.bottom {
   bottom: 0;
   border-bottom-style: solid;
-  border-radius: 0 0 30px 30px;
+  border-radius: 0 0 9999px 9999px;
   background: #ff2f7d url(../images/DarkTheme_Icons/CaratPickerDown_Icon.png) center -60px no-repeat;
 }
 .moon-scroll-picker-overlay-container.selected .moon-scroll-picker-overlay {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1697,7 +1697,7 @@
   border-bottom-width: 30px;
   border-bottom-style: solid;
   border-bottom-color: transparent;
-  border-radius: 30px;
+  border-radius: 9999px;
 }
 .spotlight .moon-scroll-picker {
   background: #ff2f7d;
@@ -1745,13 +1745,13 @@
 .moon-scroll-picker-overlay.top {
   top: 0;
   border-top-style: solid;
-  border-radius: 30px 30px 0 0;
+  border-radius: 9999px 9999px 0 0;
   background: #ff2f7d url(../images/LightTheme_Icons/CaratPickerUp_Icon.png) center -60px no-repeat;
 }
 .moon-scroll-picker-overlay.bottom {
   bottom: 0;
   border-bottom-style: solid;
-  border-radius: 0 0 30px 30px;
+  border-radius: 0 0 9999px 9999px;
   background: #ff2f7d url(../images/LightTheme_Icons/CaratPickerDown_Icon.png) center -60px no-repeat;
 }
 .moon-scroll-picker-overlay-container.selected .moon-scroll-picker-overlay {

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -182,8 +182,9 @@
 
 /* IntegerPicker */
 /* ---------------------------------------*/
-@moon-integer-picker-radius: 30px;
+@moon-integer-picker-radius: 9999px;
 @moon-integer-picker-height: 92px;
+@moon-integer-picker-overlay-height: 30px;
 @moon-integer-picker-shadow-width: 6px;
 
 /* Grid Dimensions */


### PR DESCRIPTION
Issue: Production - Date picker - bottom of picker cut off
Fixes:
In "IntegerPicker.less",
Changed variable 'height' under moon-integer-picker-overlay-container
and moon-integer-picker-overlay from 'moon-integer-picker-radius' to
'moon-integer-picker-overlay-height'. Since, to remove Bottom Cut of
picker item, radius has to be changed to a large value. But height was
using picker-radius to assign its value which is wrong and will become a
large value if we change radius. So, created a new variable
'moon-integer-picker-overlay-height' with value of old picker-radius
value and assigned to overlay-container's height.

In moonstone-variables.less,
Updated moon-integer-picker-radius to 9999px.
Added variable moon-integer-picker-overlay-height as 30px.

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
