### PR TITLE
GF-41734 Defect Fixed VideoPlayer when FastForward reaching Buffer End

### DIFF
--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -57,7 +57,8 @@ enyo.kind({
 		onSeek: "",
 		onSeekFinish: "",
 		onEnterTapArea: "",
-		onLeaveTapArea: ""
+		onLeaveTapArea: "",
+		onProgressbarScaleChanged: ""
 	},
 	tickComponents: [
 		{classes: "moon-video-transport-slider-indicator-wrapper start", components: [
@@ -138,6 +139,9 @@ enyo.kind({
 	resizeHandler: function() {
 		this.inherited(arguments);
 		this.updateSliderRange();
+		if(this.scaleFactor) {
+			this.doProgressbarScaleChanged({progressbarScaling: this.scaleFactor});
+		}
 	},
 	updateSliderRange: function() {
 		this.beginTickPos = (this.max-this.min)*0.0625;
@@ -253,6 +257,12 @@ enyo.kind({
 			if (this.isInPreview()) {
 				//* This will move popup position to playing time when preview move is end
 				this._currentTime = v;
+				if (this._currentTime == 0) {
+					this.$.feedback.feedback("Play");
+				}
+				if (this._currentTime == this.duration) {
+					this.$.feedback.feedback("Stop");
+				}
 			}
 			return true;
 		}
@@ -353,6 +363,7 @@ enyo.kind({
 		this.currentTime = this._currentTime;
 		this.duration = this._duration;
 		this.$.endTickText.setContent(this.formatTime(this.duration));
+		this.doProgressbarScaleChanged({progressbarScaling: this.scaleFactor});
 	},
 
 	//* Properly format time


### PR DESCRIPTION
Issue: moon.VideoPlayer: When fast-forward reaches end of buffer, switch
back to play.
No event is triggered by video to tell that video has reached the end of
buffer, and there is no way to know in which buffer range the current
play is in to give end condition for multiple buffer ranges case.
Fixes:
Added condition for fast-forward in timeupdate to change playback to
play mode when video reaches end of
buffer.
Added "getBufferCurrentRangeIndex" to check in which buffer range our
playback is currently.

Enyo-DCO-1.1-Signed-off-by: Anugrah Saxena anugrah.saxena@lge.com
