### PR TITLE
Defect Fix - GF-41731 - Hiding controls while sliding,when out of tap area

### DIFF
--- a/source/Slider.js
+++ b/source/Slider.js
@@ -108,6 +108,11 @@ enyo.kind({
 		});
 	},
 
+	//* Returns true if the slider is currently being dragged
+	isDragging: function() {
+		return this.dragging;
+	},
+
 	//* @protected
 	create: function() {
 		this.inherited(arguments);

--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -596,7 +596,7 @@ enyo.kind({
 		}
 	},
 	onLeaveSlider: function(inSender, inEvent) {
-		if (this.hideButtonsOnSlider && !this.$.slider.dragging) {
+		if (this.hideButtonsOnSlider && !this.$.slider.isDragging()) {
 			this.$.controls.setShowing(true);
 		}
 	},
@@ -655,7 +655,7 @@ enyo.kind({
 	},
 	//* Programatically updates slider position to match _this.currentTime_/_this.duration_.
 	updateFullscreenPosition: function() {
-		if (this.$.slider.dragging) {
+		if (this.$.slider.isDragging()) {
 			return;
 		}
 		this.$.slider.setValue(this._currentTime);


### PR DESCRIPTION
Condition check is missing, if pointer is out of tapArea while dragging.
Solution: While dragging(slider) , if pointer is out of tapArea do not
show controls.
onRelease,
1) if pointer is on tap area do not show controls.
2) if pointer is out of tap area,call show controls.

Enyo-DCO-1.1-Signed-off-by: Ashwini R ashwini13.r@lge.com
