### PR TITLE
GF-53449: Removing fit: true from moon.Panel.

### DIFF
--- a/source/Panel.js
+++ b/source/Panel.js
@@ -51,7 +51,6 @@ enyo.kind({
 
 	//* @protected
 	spotlight: "container",
-	fit: true,
 	classes: "moon-panel",
 	layoutKind: "FittableRowsLayout",
 	headerOption: null, //* Deprecated


### PR DESCRIPTION
In some arranger like carouselArranger, the only one panel is allowed to
have "fit: true".
So, given default "fit: ture" in moon.Panel screwed up layout.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
