### PR TITLE
Add 'CalendarPicker.js' to moonstone project.

### DIFF
--- a/moonstone.design
+++ b/moonstone.design
@@ -242,6 +242,31 @@
                     }
                 },
                 {
+                    "name": "moon.CalendarPicker",
+                    "kind": "moon.CalendarPicker",
+                    "description": "A calendarPicker component",
+                    "config": {
+                        "kind": "FittableRows",
+                        "components": [
+                            {
+                                "kind": "moon.Scroller",
+                                "fit": true,
+                                "components": [
+                                    {                                        
+                                        "kind": "FittableColumns",
+                                        "components": [
+                                            {
+                                                "kind": "moon.CalendarPicker",
+                                                "onChange": "changed"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
                     "name": "moon.CheckboxItem",
                     "kind": "moon.CheckboxItem",
                     "description": "A single checkbox item",

--- a/source/package.js
+++ b/source/package.js
@@ -2,6 +2,7 @@ enyo.depends(
 	"BodyText.js",
 	"Marquee.js",
 	"Button.js",
+	"CalendarPicker.js",
 	"CaptionDecorator.js",
 	"Item.js",
 	"SelectableItem.js",


### PR DESCRIPTION
ENYO-2638: AAAD, I can add "CalendarPicker" component on designer from palette.

Enyo-DCO-1.1-Signed-Off-By: SangHyun.Hong (sanghyun.hong@lgepartner.com)
