### PR TITLE
Fixes GF-44722.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -468,6 +468,13 @@ enyo.kind({
 		}
 
 		this.inherited(arguments);
+
+		// If we're not animating, then spot the active
+		// panel immediately. Otherwise, this will happen
+		// in finishTransition().
+		if (this.hasNode() && !this.animate) {
+			enyo.Spotlight.spot(this.getActive());
+		}
 	},
 	finishTransition: function(sendEvents) {
 		this.inherited(arguments);


### PR DESCRIPTION
Ensure that we spot the active panel after switching panels, even when we’re not animating.

Enyo-DCO-1.1-Signed-off-by: Gray Norton gray.norton@lge.com
