### PR TITLE
GF-33990-moon.Drawers drawersResized  Defect Fixed

### DIFF
--- a/source/Drawer.js
+++ b/source/Drawer.js
@@ -81,7 +81,7 @@ enyo.kind({
 		if (this.controlDrawerComponents == null) {
 			return clientHeight;
 		} else {
-			this.controlDrawerHeight = (this.controlDrawerHeight) ? this.controlDrawerHeight : this.$.controlDrawer.hasNode().getBoundingClientRect().height
+			this.controlDrawerHeight = (this.controlDrawerHeight) ? this.controlDrawerHeight : this.$.controlDrawer.hasNode().getBoundingClientRect().height;
 			return (clientHeight - this.controlDrawerHeight);
 		}
 	},


### PR DESCRIPTION
issue: drawer: resized() function draw extra height
cause: Drawers rendering methods are being called in the drawersResized
method which causes the problem.
solution:  drawersResized method  is modified without rendering methods.

Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P rajyavardhan.p@lge.com
