### PR TITLE
GF-53497: Update feedback when in preview mode

### DIFF
--- a/source/VideoFeedback.js
+++ b/source/VideoFeedback.js
@@ -61,7 +61,7 @@ enyo.kind({
 				"slowRewind": ["-1/2", "-1"]
 			}
 	*/
-	feedback: function(inMessage, inParams, inPersistShowing, inLeftSrc, inRightSrc) {
+	feedback: function(inMessage, inParams, inPersistShowing, inLeftSrc, inRightSrc, isInPreview) {
 		var customMessage = false;
 		inMessage = inMessage || "";
 		inParams = inParams || {};
@@ -139,9 +139,10 @@ enyo.kind({
 		// Set content as _inMessage_
 		this.$.feedText.setContent(inMessage);
 
-		// Show output controls
-		this.showFeedback();
-
+		// Show output controls when video player is not in preview mode
+		if (!isInPreview) {
+			this.showFeedback();
+		}
 		// Show icons as appropriate
 		this.updateIcons(inLeftSrc, inRightSrc);
 

--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -391,10 +391,11 @@ enyo.kind({
 	padDigit: function(inValue) {
 		return (inValue) ? (String(inValue).length < 2) ? "0"+inValue : inValue : "00";
 	},
+	/**
+		Send current status to feedback control in response to user input
+	*/
 	feedback: function(inMessage, inParams, inPersistShowing, inLeftSrc, inRightSrc) {
-		if (!this.isInPreview()) {
-			this.showKnobStatus();
-			this.$.feedback.feedback(inMessage, inParams, inPersistShowing, inLeftSrc, inRightSrc);
-		}
+		this.showKnobStatus();
+		this.$.feedback.feedback(inMessage, inParams, inPersistShowing, inLeftSrc, inRightSrc, this.isInPreview());
 	}
 });


### PR DESCRIPTION
Previously we assume that pressing FF button is unable when video is in preview mode because control box is not displayed in preview mode.
However, when user use 2 remote controllers at the same time, it is able.
Due to FF key in remocon, user can input fast forward in preview mode.

So, when video player is in preview mode, it should response to user's input.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
