### PR TITLE
Adding default margin to moon.VideoPlayer.

### DIFF
--- a/css/VideoPlayer.less
+++ b/css/VideoPlayer.less
@@ -1,6 +1,7 @@
 .moon-video-player {
 	position: relative;
 	display: inline-block;
+	margin: 0 @moon-spotlight-outset;
 	background-color: @moon-video-player-bg-color;
 }
 .moon-video-player-container {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3758,6 +3758,7 @@
 .moon-video-player {
   position: relative;
   display: inline-block;
+  margin: 0 10px;
   background-color: #000000;
 }
 .moon-video-player-container {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3752,6 +3752,7 @@
 .moon-video-player {
   position: relative;
   display: inline-block;
+  margin: 0 10px;
   background-color: #000000;
 }
 .moon-video-player-container {


### PR DESCRIPTION
Due to recent changes in panel spacing, an inline video player inside a panel was poking out to the left of the panel boundary. This change fixes that issue.

Enyo-DCO-1.1-Signed-off-by: Gray Norton gray.norton@lge.com
