### PR TITLE
GF-36142 SmallHeader on RTL Header Overlap Defect Fixed

### DIFF
--- a/css/Header.less
+++ b/css/Header.less
@@ -87,6 +87,10 @@
 	box-sizing: border-box;
 	top: -48px;
 }
+.enyo-locale-right-to-left .moon-small-header .moon-header-title-wrapper {
+	padding-right: 58px;
+	padding-left: 0;
+}
 .moon-small-header .moon-header-title-below {
 	top: -48px;
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1491,6 +1491,10 @@
   box-sizing: border-box;
   top: -48px;
 }
+.enyo-locale-right-to-left .moon-small-header .moon-header-title-wrapper {
+  padding-right: 58px;
+  padding-left: 0;
+}
 .moon-small-header .moon-header-title-below {
   top: -48px;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1490,6 +1490,10 @@
   box-sizing: border-box;
   top: -48px;
 }
+.enyo-locale-right-to-left .moon-small-header .moon-header-title-wrapper {
+  padding-right: 58px;
+  padding-left: 0;
+}
 .moon-small-header .moon-header-title-below {
   top: -48px;
 }


### PR DESCRIPTION
Issue: Header: Overlapped Header Occurs When Toggle RTL is Off.
When RTL is ON 'padding-left' was given to SmallHeader, but when RTL is
OFF padding-left was present which is not needed and no padding-right
was there.

Fixes:
Added class '.enyo-locale-right-to-left .moon-small-header
.moon-header-title-wrapper' to  'Header.less' with "padding-right"
property and padding-left made 0.

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
