### PR TITLE
GF-53448 Added check for control

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -140,7 +140,7 @@ enyo.kind({
 	getPanelIndex: function(oControl) {
 		var oPanel = null;
 
-		while (oControl.parent) {
+		while (oControl && oControl.parent) {
 			// Parent of a panel can be a client or a panels.
 			if (oControl.parent === this.$.client || oControl.parent === this) {
 				oPanel = oControl;


### PR DESCRIPTION
getPanelIndex() in Panel.js giving error when the panel object is not valid.

Enyo-DCO-1.1-Signed-off-by: Anish Ramesan anish.ramesan@lge.com
