### PR TITLE
Defect Fix - GF-40655 - Updated code to sync play/pause controls  when autoplay is true

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -282,7 +282,7 @@ enyo.kind({
 	},
 	srcChanged: function() {
 		if(this.src != this.$.video.getSrc()) {
-			this._isPlaying = Boolean(this.autoplay);
+			this._isPlaying = this.autoplay;
 			this.updatePlayPauseButtons();
 		}
 		this.$.video.setSrc(this.getSrc());


### PR DESCRIPTION
Problem : set Autoplay: true , when playing , setSrc("new vedio");
              -- new video plays with play icon.

Synchronization problem when autoplay:true.

Cause : when setSrc() is called, pause is getting called unconditionally in srcChanged() in VideoPlayer.js. 
calling pause works for case autoplay:false, but when autoplay:true, It changes the playpause controls(Toggles) then play the video. Hence this issue is raised.

Solution : Before updating controls,check for autoplay property. then change controls accordingly.
-pause() is added just to sync play/pause icon with video play status. 
-updating controls can be done directly by calling updatingPlayPauseControls()  without calling pause()  and added a check for autoplay property.

If Condition check has been added to prevent setting play/pause Controls to a falsy value, when same source is used in setSrc();
It works fine in all cases, Tested for most of the cases, by pausing,by unloading, then calling setSrc() etc..

Additional : 
 when setSrc() is being called with same source, video continues to play. In earlier case it used to pause( Since pause() method was exist in srcChanged() ).

Enyo-DCO-1.1-Signed-off-by: Ashwini R ashwini13.r@lge.com
