### PR TITLE
Fix moon.ListActions to make open property work in render time

### DIFF
--- a/samples/ListActionsSample.js
+++ b/samples/ListActionsSample.js
@@ -21,13 +21,13 @@ enyo.kind({
 					]},
 					{action:"category2", components: [
 						{kind: "moon.Divider", content: "Category 2 (DataRepeater)"},
-						{kind: "enyo.DataRepeater", containerOptions:{kind:"moon.Scroller", classes:"enyo-fill", vertical: "scroll"}, name:"repeater", fit:true, components: [
+						{kind: "enyo.DataRepeater", containerOptions:{kind:"moon.Scroller", classes:"enyo-fill"}, name:"repeater", fit:true, components: [
 							{kind:"moon.ToggleItem", bindings: [{from:".model.name", to:".content"}]}
 						]}
 					]},
 					{action:"category1", components: [
 						{kind: "moon.Divider", content:"Category 1 (Static)"},
-						{kind: "moon.Scroller", horizontal: "hidden", vertical: "scroll", fit: true, components: [
+						{kind: "moon.Scroller", fit: true, components: [
 							{kind: "enyo.Group", name:"group", highlander: true, defaultKind: "moon.SelectableItem", components: [
 								{content:"Just Released"},
 								{content:"Recommended"},
@@ -44,7 +44,7 @@ enyo.kind({
 				{kind: "moon.ListActions", proportionalWidth: true, iconSrc: "./assets/icon-list.png", listActions: [
 					{action: "Cost", components: [
 						{kind: "moon.Divider", content:"Cost"},
-						{kind: "moon.Scroller", horizontal: "hidden", defaultKind: "moon.ToggleItem", fit: true, components: [
+						{kind: "moon.Scroller", defaultKind: "moon.ToggleItem", fit: true, components: [
 							{content:"$"},
 							{content:"$$"},
 							{content:"$$$"}
@@ -52,7 +52,7 @@ enyo.kind({
 					]},
 					{action: "Flavor", components: [
 						{kind: "moon.Divider", content:"Flavor"},
-						{kind: "moon.Scroller", horizontal: "hidden", defaultKind: "moon.CheckboxItem", fit: true, components: [
+						{kind: "moon.Scroller", defaultKind: "moon.CheckboxItem", fit: true, components: [
 							{content:"Spicy"},
 							{content:"Sweet"},
 							{content:"Sour"},
@@ -72,7 +72,7 @@ enyo.kind({
 				{kind: "moon.ListActions", autoCollapse: true, iconSrc: "./assets/icon-list.png", listActions: [
 					{action: "AutoCollapseTest", components: [
 						{kind: "moon.Divider", content:"Try Auto-collapse"},
-						{kind: "moon.Scroller", horizontal: "hidden", fit: true, components: [
+						{kind: "moon.Scroller", fit: true, components: [
 							{kind: "enyo.Group", highlander: true, defaultKind: "moon.CheckboxItem", components: [
 								{content:"Select"},
 								{content:"One"},


### PR DESCRIPTION
Fixing http://jira2.lgsvl.com/browse/GF-54724
- Fix: scroller for optionGroup is always showing in samples.
- Fix: scroller for optionGroup having height in stacked status.
- Fix: scroller for drawer is always showing in listActions.
- Fix: Skip animation before render.
- Fix: Show drawer when open is true on render time.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
