### PR TITLE
GF-40856: make a hidden paging controls not spotlightable

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -323,7 +323,6 @@ enyo.kind({
 			this.$.pageUpControl,
 			this.$.pageDownControl
 		], function(c) {
-			c.spotlight = this.container.spotlightPagingControls;
 			c.addRemoveClass("hover", !this.container.spotlightPagingControls);
 		}, this);
 	},


### PR DESCRIPTION
_Jira_
http://jira2.lgsvl.com/browse/GF-40856.
(An Hidden paging controls seems to get spotlight.)

_Problem_
There are two kinds sources setting `spotlight` property for paging controls.

```
rendered: function() {
    ...
    this.setupBounds();
    this.updateSpotlightPagingControls();
}
```

```
this.setupBounds(); > this.enableDisableScrollColumns(); > enableDisableVertical/HorizontalScrollControls
this.updateSpotlightPagingControls();
```

In `enableDisableVertical/HorizontalScrollControls` function, it set `spotlight` property of a paging control via considered hidden status.
But, In `updateSportlightPagingControl` function, it try to set `spotlight` property of a paging control again regardless hidden status. 

_Change_
 Removed the unnecessary `spotlight` setting code  from `updateSportlightPagingControl` function

Enyo-DCO-1.1-Signed-off-by: Junil Kim logyourself@gmail.com
