### PR TITLE
GF-51529: Update meridiem's overlays when it is update due to hour chang...

### DIFF
--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -21,6 +21,7 @@ enyo.kind({
 		meridiems: ["AM","PM"]
 	},
 	valueChanged: function() {
+		this.inherited(arguments);
 		this.updateOverlays();
 	},
 	//* @protected


### PR DESCRIPTION
...ing.

When hour changed from 11 to 12, or 12 to 11 meridiem's arrow does not
updated.
This issue reported from Q Event. You can see detail in Jira comments.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
