### PR TITLE
GF-40718: Adjust scrollInterval to TV behavior.

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -51,7 +51,7 @@ enyo.kind({
 		]}
 	],
 	//* @protected
-	scrollInterval: 65,
+	scrollInterval: 150,
 	rendered: function(){
 		this.inherited(arguments);
 		this.rangeChanged();
@@ -163,7 +163,7 @@ enyo.kind({
 		if(!st.scrollNode) {
 			return;
 		}
-		
+
 		while (n && n.parentNode && n.id != st.scrollNode.id) {
 			b.top += n.offsetTop;
 			b.left += n.offsetLeft;


### PR DESCRIPTION
This PR is related with https://github.com/enyojs/moonstone/pull/523 
Due to miss communication, scrollInterval value still remained as initial number.
It makes TV behavior too slow.

Just increasing scrollInterval from 65 to 150, scrolling behavior on TV looks so nice.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
