### PR TITLE
Collection of minor fixes made during bug scrub:

### DIFF
--- a/patterns-samples/Video/Video.BrowserMoviesNarrowSample.js
+++ b/patterns-samples/Video/Video.BrowserMoviesNarrowSample.js
@@ -16,7 +16,6 @@ enyo.kind({
         {
             kind : "moon.Scroller",
             fit: true,
-            touch : true,
             horizontal : "hidden",
             components : [
                 {

--- a/samples/ContextualPopupSample.js
+++ b/samples/ContextualPopupSample.js
@@ -85,7 +85,7 @@ enyo.kind({
 				autoDismiss: false,
 				spotlightModal: true,
 				components: [
-					{kind: "Scroller", horizontal: "auto", touch: true, thumb: false, classes: "enyo-fill", components: [
+					{kind: "moon.Scroller", horizontal: "auto", classes: "enyo-fill", components: [
 						{kind: "moon.Button", content: "Button"},
 						{kind: "moon.ToggleButton", content: "SpotlightModal", active: true, ontap: "buttonToggled"},
 						{tag: "br"},
@@ -103,7 +103,7 @@ enyo.kind({
 				kind: "moon.ContextualPopup",
 				classes: "moon-8h moon-4v",
 				components: [
-					{kind: "Scroller", horizontal: "auto", touch: true, thumb: false, classes: "enyo-fill", components: [
+					{kind: "moon.Scroller", horizontal: "auto", classes: "enyo-fill", components: [
 						{kind: "moon.Button", content: "Button 1"},
 						{kind: "moon.Button", content: "Button 2"},
 						{kind: "moon.Button", content: "Button 3"}

--- a/samples/FontSample.js
+++ b/samples/FontSample.js
@@ -30,6 +30,11 @@ enyo.kind({
 				{content:"텔레비전"},
 				{content:"M혼I합X된ED"}
 			]},
+			{classes:"moon-body-text", components: [
+				{content:"Body Text"},
+				{content:"텔레비전"},
+				{content:"M혼i합x된ed"}
+			]},
 			{classes:"moon-divider-text", components: [
 				{content:"Divider"},
 				{content:"텔레비전"},
@@ -73,6 +78,11 @@ enyo.kind({
 				{content:"SMALL BUTTON"},
 				{content:"텔레비전"},
 				{content:"M혼I합X된ED"}
+			]},
+			{classes:"moon-body-text", components: [
+				{content:"Body Text"},
+				{content:"텔레비전"},
+				{content:"M혼i합x된ed"}
 			]},
 			{classes:"moon-divider-text", components: [
 				{content:"Divider"},

--- a/samples/PanelsWithCardArrangerSample.js
+++ b/samples/PanelsWithCardArrangerSample.js
@@ -2,7 +2,7 @@ enyo.kind({
 	name: "moon.sample.PanelsWithCardArrangerSample",
 	classes: "moon enyo-fit",
 	components: [
-		{name: "panels", kind: "moon.Panels", arrangerKind: "CardArranger", classes: "enyo-fit", components: [
+		{name: "panels", kind: "moon.Panels", arrangerKind: "CardArranger", animate:false, classes: "enyo-fit", components: [
 			{title: "First", components: [
 				{kind: "moon.Item", content: "Item One", ontap: "next"},
 				{kind: "moon.Item", content: "Item Two", ontap: "next"},

--- a/source/CaptionDecorator.js
+++ b/source/CaptionDecorator.js
@@ -23,11 +23,11 @@ enyo.kind({
 	decoratorBounds: null,
 	classes: "moon-button-caption-decorator",
 	components: [
-		{kind: "enyo.Control", name: "leftCaption",     classes: "moon-divider-text moon-caption left",   canGenerate: false, content: "Left Caption"},
-		{kind: "enyo.Control", name: "topCaption",      classes: "moon-divider-text moon-caption top",    canGenerate: false, content: "Top Caption"},
+		{kind: "enyo.Control", name: "leftCaption",     classes: "moon-divider-text moon-caption left",   canGenerate: false},
+		{kind: "enyo.Control", name: "topCaption",      classes: "moon-divider-text moon-caption top",    canGenerate: false},
 		{kind: "enyo.Control", name: "client",          classes: "moon-divider-text moon-caption-client"},
-		{kind: "enyo.Control", name: "rightCaption",    classes: "moon-divider-text moon-caption right",  canGenerate: false, content: "Right Caption"},
-		{kind: "enyo.Control", name: "bottomCaption",   classes: "moon-divider-text moon-caption bottom", canGenerate: false, content: "Bottom Caption"}
+		{kind: "enyo.Control", name: "rightCaption",    classes: "moon-divider-text moon-caption right",  canGenerate: false},
+		{kind: "enyo.Control", name: "bottomCaption",   classes: "moon-divider-text moon-caption bottom", canGenerate: false}
 	],
 	create: function() {
 		this.inherited(arguments);
@@ -53,15 +53,15 @@ enyo.kind({
 		this.$.bottomCaption.canGenerate =  (side === "bottom");
 		this.$.leftCaption.canGenerate =    (side === "left");
 
+		// Update the content, including position if needed
+		this.contentChanged();
+
 		// If this control has already been rendered, re-render to update caption side
 		if (this.hasNode()) {
-			// If _showOnFocus_ is _true_, reset caption position
-			if (this.getShowOnFocus()) {
-				this.resetCaptionPosition();
-			}
 			// Re-render to display caption on proper side
 			this.render();
 		}
+
 	},
 	showOnFocusChanged: function() {
 		this.addRemoveClass("showOnFocus", this.getShowOnFocus());

--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -61,6 +61,7 @@ enyo.kind({
 		
 		if (this.generated && !this.getOpen()) {
 			this.updateValue();
+			this.$.clientInput.blur();
 		}
 	},
 	

--- a/source/Input.js
+++ b/source/Input.js
@@ -18,11 +18,6 @@ enyo.kind({
 	kind	: 'enyo.Input',
 	classes	: 'moon-input',
 
-	published: {
-		// all, email, only text, text/number (no special chars)
-		fieldType: 'numeric'
-	},
-
 	//* @protected
 	/**********************************************/
 

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -231,9 +231,6 @@ moon.MarqueeItem = {
 	//* Create a marquee-able div inside of _this_
 	_marquee_createMarquee: function() {
 		this.createComponent({classes: "moon-marquee-text-wrapper", components: [{name: "marqueeText", classes: "moon-marquee-text", allowHtml: this.allowHtml, content: this.content}]});
-		// FIXME: When created in DataList, controls don't go through the normal render path that
-		// sets this, but parent.generated==true is required for dynamically rendering new controls
-		this.parent.generated = true;
 		this.render();
 		return true;
 	},

--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -69,11 +69,11 @@ enyo.kind({
 		onSpotlightFocused: "scrollIntoView"
 	},
 	components: [
-		{name: "buttonLeft",  kind: "enyo.Button", classes: "moon-simple-picker-button left", spotlight: true, defaultSpotlightRight: "buttonRight", ontap: "left"},
+		{name: "buttonLeft",  kind: "enyo.Button", classes: "moon-simple-picker-button left", spotlight: true, ontap: "left"},
 		{kind: "enyo.Control", name: "clientWrapper", classes:"moon-simple-picker-client-wrapper", components: [
 			{kind: "enyo.Control", name: "client", classes: "moon-simple-picker-client"}
 		]},
-		{name: "buttonRight", kind: "enyo.Button", classes: "moon-simple-picker-button right", spotlight: true, defaultSpotlightLeft: "buttonLeft", ontap: "right"}
+		{name: "buttonRight", kind: "enyo.Button", classes: "moon-simple-picker-button right", spotlight: true, ontap: "right"}
 	],
 	create: function() {
 		this.inherited(arguments);
@@ -178,7 +178,7 @@ enyo.kind({
 	//* Hide _inControl_ and disable spotlight functionality
 	hideNavButton: function(inControl) {
 		inControl.addClass("hidden");
-		enyo.Spotlight.unspot();
+		enyo.Spotlight.spot(inControl == this.$.buttonLeft ? this.$.buttonRight : this.$.buttonLeft);
 		inControl.spotlight = false;
 	},
 	//* Show _inControl_ and enable spotlight functionality


### PR DESCRIPTION
- Remove errant touch:true from pattern-sample and ContextualPopupSample, resulting in wrong scroll strategy
- Add "moon-body-text" to FontSample
- Set "animate:false" on CardArranger panels sample
- GF-41153: Ensure content is updated when changing CaptionDecorator position
- Make sure the input is blurred (and VKB is closed) when the ExpandableInput is closed
- Remove bogus "fieldType" published property from moon.Input (use enyo.Input:type)
- Remove generated hack in Marquee, now that core issue is resolved (https://github.com/enyojs/enyo/pull/502)
- Remove default spotlight left/right from buttons (causes problems when disabled, RTL).  Instead, spot the opposite one when reaching the end of the list.
  DCO-1.1-Signed-Off-By: Kevin Schaaf (kevin.schaaf@lge.com)
