### PR TITLE
GF-51515-ExpandableInput-onchange Event Issue

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -36,12 +36,12 @@ enyo.kind({
 		]},
 		{name: "drawer", kind: "enyo.Drawer", classes:"moon-expandable-list-item-client indented", components: [
 			{name: "inputDecorator", kind: "moon.InputDecorator", onSpotlightFocus: "inputFocus", onSpotlightSelect: "expandContract", onSpotlightDown: "inputDown", components: [
-				{name: "clientInput", kind: "moon.Input", onblur: "blured"}
+				{name: "clientInput", kind: "moon.Input", onchange: "doChange"}
 			]}
 		]}
 	],
 	bindings: [
-		{from: ".value", to: ".$.clientInput.value"},
+		{from: ".value", to: ".$.clientInput.value", oneWay: false},
 		{from: ".placeholder", to: ".$.clientInput.placeholder"},
 		{from: ".showCurrentValue", to: ".$.currentValue.showing"},
 		{from: ".currentValueText", to: ".$.currentValue.content"},
@@ -50,27 +50,6 @@ enyo.kind({
 	computed: {
 		"showCurrentValue": ["open", "value", "noneText"],
 		"currentValueText": ["value", "noneText"]
-	},
-	blured: function() {
-		if (this.getOpen() && this.getAutoCollapse()) {
-			this.expandContract();
-		} else {
-			this.updateValue();
-		}
-	},
-	// Change handlers
-	valueChanged: function() {
-		if (this.generated) {
-			this.fireChangeEvent();
-		}
-	},
-	openChanged: function() {
-		this.inherited(arguments);
-		
-		if (this.generated && !this.getOpen()) {
-			this.updateValue();
-			this.$.clientInput.blur();
-		}
 	},
 	
 	// Computed props
@@ -88,10 +67,6 @@ enyo.kind({
 			this.setActive(true);
 			this.focusInput();
 		}
-	},
-	//* Sets _this.value_ to _this.$.clientInput.value_.
-	updateValue: function() {
-		this.setValue(this.$.clientInput.getValue());
 	},
 	//* Focuses the _moon.Input_ when the input decorator receives focus.
 	inputFocus: function(inSender, inEvent) {
@@ -120,10 +95,6 @@ enyo.kind({
 	*/
 	inputDown: function(inSender, inEvent) {
 		return this.getLockBottom();
-	},
-	//* Fires an _onChange_ event
-	fireChangeEvent: function() {
-		this.doChange({value: this.value});
 	},
 	stopHeaderMarquee: function() {
 		this.$.headerWrapper.stopMarquee();


### PR DESCRIPTION
Issue: onchange event should fire when the user clicks away from input filed on the panel

Cause & Solution : Once User done with providing input in the ExpandableInput field, when he
click away from the input field,  'onchange' event is not getting fired.
So based on the requirement added the function which can trigger the
event as desired.

Enyo-DCO-1.1-Signed-off-by: Srinivas V  srinivas.v@lge.com
