### PR TITLE
GF-52929-Disabled IconButton displays focus upon clicking

### DIFF
--- a/css/Icon.less
+++ b/css/Icon.less
@@ -38,6 +38,9 @@
 	&.small {
 		background-position: center -(@moon-icon-sprite-small-size);
 	}
+	&.disabled {
+		background-position: center 0;
+	}
 }
 
 .moon-icon.disabled {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -772,6 +772,11 @@
 .moon-icon-toggle.active.small {
   background-position: center -50px;
 }
+.moon-icon.moon-icon-button.active.disabled,
+.moon-icon.moon-icon-button:active:hover.disabled,
+.moon-icon-toggle.active.disabled {
+  background-position: center 0;
+}
 .moon-icon.disabled {
   opacity: 0.6;
   filter: alpha(opacity=60);

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -772,6 +772,11 @@
 .moon-icon-toggle.active.small {
   background-position: center -50px;
 }
+.moon-icon.moon-icon-button.active.disabled,
+.moon-icon.moon-icon-button:active:hover.disabled,
+.moon-icon-toggle.active.disabled {
+  background-position: center 0;
+}
 .moon-icon.disabled {
   opacity: 0.6;
   filter: alpha(opacity=60);


### PR DESCRIPTION
when we click on disabled image asset IconButton button, the image
inside the button is getting focus due to some missing css properties,
so added desired css properties to fix this issue.

Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com
