### PR TITLE
GF-54106: Fix non-ilib default format: month "M" should be uppercase sin...

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -30,7 +30,7 @@ enyo.kind({
 	},
 	//*@protected
 	iLibFormatType: "date",
-	defaultOrdering: "mdy",
+	defaultOrdering: "Mdy",
 	setupPickers: function(ordering) {
 		var orderingArr = ordering.split("");
 		var doneArr = [];


### PR DESCRIPTION
...ce we're using non-lowercased tests now.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
