### PR TITLE
GF-40525: Picker option and itself could be dymanically destroyed

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -170,16 +170,14 @@ enyo.kind({
 	removeControl: enyo.inherit(function(sup) {
 		return function(inControl) {
 			// Skip extra work during panel destruction.
-			if (this.destroying) {
-				return sup.apply(this, arguments);
+			if (!this.destroying) {
+				// set currentValue, selected and selectedIndex to defaults value
+				if (this.selected === inControl) {
+					this.setSelected(null);
+					this.setSelectedIndex(-1);
+					this.$.currentValue.setContent(this.getNoneText());
+				}
 			}
-			// set currentValue, selected and selectedIndex to defaults value
-			if (this.selected === inControl) {
-				this.setSelected(null);
-				this.setSelectedIndex(-1);
-				this.$.currentValue.setContent(this.getNoneText());
-			}
-			this.inherited(arguments);
 			sup.apply(this, arguments);
 		};
 	}),


### PR DESCRIPTION
Override destroy related methods to deal with destroying picker option and
picker itself.

This PR is the same PR with https://github.com/enyojs/moonstone/pull/612.
Due to overtime issue (master branch gone to far), I re-create PR.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
