### PR TITLE
VideoPlayer: Avoid refreshing autoHide timeout when mouse moves in blank space between info header and trick-play

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -159,11 +159,11 @@ enyo.kind({
 		]},
 
 		//* Fullscreen controls
-		{name: "fullscreenControl", classes: "moon-video-fullscreen-control enyo-fit", ontap: "toggleControls", onmousemove: "mousemove", components: [
+		{name: "fullscreenControl", classes: "moon-video-fullscreen-control enyo-fit", ontap: "toggleControls", components: [
 		
-			{name: "videoInfoHeader", showing: false, classes: "moon-video-player-header"},
+			{name: "videoInfoHeader", showing: false, onmousemove: "mousemove", classes: "moon-video-player-header"},
 			
-			{name: "playerControl", classes: "moon-video-player-bottom", showing: false, components: [
+			{name: "playerControl", classes: "moon-video-player-bottom", onmousemove: "mousemove", showing: false, components: [
 				{name: "controls", kind: "FittableColumns", classes: "moon-video-player-controls", XonSpotlightUp: "showFSInfoWithPreventEvent", XonSpotlightDown: "preventEvent", ontap: "resetAutoTimeout", components: [
 			
 					{name: "leftPremiumPlaceHolder", classes: "moon-video-player-premium-placeholder-left", XonSpotlightLeft: "preventEvent"},


### PR DESCRIPTION
- Fixing http://jira2.lgsvl.com/browse/GF-40524 

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
