### PR TITLE
Removing hidePagingOnKey, hidePagingOnLeave, pageSize from moon.List

### DIFF
--- a/source/List.js
+++ b/source/List.js
@@ -14,18 +14,6 @@ enyo.kind({
 	kind: "enyo.List",
 	//* @protected
 	classes: "moon-list",
-	//* @public
-	published: {
-		//* If true, paging controls are hidden if a key is pressed (in 5-way mode)
-		hidePagingOnKey: true,
-		//* If true, paging controls are hidden if the user's pointer leaves this control
-		hidePagingOnLeave: true,
-		/**
-			Amount to scroll when a paging control is tapped. Set to the row size by
-			default.
-		*/
-		pageSize: null
-	},
 	//* @protected
 	/**
 		Default scrolling strategy is _moon.ScrollStrategy_, which extends


### PR DESCRIPTION
Fixing http://jira2.lgsvl.com/browse/GF-43229

Per Kevin
- Those are very old legacy properties from when List and Scroller had different implementations of the paging buttons. 
- Now Scroller implements the paging scheme, so List should have no properties controlling it. 

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
