### PR TITLE
GF-43095-PanelsVideoPlayerSample-Inline Viedo Overlapping Issue

### DIFF
--- a/samples/PanelsVideoPlayerSample.css
+++ b/samples/PanelsVideoPlayerSample.css
@@ -1,5 +1,0 @@
-.enyo-locale-right-to-left .moon-item-capture {
-  position: absolute;
-  left: 0;
-}
-

--- a/samples/PanelsVideoPlayerSample.js
+++ b/samples/PanelsVideoPlayerSample.js
@@ -70,30 +70,13 @@ enyo.kind({
 							{kind: "moon.IconButton", src: "$lib/moonstone/images/video-player/icon-placeholder.png"}
 						]
 					}]
-				},
-				{classes: "moon-3h", components: [
-					{kind: "moon.Item", classes:"moon-item-capture",content: "Capture", ontap: "capture"}
-				]}
-			]},
-			{kind: "moon.Panel", title: "Capture to Canvas", components: [
-				{kind: "moon.Scroller", fit: true, components: [
-					{tag: "canvas", name: "capture", spotlight: true}
-				]}
+				}
 			]}
 		]}
 	],
 	bindings: [
 		{from:".$.autoplayToggle.value", to:".$.player.autoplay"}
 	],
-	capture: function(inSender, inEvent) {
-		try {
-			this.updateCanvas();
-		} catch (e) {
-			enyo.warn(e);
-		}
-		this.$.panels.setIndex(2);
-		return true;
-	},
 	unload: function() {
 		this.$.player.unload();
 	},
@@ -132,14 +115,5 @@ enyo.kind({
 		this.src = "http://foo.bar";
 		this.$.player.setSrc(this.src);
 		this.$.videoInfoHeader.setTitle("Error video");
-	},
-	updateCanvas: function() {
-		var drawingNode = this.$.capture.hasNode();
-		var videoNode = this.$.player.getVideo().hasNode();
-		var ctx = drawingNode.getContext("2d");
-		var vdb = videoNode.getBoundingClientRect();
-		this.$.capture.applyStyle("width", vdb.width+"px");
-		this.$.capture.applyStyle("height", vdb.height+"px");
-		ctx.drawImage(videoNode, 0, 0, 300, 150);
 	}
 });


### PR DESCRIPTION
This is the sample issue not the framework issue, in the sample
moon.Item "Capture" is initially aligned to right. when we turn on the
RTL, the alignment of this item is not reflected as desired, that is why
'Capture' item is overlapping on the Inline Video.
so added a class to the sample.css which can do the job when RTL is
turned on.

Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com
