### PR TITLE
GF-51374: moon.VideoTransportSlider, a feedback text are overlapped some...

### DIFF
--- a/source/VideoFeedback.js
+++ b/source/VideoFeedback.js
@@ -33,8 +33,8 @@ enyo.kind({
 	_autoTimer: null,
 
 	components: [
-		{name: "leftIcon",  classes: "moon-video-feedback-icon-left",  allowHtml: true, content: "&nbsp;", showing: false},
-		{name: "feedText",  classes: "moon-video-feedback-text"},
+		{name: "leftIcon",  classes: "moon-video-feedback-icon-left", allowHtml: true, content: "&nbsp;", showing: false},
+		{name: "feedText",  classes: "moon-video-feedback-text", allowHtml: true, content: "&nbsp;"},
 		{name: "rightIcon", classes: "moon-video-feedback-icon-right", allowHtml: true, content: "&nbsp;", showing: false}
 	],
 
@@ -111,7 +111,7 @@ enyo.kind({
 			inMessage = "";
 			inLeftSrc = enyo.path.rewrite(this._imagePath + this._pauseJumpBackImg);
 			break;
-			
+
 		case "JumpToEnd":
 			inMessage = "";
 			inRightSrc = enyo.path.rewrite(this._imagePath + this._pauseJumpForwardImg);


### PR DESCRIPTION
...times at first time

A feedback text are overlapped sometimes at first time. Initially width and height are 0, then set contents, in this case, text are overlapped. In order to fix, I've added empty space same as left/right Icons.

Enyo-DCO-1.1-Signed-off-by: Goun Lee goun.lee@lge.com
