### PR TITLE
Remove the CSS(related to IconButton) class in Icon.less for GF-54246

### DIFF
--- a/css/Icon.less
+++ b/css/Icon.less
@@ -30,19 +30,6 @@
 	}
 }
 
-.moon-icon.moon-icon-button.active,
-.moon-icon.moon-icon-button:active:hover,
-.moon-icon-toggle.active {
-	background-position: center -(@moon-icon-sprite-size);
-	color: @moon-icon-button-active-text-color;
-	&.small {
-		background-position: center -(@moon-icon-sprite-small-size);
-	}
-	&.disabled {
-		background-position: center 0;
-	}
-}
-
 .moon-icon.disabled {
 	opacity: @moon-disabled-opacity;
 	filter: alpha(opacity=@moon-disabled-opacity-ie);

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1,5 +1,5 @@
 /* WARNING: This is a generated file for backward-compatibility.  Most      */
-/* users should instead modify LESS files.  If you choose to edit this CSS  */
+/* usrs should instead modify LESS files.  If you choose to edit this CSS   */
 /* directly rather than LESS files, you should make sure less.xx.yy.min.js  */
 /* is commented out in your debug.html, and run deploy.sh/bat using the     */
 /* '-c' flag to disable LESS compilation.  This will force the loader and   */
@@ -635,22 +635,6 @@
   bottom: -14px;
   left: -14px;
   right: -14px;
-}
-.moon-icon.moon-icon-button.active,
-.moon-icon.moon-icon-button:active:hover,
-.moon-icon-toggle.active {
-  background-position: center -75px;
-  color: #ffffff;
-}
-.moon-icon.moon-icon-button.active.small,
-.moon-icon.moon-icon-button:active:hover.small,
-.moon-icon-toggle.active.small {
-  background-position: center -50px;
-}
-.moon-icon.moon-icon-button.active.disabled,
-.moon-icon.moon-icon-button:active:hover.disabled,
-.moon-icon-toggle.active.disabled {
-  background-position: center 0;
 }
 .moon-icon.disabled {
   opacity: 0.6;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1,5 +1,5 @@
 /* WARNING: This is a generated file for backward-compatibility.  Most      */
-/* users should instead modify LESS files.  If you choose to edit this CSS  */
+/* usrs should instead modify LESS files.  If you choose to edit this CSS   */
 /* directly rather than LESS files, you should make sure less.xx.yy.min.js  */
 /* is commented out in your debug.html, and run deploy.sh/bat using the     */
 /* '-c' flag to disable LESS compilation.  This will force the loader and   */
@@ -635,22 +635,6 @@
   bottom: -14px;
   left: -14px;
   right: -14px;
-}
-.moon-icon.moon-icon-button.active,
-.moon-icon.moon-icon-button:active:hover,
-.moon-icon-toggle.active {
-  background-position: center -75px;
-  color: #4b4b4b;
-}
-.moon-icon.moon-icon-button.active.small,
-.moon-icon.moon-icon-button:active:hover.small,
-.moon-icon-toggle.active.small {
-  background-position: center -50px;
-}
-.moon-icon.moon-icon-button.active.disabled,
-.moon-icon.moon-icon-button:active:hover.disabled,
-.moon-icon-toggle.active.disabled {
-  background-position: center 0;
 }
 .moon-icon.disabled {
   opacity: 0.6;


### PR DESCRIPTION
Remove the CSS class(related to IconButton) in Icon.less file for GF-54246.
It occur improper behavior due to override some css property when the user tap the IconButton .
And, if it is removed, it doesn't make some problem on IconButton's behavior.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
