### PR TITLE
Better fix for moon.Panels background scrim issues.

### DIFF
--- a/css/Panels.less
+++ b/css/Panels.less
@@ -17,7 +17,7 @@
 }
 
 /* Scrim */
-.moon-panels-background-scrim {
+.moon-panels .moon-panels-background-scrim {
 	position: absolute;
 	left: 0;
 	top: 0;
@@ -26,8 +26,6 @@
 	background-color: black;
 	pointer-events: none;
 	opacity: 0;
-}
-.moon-panels-background-scrim.transition {
 	transition: opacity 0.5s linear;
 	-webkit-transition: opacity 0.5s linear;
 	-moz-transition: opacity 0.5s linear;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -2964,7 +2964,7 @@
   pointer-events: auto;
 }
 /* Scrim */
-.moon-panels-background-scrim {
+.moon-panels .moon-panels-background-scrim {
   position: absolute;
   left: 0;
   top: 0;
@@ -2973,8 +2973,6 @@
   background-color: black;
   pointer-events: none;
   opacity: 0;
-}
-.moon-panels-background-scrim.transition {
   transition: opacity 0.5s linear;
   -webkit-transition: opacity 0.5s linear;
   -moz-transition: opacity 0.5s linear;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -2959,7 +2959,7 @@
   pointer-events: auto;
 }
 /* Scrim */
-.moon-panels-background-scrim {
+.moon-panels .moon-panels-background-scrim {
   position: absolute;
   left: 0;
   top: 0;
@@ -2968,8 +2968,6 @@
   background-color: black;
   pointer-events: none;
   opacity: 0;
-}
-.moon-panels-background-scrim.transition {
   transition: opacity 0.5s linear;
   -webkit-transition: opacity 0.5s linear;
   -moz-transition: opacity 0.5s linear;

--- a/source/Panels.js
+++ b/source/Panels.js
@@ -40,7 +40,7 @@ enyo.kind({
 		onPostTransitionComplete:	"panelPostTransitionComplete"
 	},
 	handleTools: [
-		{name: "backgroundScrim", kind: "enyo.Control", classes: "moon-panels-background-scrim", showing: false, ontransitionend: "hideScrim"},
+		{name: "backgroundScrim", kind: "enyo.Control", classes: "moon-panels-background-scrim"},
 		{name: "clientWrapper", kind: "enyo.Control", classes: "enyo-fill enyo-arranger moon-panels-client", components: [
 			{name: "scrim", classes: "moon-panels-panel-scrim"},
 			{name: "client", tag: null}
@@ -523,8 +523,6 @@ enyo.kind({
 		if (!this.hasNode()) {
 			return;
 		}
-		this.$.backgroundScrim.show();
-		this.$.backgroundScrim.addClass("transition");
 		this.$.backgroundScrim.addClass("visible");
 		this.$.showHideHandle.addClass("right");
 		this.$.showHideAnimator.play(this.createShowAnimation().name);
@@ -535,8 +533,6 @@ enyo.kind({
 		if (!this.hasNode()) {
 			return;
 		}
-		this.$.backgroundScrim.show();
-		this.$.backgroundScrim.addClass("transition");
 		this.$.backgroundScrim.removeClass("visible");
 		this.$.showHideHandle.removeClass("right");
 		this.$.showHideAnimator.play(this.createHideAnimation().name);
@@ -544,8 +540,6 @@ enyo.kind({
 	},
 	//* Set to show state without animation
 	_directShow: function() {
-		this.$.backgroundScrim.show();
-		this.$.backgroundScrim.removeClass("transition");
 		this.$.backgroundScrim.addClass("visible");
 		this.$.showHideHandle.addClass("right");
 		if (this.handleShowing) {
@@ -554,18 +548,12 @@ enyo.kind({
 	},
 	//* Set to hide state without animation
 	_directHide: function() {
-		this.$.backgroundScrim.hide();
-		this.$.backgroundScrim.removeClass("transition");
 		this.$.backgroundScrim.removeClass("visible");
 		var x = this.getOffscreenXPosition();
 		this.$.showHideHandle.addClass("hidden");
 		this.$.showHideHandle.removeClass("right");
 		this.$.clientWrapper.applyStyle("-webkit-transform", "translate3d( " + x + "px, 0, 0)");
 		this.hideAnimationComplete();
-	},
-	hideScrim: function() {
-		this.$.backgroundScrim.hide();
-		return true;
 	},
 	createShowAnimation: function() {
 		return this.$.showHideAnimator.newAnimation({


### PR DESCRIPTION
Transition now works for both fade-in and fade-out. Fixed specificity of CSS selector to ensure pointer-events: none applies. Simplified logic.

Enyo-DCO-1.1-Signed-off-by: Gray Norton gray.norton@lge.com
