### PR TITLE
[GF-45791] In moon.Slider, popWidth property not working

### DIFF
--- a/source/Slider.js
+++ b/source/Slider.js
@@ -158,6 +158,7 @@ enyo.kind({
 		this.inherited(arguments);
 		this.popupColorChanged();
 		this.popupHeightChanged();
+		this.popupWidthChanged();
 		this.drawToCanvas(this.popupColor);
 		this._setValue(this.value);
 		this.addRemoveClass("moon-slider-rtl", this.rtl);


### PR DESCRIPTION
Fixing http://jira2.lgsvl.com/browse/GF-45791

The popWidthChanged is not called in render time.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
