### PR TITLE
GF-42757,43529 : Enforcing font CSS change

### DIFF
--- a/source/moonstone-fonts.js
+++ b/source/moonstone-fonts.js
@@ -1,0 +1,38 @@
+(function() {
+	var loc = new ilib.Locale();
+	var language = loc.getLanguage();
+	if (language === 'ur') {
+		var style = document.createElement("style");
+		document.head.appendChild(style);
+		style.innerText =
+			'@font-face { ' +
+			'	font-family: "LG Display;' +
+			'	src: local("LG Display_Urdu");' +
+			'	font-weight: normal;' +
+			'	unicode-range: U+0600-U+06FF;' +
+			'	unicode-range: U+FE70-U+FEFE;' +
+			'	unicode-range: U+FB50-U+FDFF;' +
+			'}';
+	}
+	else if (language === 'ja') {
+		var style = document.createElement("style");
+		document.head.appendChild(style);
+		style.innerText =
+			'@font-face { ' +
+			'	font-family: "LG Display";' +
+			'	src: local("LG Display_JP");' +
+			'	font-weight: normal;' +
+			'	unicode-range: U+0000-U+00FF;' +
+			'	unicode-range: U+2E80-U+2EFF;' +
+			'	unicode-range: U+2F00-U+2FDF;' +
+			'	unicode-range: U+3000-U+303F;' +
+			'	unicode-range: U+3040-U+309F;' +
+			'	unicode-range: U+30A0-U+30FF;' +
+			'	unicode-range: U+3200-U+33FF;' +
+			'	unicode-range: U+3400-U+4DBF;' +
+			'	unicode-range: U+4E00-U+9FFF;' +
+			'	unicode-range: U+E000-U+FAFF;' +
+			'	unicode-range: U+FF00-U+FFEF;' +
+			'}';
+	}
+})();

--- a/source/package.js
+++ b/source/package.js
@@ -1,5 +1,6 @@
 enyo.depends(
 	"moon-ilib.js",
+	"moonstone-fonts",
 	"BodyText.js",
 	"Marquee.js",
 	"Button.js",


### PR DESCRIPTION
GF-42757,43529 : Enforcing font CSS change for Japan and Urdu.

Modify enyo css files to support Japan fonts and Urdu fonts.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
