### PR TITLE
Defect Fix - GF- 43307 - Mistyped Text Causes Overlapping Text

### DIFF
--- a/source/Clock.js
+++ b/source/Clock.js
@@ -34,7 +34,7 @@ enyo.kind({
 		this.startJob("refresh", this.bindSafely("refreshJob"), this.getRefresh());
 	},
 	dateChanged: function() {
-		if(this.date && this.date instanceof Date) {
+		if((this.date && this.date instanceof Date) && !isNaN(this.date)) {
 			this._timeDiff = this.date.getTime() - Date.now();
 		} else {
 			this._timeDiff = 0;
@@ -51,7 +51,7 @@ enyo.kind({
 		this.$.hour.setContent(this._formatNumber(h));
 		this.$.minute.setContent(this._formatNumber(d.getMinutes()));
 		this.$.meridiem.setContent(meridiem);
-		this.$.month.setContent(this.months[d.getMonth()] || " ");
+		this.$.month.setContent(this.months[d.getMonth()]);
 		this.$.day.setContent(this._formatNumber(d.getUTCDate()));
 		this.startJob("refresh", this.bindSafely("refreshJob"), this.getRefresh());
 	},


### PR DESCRIPTION
When wrong input, Defualt value is missing for month, hence with is set
to zero and contents getting overlapped.

Solution : Add default value to month on wrong input similar to other
controls.

Enyo-DCO-1.1-Signed-off-by: Ashwini R ashwini13.r@lge.com
