### PR TITLE
ENYO-3511: Error occurs when drag and drop moon.TimePicker

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -62,14 +62,11 @@ enyo.kind({
 		]}
 	],
 	//* @protected
-	scrollFrame: 3, // parameter that determines scroll math simulation speed
 	rendered: function(){
 		this.inherited(arguments);
 		this.rangeChanged();
 		this.updateOverlays();
 		this.refreshScrollState();
-		this.$.scroller.getStrategy().setFixedTime(false);
-		this.$.scroller.getStrategy().setFrame(this.scrollFrame);
 	},
 	refreshScrollState: function() {
 		this.updateScrollBounds();


### PR DESCRIPTION
Removes not existing functions.
- enyo.Scroller does not have setFixedTime / setFrame funtions.

ENYO-3511: Error occurs when drag and drop moon.TimePicker
Enyo-DCO-1.1-Signed-Off-By: SangHyun.Hong (sanghyun.hong@lgepartner.com)
