### PR TITLE
GF-40718: Adjust scroll perf on different platform

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -1,6 +1,6 @@
 /**
 	_moon.ScrollStrategy_ inherits from
-	<a href="#enyo.TranslateScrollStrategy ">enyo.TranslateScrollStrategy </a>. Its main
+	<a href="#enyo.TranslateScrollStrategy">enyo.TranslateScrollStrategy</a>. Its main
 	purpose is to handle scroller paging for
 	<a href="#moon.Scroller">moon.Scroller</a> and
 	<a href="#moon.List">moon.List</a>.
@@ -8,7 +8,7 @@
 
 enyo.kind({
 	name: "moon.ScrollStrategy",
-	kind: "enyo.TranslateScrollStrategy ",
+	kind: "enyo.TranslateScrollStrategy",
 	published: {
 		//* Increase this value to increase the distance scrolled by the scroll wheel
 		scrollWheelMultiplier: 5,


### PR DESCRIPTION
This PR is related with https://github.com/enyojs/moonstone/pull/523
Due to miss communication, scrollInterval value still remained as initial number.
It makes TV behavior too slow.

Increasing scrollInterval from 65 to 150 makes scrolling behavior on TV so smooth.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
