### PR TITLE
GF-42447: The first child of Popup should not be focused when it is opened in pointer Mode

### DIFF
--- a/samples/PopupSample.js
+++ b/samples/PopupSample.js
@@ -13,11 +13,11 @@ enyo.kind({
 
 		{name: "basicPopup", kind: "moon.Popup", content: "Popup..."},
 		{name: "longPopup", kind: "moon.Popup", allowHtml: true, content: "Don't go changing, to try and please me  <br>You never let me down before  <br>Don'timagine you're too familiar  <br>And I don't see you anymore  <br>I wouldn't leave you in times of trouble  <br>We never could have come this far I took the good times, I'll take the bad times I'll take you just the way you are Don't go trying some new fashion Don't change the color of your hair You always have my unspoken passion Although I might not seem to care I don't want clever conversation I never want to work that hard I just want someone that I can talk to I want you just the way you are. I need to know that you will always be The same old someone that I knew What will it take till you believe in me The way that I believe in you."},
-		{name: "buttonPopup", kind: "moon.Popup", floating:true, components: [
+		{name: "buttonPopup", kind: "moon.Popup", floating:true, defaultSpotlightControl: "goodbye", components: [
 			{kind: "moon.Divider", content: "Buttons in popup example"},
 			{classes: "moon-hspacing", components: [
 				{kind: "moon.Button", content: "Hello"},
-				{kind: "moon.Button", content: "Goodbye"},
+				{name: "goodbye", kind: "moon.Button", content: "Goodbye [default focus]"},
 				{kind: "moon.ToggleButton", content: "SpotlightModal", ontap: "buttonToggled"}
 			]}
 		]},

--- a/source/Popup.js
+++ b/source/Popup.js
@@ -13,7 +13,7 @@ enyo.kind({
 	*/
 	modal: true,
 	floating: true,
-	_spotlight: null,
+	_spotlightOld: null,
 	_bounds: null,
 	spotlight: "container",
 	handlers: {
@@ -94,7 +94,7 @@ enyo.kind({
 		this.allowHtmlChanged();
 		this.contentChanged();
 		this.inherited(arguments);
-		this._spotlight = this.spotlight;
+		this._spotlightOld = this.spotlight;
 	},
 	rendered: function () {
 		this.inherited(arguments);
@@ -174,13 +174,13 @@ enyo.kind({
 		this.showHideScrim(this.showing);
 		if (this.showing) {
 			this.activator = enyo.Spotlight.getCurrent();
-			this.spotlight = this._spotlight;
+			this.spotlight = this._spotlightOld;
 			this.configCloseButton();
 			var spottableChildren = enyo.Spotlight.getChildren(this).length;
 			if (spottableChildren === 0) {
 				this.spotlight = false;
 			} else if ((this.spotlight) && (spottableChildren > 0)) {
-				enyo.Spotlight.spot(enyo.Spotlight.getFirstChild(this));
+				enyo.Spotlight.spot(this);
 			}
 		}
 	},


### PR DESCRIPTION
Fixing http://jira2.lgsvl.com/browse/GF-42447

moon.Popup should not give focus to first child when it is opened in
pointer mode.

The container decorator is already have defaultSpotlightControl property
and popup itself is container so we don't need to add defaultControl.

And moon.Popup has _spotlight private property which is caching last
spotlight property but it is conflict with container decorator in
spotlight so I modified _spotlight to _spotlightOld.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
