### PR TITLE
Using enyo.Spotlight.spot() instead of enyo.Spotlight.intialize()...

### DIFF
--- a/samples/ActivityPanelsWithVideoSample.js
+++ b/samples/ActivityPanelsWithVideoSample.js
@@ -93,7 +93,7 @@ enyo.kind({
 	],
 	rendered: function() {
 		this.inherited(arguments);
-		enyo.Spotlight.initialize({spot: this.$.panels});
+		enyo.Spotlight.spot(this.$.panels);
 	},
 	// custom next handler for each panel to avoid switching from one active panel
 	// to another with no visible change for demo


### PR DESCRIPTION
...to specify a control to spot when an app is first rendered.

Depends on https://github.com/enyojs/spotlight/pull/58. Both should be part of 2.3.0-rc.2.

The reference to the old initialize() way of doing this has been removed from the rc.1 release notes.

Enyo-DCO-1.1-Signed-off-by: Gray Norton gray.norton@lge.com
