### PR TITLE
Fixing http://jira2.lgsvl.com/browse/GF-41634

### DIFF
--- a/source/InputDecorator.js
+++ b/source/InputDecorator.js
@@ -109,13 +109,13 @@ enyo.kind({
 	onFocus: function(oSender, oEvent) {
 		enyo.Spotlight.spot(this);
 		// enyo.Spotlight.disablePointerMode();
-		enyo.log(enyo.Spotlight.freeze());
+		enyo.Spotlight.freeze();
 		this.updateFocus(true);
 	},
 
 	onBlur: function() {
 		// enyo.Spotlight.enablePointerMode();
-		enyo.log(enyo.Spotlight.unfreeze());
+		enyo.Spotlight.unfreeze();
 		this.updateFocus(false);
 	},
 


### PR DESCRIPTION
Freezing spotlight on currently focused element to prevent mouse from spotting something else while pointer is moved from it to vkb.
