### PR TITLE
GF-53593 UTC date not required

### DIFF
--- a/source/Clock.js
+++ b/source/Clock.js
@@ -151,7 +151,7 @@ enyo.kind({
 		this.$.meridiem.setContent(meridiem);
 	},
 	updateMonthDay: function(inDate) {
-		var md = this._mdf ? this._mdf.format(new ilib.Date.GregDate({unixtime: inDate.getTime(), timezone:"UTC"})) : this.months[inDate.getMonth()] + " " + this._formatNumber(inDate.getUTCDate());
+		var md = this._mdf ? this._mdf.format(new ilib.Date.GregDate({unixtime: inDate.getTime(), timezone:"UTC"})) : this.months[inDate.getMonth()] + " " + this._formatNumber(inDate.getDate());
 		this.$.bottom.setContent(md);
 	},
 	handleLocaleChangeEvent: function() {


### PR DESCRIPTION
new Date() uses local time instead of UTC, so to get correct date we
could use getDate() instead of getUTCDate()

Enyo-DCO-1.1-Signed-off-by: Anish Ramesan anish.ramesan@lge.com
