### PR TITLE
Update Moonstone code to use enyo.bindSafely so there aren't

### DIFF
--- a/source/HighlightText.js
+++ b/source/HighlightText.js
@@ -1,15 +1,15 @@
-/** 
+/**
 	_moon.HighlightText_ is a control that displays highlighted text.  In response
-	to calling `setHighlight` or receiving `onHighlight` event, it will highlight a 
+	to calling `setHighlight` or receiving `onHighlight` event, it will highlight a
     specified string if that string is found within the control's content.
 
 	For example, let's say we have the following control:
-	
+
 		{kind: "moon.HighlightText", name: "myHT", content: "Hello World!"}
 
 	In response to the event
 
-		this.waterfall("onHighlight", {highlight: "Hello"}); 
+		this.waterfall("onHighlight", {highlight: "Hello"});
 
     or calling the API directly:
 
@@ -53,7 +53,7 @@ enyo.kind({
     //* @protected
     generateInnerHtml: function() {
         if (this.search) {
-            return this.content.replace(this.search, enyo.bind(this, function(s) {
+            return this.content.replace(this.search, this.bindSafely(function(s) {
                 return "<span style='pointer-events:none;' class='" + this.highlightClasses + "'>" + enyo.Control.escapeHtml(s) + "</span>";
             }));
         } else {

--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -93,7 +93,7 @@ enyo.kind({
 		this.$.repeater.setCount(this.max-this.min+1);
 		this.$.repeater.render();
 		//asynchronously scroll to the current node, this works around a potential scrolling glitch
-		enyo.asyncMethod(enyo.bind(this,function(){
+		enyo.asyncMethod(this.bindSafely(function(){
 			this.$.scroller.scrollToNode(this.$.repeater.fetchRowNode(this.value - this.min));
 		}));
 	},

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -88,7 +88,7 @@ moon.MarqueeSupport = {
 			this._marquee_startHold();
 		}
 	},
-	
+
 	//* @public
 	/**
 		Starts timer to waterfall an _onRequestMarqueeStart_ event that kicks off
@@ -100,7 +100,7 @@ moon.MarqueeSupport = {
 		if (this.marqueeWaitList.length === 0) {
 			return;
 		}
-	
+
 		this._marquee_active = true;
 		this.startJob("marqueeSupportJob", "_marquee_startChildMarquees", this.marqueeDelay);
 	},
@@ -124,9 +124,9 @@ moon.MarqueeSupport = {
 	addMarqueeItem: function(inControl) {
 		this.marqueeWaitList.push(inControl);
 	},
-	
+
 	//* @protected
-	
+
 	//* Waterfalls request for child animations to build up _this.marqueeWaitList_.
 	_marquee_buildWaitList: function() {
 		this.marqueeWaitList = [];
@@ -209,7 +209,7 @@ moon.MarqueeItem = {
 	*/
 	_marquee_contentChanged: function() {
 		if (this.$.marqueeText) {
-			this.$.marqueeText.setContent(this.content);		
+			this.$.marqueeText.setContent(this.content);
 		}
 		this._marquee_invalidateMetrics();
 		if (this._marquee_puppetMaster) {
@@ -222,29 +222,29 @@ moon.MarqueeItem = {
 		if (!inEvent || this.disabled || !this._marquee_enabled || this._marquee_fits) {
 			return;
 		}
-		
+
 		this._marquee_puppetMaster = inEvent.originator;
 		inEvent.originator.addMarqueeItem(this);
-		
+
 		this.marqueePause = inEvent.marqueePause || 1000;
 		this.marqueeSpeed = inEvent.marqueeSpeed || 60;
 	},
 	//* Starts marquee animation.
 	_marquee_startAnimation: function(inSender, inEvent) {
 		var distance = this._marquee_calcDistance();
-		
+
 		// If there is no need to animate, return early
 		if (!this._marquee_shouldAnimate(distance)) {
 			this._marquee_fits = true;
 			this.doMarqueeEnded();
 			return;
 		}
-		
+
 		// Lazy creation of _this.$.marqueeText_
 		if (!this.$.marqueeText) {
 			this._marquee_createMarquee();
 		}
-		
+
 		this._marquee_addAnimationStyles(distance);
 		return true;
 	},
@@ -266,7 +266,7 @@ moon.MarqueeItem = {
 		if (inEvent.originator !== this.$.marqueeText) {
 			return;
 		}
-		
+
 		this.startJob("stopMarquee", "_marquee_stopAnimation", this.marqueePause);
         return true;
 	},
@@ -296,13 +296,13 @@ moon.MarqueeItem = {
 	},
 	_marquee_addAnimationStyles: function(inDistance) {
 		var duration = this._marquee_calcDuration(inDistance);
-		
+
 		this.$.marqueeText.addClass("animate-marquee");
 		this.$.marqueeText.applyStyle("transition-duration", duration + "s");
 		this.$.marqueeText.applyStyle("-webkit-transition-duration", duration + "s");
-		
+
 		// Need this timeout for FF!
-		setTimeout(enyo.bind(this, function() {
+		setTimeout(this.bindSafely(function() {
 			enyo.dom.transform(this.$.marqueeText, {translateX: this._marquee_adjustDistanceForRTL(inDistance) + "px"});
 		}), 100);
 	},
@@ -310,12 +310,12 @@ moon.MarqueeItem = {
 		if (!this.$.marqueeText) {
 			return;
 		}
-		
+
 		this.$.marqueeText.applyStyle("transition-duration", "0s");
-		this.$.marqueeText.applyStyle("-webkit-transition-duration", "0s");	
-		
+		this.$.marqueeText.applyStyle("-webkit-transition-duration", "0s");
+
 		// Need this timeout for FF!
-		setTimeout(enyo.bind(this, function() {
+		setTimeout(this.bindSafely(function() {
 			this.$.marqueeText.removeClass("animate-marquee");
 			enyo.dom.transform(this.$.marqueeText, {translateX: null});
 		}), 0);

--- a/source/Popup.js
+++ b/source/Popup.js
@@ -5,21 +5,21 @@
 enyo.kind({
 	name : "moon.Popup",
 	kind : enyo.Popup,
-	
+
 	//* @protected
 	modal     : true,
 	classes   : "moon moon-neutral enyo-unselectable moon-popup",
 	floating  : true,
 	_bounds   : null,
 	spotlight : "container",
-	
+
 	handlers: {
 		onRequestScrollIntoView   : "_preventEventBubble",
 		ontransitionend           : "animationEnd",
 		onSpotlightSelect         : "onSpotlightSelect",
 		onSpotlightContainerLeave : "onLeave"
 	},
-	
+
 	//* @public
 	published: {
 		/**
@@ -161,7 +161,7 @@ enyo.kind({
 			} else {
 				this.animateHide();
 				var args = arguments;
-				this.animationEnd = enyo.bind(this, function() {
+				this.animationEnd = this.bindSafely(function() {
 					this.inherited(args);
 				});
 			}

--- a/source/StyleAnimator.js
+++ b/source/StyleAnimator.js
@@ -81,7 +81,7 @@ enyo.kind({
 		this.applyValues(animation.startValues);
 		this.cacheStartValues(animation.startValues);
 
-		setTimeout(enyo.bind(this, function() { this._play(inName); }), 0);
+		enyo.asyncMethod(this.bindSafely(function() { this._play(inName); }));
 	},
 	//* @public
 	//* Jumps directly to the end state of a given animation (without animating).
@@ -230,7 +230,7 @@ enyo.kind({
 			for (var j = 0, control; (control = frames[i].controls[j]); j++) {
 				c = control.control;
 				cID = c.id;
-				
+
 				if (!startValues[cID]) {
 					startValues[cID] = {
 						control: c,
@@ -343,7 +343,7 @@ enyo.kind({
 	//* Begins stepping.
 	beginStepping: function() {
 		if (!this.stepInterval) {
-			this.stepInterval = setInterval(enyo.bind(this, "_step"), this.stepIntervalMS);
+			this.stepInterval = setInterval(this.bindSafely("_step"), this.stepIntervalMS);
 		}
 	},
 	//* @protected


### PR DESCRIPTION
crashes if timers aren't removed when controls are destroyed.
This fixes an issue seen with EnyoBench.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
