### PR TITLE
GF-45650: Panels Unexpectedly Sit Together Upon Expanding

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -47,7 +47,6 @@ enyo.kind({
 		onSpotlightContainerLeave:	"onSpotlightPanelLeave",
 		onSpotlightContainerEnter:	"onSpotlightPanelEnter",
 
-		onTransitionFinish:			"transitionFinish",
 		onPreTransitionComplete:	"panelPreTransitionComplete",
 		onPostTransitionComplete:	"panelPostTransitionComplete"
 	},
@@ -190,12 +189,12 @@ enyo.kind({
 		}
 	},
 	onTap: function(oSender, oEvent) {
-		if (oEvent.originator === this.$.showHideHandle || this.pattern === "none" || this.inPanelTransition === true) {
+		if (oEvent.originator === this.$.showHideHandle || this.pattern === "none") {
 			return;
 		}
 
 		if (this.shouldHide(oEvent)) {
-			if (this.showing && this.useHandle === true) {
+			if (this.showing && this.useHandle === true && this.inPanelTransition === false) {
 				this.hide();
 			}
 		} else {
@@ -322,7 +321,7 @@ enyo.kind({
 			return;
 		}
 
-		if (this.toIndex !== null) {
+		if (this.toIndex !== null || this.inPanelTransition === true) {
 			this.queuedIndex = inIndex;
 			return;
 		}
@@ -477,6 +476,7 @@ enyo.kind({
 		// in finishTransition().
 		if (this.hasNode() && !this.animate) {
 			enyo.Spotlight.spot(this.getActive());
+			this.inPanelTransition = false;
 		}
 	},
 	finishTransition: function(sendEvents) {


### PR DESCRIPTION
Fixing http://jira2.lgsvl.com/browse/GF-45650
- Block subsequent tap event handling while panel transitioning.
- Block and queuing subsequent  setIndex handling while panel transitioning.
- Release panel transitioning flag when there is no animation.

This fix can block redundant spotlight enter handling while it is transitioning.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
