### PR TITLE
StyleAnimator was missing enyo prefix

### DIFF
--- a/source/StyleAnimator.js
+++ b/source/StyleAnimator.js
@@ -1,5 +1,5 @@
 enyo.kind({
-	name: "StyleAnimator",
+	name: "enyo.StyleAnimator",
 	kind: "Component",
 	events: {
 		onStep: "",


### PR DESCRIPTION
This caused it to be added to globals, not what we want for
this kind that will eventually move into enyo core.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
