### PR TITLE
Gf 53970 SimplePicker: When 5-way mode, internal spot() call in hideNavButton() makes race condition.

### DIFF
--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -72,11 +72,11 @@ enyo.kind({
 		onSpotlightFocused: "scrollIntoView"
 	},
 	components: [
-		{name: "buttonLeft",  kind: "moon.IconButton", noBackground:true, classes: "moon-simple-picker-button left", icon:"arrowlargeleft", ontap: "left", onholdpulse:"left"},
+		{name: "buttonLeft",  kind: "moon.IconButton", noBackground:true, classes: "moon-simple-picker-button left", icon:"arrowlargeleft", ontap: "left", onholdpulse:"left", defaultSpotlightDisappear: "buttonRight"},
 		{kind: "enyo.Control", name: "clientWrapper", classes:"moon-simple-picker-client-wrapper", components: [
 			{kind: "enyo.Control", name: "client", classes: "moon-simple-picker-client"}
 		]},
-		{name: "buttonRight", kind: "moon.IconButton", noBackground:true, classes: "moon-simple-picker-button right", icon:"arrowlargeright", ontap: "right", onholdpulse:"right"}
+		{name: "buttonRight", kind: "moon.IconButton", noBackground:true, classes: "moon-simple-picker-button right", icon:"arrowlargeright", ontap: "right", onholdpulse:"right", defaultSpotlightDisappear: "buttonLeft"}
 	],
 	create: function() {
 		this.inherited(arguments);
@@ -180,15 +180,7 @@ enyo.kind({
 	},
 	//* Hides _inControl_ and disables spotlight functionality.
 	hideNavButton: function(inControl) {
-		var current = enyo.Spotlight.getCurrent();
 		inControl.setDisabled(true);
-		if (current && !current.getDisabled() && current.isDescendantOf(this)) {
-			if (enyo.Spotlight.getPointerMode()) {
-				enyo.Spotlight.unspot();
-			} else {
-				enyo.Spotlight.spot(inControl == this.$.buttonLeft ? this.$.buttonRight : this.$.buttonLeft);
-			}	
-		}		
 	},
 	//* Shows _inControl_ and enables spotlight functionality.
 	showNavButton: function(inControl) {


### PR DESCRIPTION
In bPointerMode, only mouse cursor addressed control is allowed to have spotlight focus.
In other hand any control which call spot() manually can have spotlight. It makes problem.

moon.SimplePicker has hideNavButton(), it will be called from selectedIndexChanged().
This changed method is called not only actual changing time but also in creating time too and it require spotlight focus.
So if some control which has multiple simplePicker inside of it like moon.Calendar is created, race condition takes place.

To stop this race condition, UI control which uses enyo.Spotlight.spot() manually must consider current spotlight's location.
If _oCurrent is out of UI control, spot() should be rejected because it is not occurred by any user input to UI control.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
