### PR TITLE
Fixing HighlightTextSample to use moon.HighlightText in the Search panel...

### DIFF
--- a/samples/HighlightTextSample.js
+++ b/samples/HighlightTextSample.js
@@ -34,7 +34,7 @@ enyo.kind({
 						{from: ".controller.text", to: ".highlight"}
 					]}
 				]}
-			], title:"SEARCH", titleBelow: "Items in Repeater", subTitleBelow: "Case sensitive"}
+			], title:"SEARCH", titleBelow: "Filtered items in DataList", subTitleBelow: "Case sensitive"}
 		]}
 	],
 	bindings: [


### PR DESCRIPTION
.... Also changing filtering function so that we match a substring anywhere in the list item, which makes for much more interesting highlighting.

Enyo-DCO-1.1-Signed-off-by: Gray Norton gray.norton@lge.com
