### PR TITLE
GF-35777: don't create layers for ExpandableListItems

### DIFF
--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -78,7 +78,6 @@ enyo.kind({
 	//* @protected
 	create: function() {
 		this.inherited(arguments);
-		enyo.dom.accelerate(this, "auto");
 		this.openChanged();
 		this.setActive(this.open);
 		this.disabledChanged();
@@ -134,11 +133,11 @@ enyo.kind({
 	//* If drawer is currently open, and event was sent via keypress (i.e., it has a direction), process header focus
 	headerFocus: function(inSender, inEvent) {
 		var direction = inEvent && inEvent.dir;
-		
+
 		if (this.getOpen() && this.getAutoCollapse() && direction === "UP") {
 			this.setActive(false);
 		}
-		
+
 		if (inEvent.originator === this.$.header) {
 			this.bubble("onRequestScrollIntoView", {side: "top"});
 		}


### PR DESCRIPTION
Creating separate layers for the expandable list items is hurting full screen
performance and leading to OOM errors on EnyoBench.  Removing this acceleration
doesn't seem to affect on-screen perf very much since the drawers are pushing
other content, leading to layout changes and repaints, so we'll disable this until
we can find a better scheme for drawers that expand in-line.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
