### PR TITLE
GF-43737: Refuse invalid ranged value

### DIFF
--- a/source/ExpandableIntegerPicker.js
+++ b/source/ExpandableIntegerPicker.js
@@ -74,7 +74,7 @@ enyo.kind({
 	// Change handlers
 	valueChanged: function(inOld) {
 		if (this.value < this.min || this.value > this.max) {
-			this.setValue(inOld);
+			this.value = inOld;
 		}
 		this.fireChangeEvent();
 	},


### PR DESCRIPTION
As explained in Jira description, over ranged value could be given with setValue()
If developer call setValue() with an invalid range, it should prevent to change value.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
