### PR TITLE
GF-53518-defect Fixed

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -96,6 +96,15 @@ enyo.kind({
 		var maxDays = this.monthLength(year, month);
 		this.setValue(new Date(year, month, (day <= maxDays) ? day : maxDays));
 	},
+	getPickerDate: function() {
+		var minDate = new Date(this.minYear, 0, 1);
+		var maxDate = new Date(this.maxYear, 11, 31);
+		var presentDate = new Date();
+		if((minDate > presentDate) || (maxDate < presentDate)) {
+			return minDate;
+		}
+		return presentDate;
+	},
 	setChildPickers: function(inOld) {
 		var updateDays = inOld &&
 			(inOld.getFullYear() != this.value.getFullYear() ||

--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -98,7 +98,7 @@ enyo.kind({
 	},
 	initDefaults: function() {
 		var ordering;
-		this.value = this.value || new Date();
+		this.value = this.value || this.getPickerDate();
 		//Attempt to use the ilib lib (assuming that it is loaded)
 		if (typeof ilib !== "undefined") {
 			this.initILib();
@@ -108,6 +108,10 @@ enyo.kind({
 		}
 		this.setupPickers(ordering);
 		this.noneTextChanged();
+	},
+	getPickerDate: function() {
+		// implement in subkind
+		return new Date();
 	},
 	setupPickers: function(ordering) {
 		// implement in subkind, calling this.inherited() at the end


### PR DESCRIPTION
DatePicker : request exception handling in minYear and maxYear

If "value" property is not used in any subkind the picker shows the
current date as the default value irrespective of minYear and maxYear in
the context.
So to handle the exception getPickerDate() method is introduced to
return the "value" property based on the minYear and maxYear.

Enyo-DCO-1.1-Signed-off-by: RajyavardhanP rajyavardhan.p@lge.com
