### PR TITLE
GF-38774 Typo "Meridian" to "Meridiem" Fixed in TimePickerSample

### DIFF
--- a/css/Clock.less
+++ b/css/Clock.less
@@ -19,7 +19,7 @@
 	display: inline-block;
 	line-height: 65px;
 }
-.moon-clock-meridian {
+.moon-clock-meridiem {
 	font-family: "MuseoSans Medium";
 	font-size: 24px;
 	white-space: nowrap;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3627,7 +3627,7 @@ button:focus {
   display: inline-block;
   line-height: 65px;
 }
-.moon-clock-meridian {
+.moon-clock-meridiem {
   font-family: "MuseoSans Medium";
   font-size: 24px;
   white-space: nowrap;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3622,7 +3622,7 @@ button:focus {
   display: inline-block;
   line-height: 65px;
 }
-.moon-clock-meridian {
+.moon-clock-meridiem {
   font-family: "MuseoSans Medium";
   font-size: 24px;
   white-space: nowrap;

--- a/samples/TimePickerSample.js
+++ b/samples/TimePickerSample.js
@@ -5,7 +5,7 @@ enyo.kind({
 	components: [
 		{kind: 'moon.Scroller', fit: true, components: [
 			{classes: "moon-5h", components: [
-				{kind: "moon.TimePicker", name:"picker", content: "Time", meridiemEnable: true, onChange: "changed", hourText: $L("hour"), minuteText: $L("minute"), meridianText: $L("meridian")},
+				{kind: "moon.TimePicker", name:"picker", content: "Time", meridiemEnable: true, onChange: "changed", hourText: $L("hour"), minuteText: $L("minute"), meridiemText: $L("meridiem")},
 				{kind: "moon.TimePicker", name:"disabledPicker", meridiemEnable: true, disabled: true, noneText: $L("Disabled Time Picker"), content: "Disabled Time"},
 				{name: "localePicker", kind: "moon.ExpandablePicker", noneText: $L("No Locale Selected"), content: "Choose Locale", onChange:"pickerHandler", components: [
 					{content: "Use Default Locale", active: true},

--- a/source/Clock.js
+++ b/source/Clock.js
@@ -18,7 +18,7 @@ enyo.kind({
 		{kind: "enyo.Control", name: "hour", classes: "moon-clock-hour"},
 		{name: "right", classes: "moon-clock-right", components: [
 			{kind: "enyo.Control", name: "minute", classes: "moon-clock-minute"},
-			{kind: "enyo.Control", name: "meridian", classes: "moon-clock-meridian"},
+			{kind: "enyo.Control", name: "meridiem", classes: "moon-clock-meridiem"},
 			{classes: "moon-click-divider"},
 			{kind: "enyo.Control", name: "month", classes: "moon-clock-month"},
 			{kind: "enyo.Control", name: "day", classes: "moon-clock-day"}
@@ -44,13 +44,13 @@ enyo.kind({
 	refreshJob: function() {
 		var d = new Date(Date.now() + this._timeDiff),
 			h = d.getHours(),
-			meridian = "am";
+			meridiem = "am";
 
-		meridian = h > 11 ? "pm" : "am";
+		meridiem = h > 11 ? "pm" : "am";
 		h = h > 12 ? h-12: h;
 		this.$.hour.setContent(this._formatNumber(h));
 		this.$.minute.setContent(this._formatNumber(d.getMinutes()));
-		this.$.meridian.setContent(meridian);
+		this.$.meridiem.setContent(meridiem);
 
 		this.$.month.setContent(this.months[d.getMonth()]);
 		this.$.day.setContent(this._formatNumber(d.getUTCDate()));

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -68,8 +68,8 @@ enyo.kind({
 		hourText: "hour",
 		//* Optional label for minute
 		minuteText: "minute",
-		//* Optional label for meridian
-		meridianText: "meridian"
+		//* Optional label for meridiem
+		meridiemText: "meridiem"
 	},
 	//*@protected
 	iLibFormatType  : "time",
@@ -166,7 +166,7 @@ enyo.kind({
 						this.createComponent(
 							{classes: "moon-date-picker-wrap", components:[
 								{kind:"moon.MeridiemPicker", name:"meridiem", classes:"moon-date-picker-field", value: this.value.getHours() > 12 ? 1 : 0, meridiems: this.meridiems || ["am","pm"] },
-								{name: "meridianLabel", content: this.meridianText || "meridian", classes: "moon-date-picker-label moon-divider-text"}
+								{name: "meridiemLabel", content: this.meridiemText || "meridiem", classes: "moon-date-picker-label moon-divider-text"}
 							]}
 						);
 					}
@@ -240,7 +240,7 @@ enyo.kind({
 	minuteTextChanged: function (inOldvalue, inNewValue) {
 		this.$.minuteLabel.setContent(inNewValue);
 	},
-	meridianTextChanged: function (inOldvalue, inNewValue) {
-		this.$.meridianLabel.setContent(inNewValue);
+	meridiemTextChanged: function (inOldvalue, inNewValue) {
+		this.$.meridiemLabel.setContent(inNewValue);
 	}
 });


### PR DESCRIPTION
Issue: Typo: "Meridian" should be "Meridiem" in source code.
Fixes: Changed  Clock.less, Clock.js, and TimePicker.js,
TimePickerSample.js by replacing "Meridian" to "Meridiem".

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
