### PR TITLE
GF-40718: Make Scroller have consistent perf on TV

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -51,14 +51,13 @@ enyo.kind({
 		]}
 	],
 	//* @protected
-	scrollInterval: 65,
+	scrollFrame: 3, // parameter that determines scroll math simulation speed
 	rendered: function(){
 		this.inherited(arguments);
 		this.rangeChanged();
 		this.refreshScrollState();
-		this.$.scroller.getStrategy().setInterval(this.scrollInterval);
 		this.$.scroller.getStrategy().setFixedTime(false);
-		this.$.scroller.getStrategy().setFrame(3);
+		this.$.scroller.getStrategy().setFrame(this.scrollFrame);
 	},
 	refreshScrollState: function() {
 		this.updateScrollBounds();


### PR DESCRIPTION
Currently scrolling based on frame interval.
However to keep consistent performance. we'd better use scrolling based
on time interval.

FYI please refer https://github.com/enyojs/enyo/pull/508

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
