### PR TITLE
Gf 53828 blakestephens: Adding LG Display-Light support into moonstone-fonts: miso and museo-sans.

### DIFF
--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -137,7 +137,7 @@
 }
 @font-face {
   font-family: "MuseoSans Medium Italic";
-  src: local("LG Display-Regular");
+  src: local("LG Display-Light");
   font-style: italic;
 }
 @font-face {
@@ -212,7 +212,7 @@
 }
 @font-face {
   font-family: "LG Display";
-  src: local("LG Display-light");
+  src: local("LG Display-Light");
   font-weight: normal;
   font-style: normal;
 }

--- a/css/moonstone-fonts.less
+++ b/css/moonstone-fonts.less
@@ -104,7 +104,7 @@
 
 @font-face {
   font-family: "MuseoSans Medium Italic";
-  src: local("LG Display-Regular");
+  src: local("LG Display-Light");
   font-style: italic;
 }
 @font-face {
@@ -200,7 +200,7 @@
 }
 @font-face {
   font-family: "LG Display";
-  src: local("LG Display-light");
+  src: local("LG Display-Light");
   font-weight: normal;
   font-style: normal;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -137,7 +137,7 @@
 }
 @font-face {
   font-family: "MuseoSans Medium Italic";
-  src: local("LG Display-Regular");
+  src: local("LG Display-Light");
   font-style: italic;
 }
 @font-face {
@@ -212,7 +212,7 @@
 }
 @font-face {
   font-family: "LG Display";
-  src: local("LG Display-light");
+  src: local("LG Display-Light");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
