### PR TITLE
GF:44975: Changed spotlight:'container' in ExpandableListItem

### DIFF
--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -75,7 +75,7 @@ enyo.kind({
 	},
 	//* @protected
 	classes: "moon-expandable-list-item",
-	spotlight: false,
+	spotlight: "container",
 	defaultKind: "moon.Item",
 	handlers: {
 		onSpotlightDown: "spotlightDown",


### PR DESCRIPTION
in regards http://jira2.lgsvl.com/browse/GF-44975
Because ExpandableListitem is spotlight:false, defaultSpotlightControl property doesn't work. so I've changed spotlight:"contaier".  After changes this, other ExpandablePicker 's behavior is same as before.

Enyo-DCO-1.1-Signed-off-by: Goun Lee goun.lee@lge.com
