### PR TITLE
Defect Fix - GF-44931 - Broken Picker Arrows

### DIFF
--- a/css/SimpleIntegerPicker.less
+++ b/css/SimpleIntegerPicker.less
@@ -1,4 +1,5 @@
 .moon-simple-integer-picker {
+  white-space: nowrap;
   .moon-sub-header-text;
   position: relative;
   display: table-cell;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -955,6 +955,7 @@
   margin-left: 10px;
 }
 .moon-simple-integer-picker {
+  white-space: nowrap;
   font-family: "MuseoSans 700";
   font-size: 30px;
   font-weight: normal;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -955,6 +955,7 @@
   margin-left: 10px;
 }
 .moon-simple-integer-picker {
+  white-space: nowrap;
   font-family: "MuseoSans 700";
   font-size: 30px;
   font-weight: normal;

--- a/patterns-samples/SlideshowControl/LayeredContainer/LayeredContainer.css
+++ b/patterns-samples/SlideshowControl/LayeredContainer/LayeredContainer.css
@@ -50,11 +50,11 @@
 }
 
 .moon-photo-slideshow-control-buttons {
-	height: 120px;	
+	height: 130px;	
 }
 
 .moon-photo-slideshow-control-list {
-	height: 202px;	/* 160 + 16 * 2 + 10 */
+	height: 230px;
 }
 
 .moon-photo-slideshow-control-left-button {
@@ -77,7 +77,7 @@
 }
 
 .moon-photo-slideshow-control-picker-wrapper {
-	width:250px;
+	width:270px;
 	display:block;
 }
 


### PR DESCRIPTION
added "white-space: nowrap;" to simple integer picker.
Modified CSS of sample to handle these issues.
1. avoid overlapping of picker on images,
2. Images truncation
3. Picker truncation issues.

Enyo-DCO-1.1-Signed-off-by: Ashwini R ashwini13.r@lge.com
