### PR TITLE
GF-45752:Add enyo.warn about popupHeight property in moon.Slider

### DIFF
--- a/source/Slider.js
+++ b/source/Slider.js
@@ -60,7 +60,7 @@ enyo.kind({
 		showPercentage: true,
 		//* Popup width in pixels
 		popupWidth: "auto",
-		//* Popup height in pixels
+		//* Popup height in pixels, and it is designed for under 72 pixels.
 		popupHeight: 67,
 		//* Popup offset in pixels
 		popupOffset: 8,
@@ -196,6 +196,10 @@ enyo.kind({
 	},
 	//* Updates popup height.
 	popupHeightChanged: function() {
+		if (this.getPopupHeight() >= 72) {
+			enyo.warn("This popupHeight API is designed for under 72 pixels.");
+		}
+
 		this.$.drawingLeft.setAttribute("height", this.getPopupHeight());
 		this.$.drawingRight.setAttribute("height", this.getPopupHeight());
 		this.$.popupLabel.applyStyle("height", this.getPopupHeight() - 7 + 'px');


### PR DESCRIPTION
I've added enyo.warn in popupHeightChanged() to warn to developers, If it is over 72 pixels, which breaks the ui. This popupHeight() has a possible to be deprecated. but currently, a certain app is using it.

Enyo-DCO-1.1-Signed-off-by: Goun Lee goun.lee@lge.com
