### PR TITLE
GF-54036: Missing 'Feb' in calendar

### DIFF
--- a/samples/CalendarSample.html
+++ b/samples/CalendarSample.html
@@ -10,7 +10,6 @@
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
-	<script src="../../enyo-ilib/full-package.js" type="text/javascript"></script>
 	<script src="../../moonstone/package.js" type="text/javascript"></script>
 	<script src="../../moonstone/source/wip-package.js" type="text/javascript"></script>
 	<script src="../../spotlight/package.js" type="text/javascript"></script>

--- a/source/Calendar.js
+++ b/source/Calendar.js
@@ -179,6 +179,7 @@ enyo.kind({
 			if (prevCal !== this._tf.getCalendar()) {
 				this.calendarChanged();
 			}
+			this.firstDayOfWeek = -1; // Force change handler when locale changes
 			this.setFirstDayOfWeek(new ilib.LocaleInfo(this.locale).getFirstDayOfWeek());
 		}
 		this.updateMonthPicker();
@@ -260,7 +261,7 @@ enyo.kind({
 			if (typeof ilib !== "undefined") {
 				var date = ilib.Date.newInstance({
 					type: this._tf.getCalendar(),
-					day:  3 + i + this.getFirstDayOfWeek()
+					day:  2 + i + this.getFirstDayOfWeek()
 				});
 				var day = this._tf.format(date);
 				daysControls[i].setContent(day);


### PR DESCRIPTION
When calendar updates month picker, It called new ilib.Date.newInstance() with unix time in updateMonthPicker().
To get new instance of each month, I gave different unix time with
millisecond parameter like "month \* 31 days \* 24 hours \* 60 minutes \* 60seconds"

But there is mistake. As you see that I gave 31 days in every month.
So when calendar start from Nov or Dec then it move to near Feb, accumulated days is over Feb.
That's the reason why Feb is disappeared.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
