### PR TITLE
GF-41734 Defect Fixed VideoPlayer when FastForward reaching Buffer End

### DIFF
--- a/source/Video.js
+++ b/source/Video.js
@@ -65,7 +65,8 @@ enyo.kind({
 		onJumpBackward: "",
 		onPlay: "",
 		onStart: "",
-		onDisableTranslation: ""
+		onDisableTranslation: "",
+		onFFBufferEnd: ""
 	},
 	handlers: {
 		//* Catch video _loadedmetadata_ event
@@ -415,6 +416,11 @@ enyo.kind({
 			return;
 		}
 		inEvent = enyo.mixin(inEvent, this.createEventData());
+
+		// Check for playback in fast-forward reaching end of buffer and switch to play mode, update playback control button
+		if((this._prevCommand == "fastForward") && (node.playbackRate > (node.buffered.end(0) - node.currentTime))) {
+			this.doFFBufferEnd();
+		}
 	},
 	ratechange: function(inSender, inEvent) {
 		var node = this.hasNode(),

--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -179,7 +179,7 @@ enyo.kind({
 			{name: "video", kind: "enyo.Video", classes: "moon-video-player-video",
 				ontimeupdate: "timeUpdate", onloadedmetadata: "metadataLoaded", durationchange: "durationUpdate", onloadeddata: "dataloaded", onprogress: "_progress", onPlay: "_play", onpause: "_pause", onStart: "_start",  onended: "_stop",
 				onFastforward: "_fastforward", onSlowforward: "_slowforward", onRewind: "_rewind", onSlowrewind: "_slowrewind",
-				onJumpForward: "_jumpForward", onJumpBackward: "_jumpBackward", onratechange: "playbackRateChange"
+				onJumpForward: "_jumpForward", onJumpBackward: "_jumpBackward", onratechange: "playbackRateChange", onFFBufferEnd: "play"
 			}
 		]},
 


### PR DESCRIPTION
Issue: moon.VideoPlayer: When fast-forward reaches end of buffer, switch
back to play.
To handle this case it was needed to use a HTML5 video loop event in
which buffered content and current content can be monitored.
Fixes:
Added case in timeupdate to handle fast-forward when it reaches end of
buffer, and added API 'onFFBufferEnd' to switch video to play mode and
update playback control to work as expected.

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
