### PR TITLE
simplePicker navi buttons are not shown when client controls are created...

### DIFF
--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -53,7 +53,7 @@ enyo.kind({
 		//* Reference to currently selected item, if any
 		selected: "",
 		//* Index of currently selected item, if any
-		selectedIndex: 0,
+		selectedIndex: null,
 		//* When true, picker transitions animate left/right
 		animate: true,
 		//* When true, button is shown as disabled and does not generate tap events


### PR DESCRIPTION
... dynamically.

When developer makes client control dynamically and set selectedIndex '0',
there is no navi button shown becuase selectedIndex is not changed.
So change default value 'null' instead of '0'

Enyo-DCO-1.1-Signed-off-by: Joohyun Yoon joohyun.yoon@lge.com
