### PR TITLE
GF-43086 - Sample Fix

### DIFF
--- a/samples/SliderSample.js
+++ b/samples/SliderSample.js
@@ -7,8 +7,8 @@ enyo.kind({
 		{from: ".$.slider1.bgProgress", to: ".$.slider2.bgProgress"}
 	],
 	components: [
-		{kind: "moon.Scroller", fit: true, style: "margin-top:20px;", components: [
-
+		{kind: "moon.Scroller", fit: true, components: [
+			{classes:"moon-1v"},
 			{kind: "moon.Divider", content: "Slider 1: Default"},
 			{name: "slider1", kind: "moon.Slider", value: 25, bgProgress: 35, onChanging: "sliderChanging", onChange: "sliderChanged"},
 


### PR DESCRIPTION
Unnecessary margin-top is added to divider inside scroller, which
causing this miscalculation.

Solution :
Since scroller is the first component, for proper display margin-top is
added, If this is the reason,
then
1. margin-top can be added to scroller instead of divider.
2. Remove margin-top completely.
Solution1 is implemented.

Enyo-DCO-1.1-Signed-off-by: Ashwini R ashwini13.r@lge.com
