### PR TITLE
Remove the CSS class(related to IconButton) in Icon.less file for GF-542...

### DIFF
--- a/css/Icon.less
+++ b/css/Icon.less
@@ -30,19 +30,6 @@
 	}
 }
 
-.moon-icon.moon-icon-button.active,
-.moon-icon.moon-icon-button:active:hover,
-.moon-icon-toggle.active {
-	background-position: center -(@moon-icon-sprite-size);
-	color: @moon-icon-button-active-text-color;
-	&.small {
-		background-position: center -(@moon-icon-sprite-small-size);
-	}
-	&.disabled {
-		background-position: center 0;
-	}
-}
-
 .moon-icon.disabled {
 	opacity: @moon-disabled-opacity;
 	filter: alpha(opacity=@moon-disabled-opacity-ie);

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -636,22 +636,6 @@
   left: -14px;
   right: -14px;
 }
-.moon-icon.moon-icon-button.active,
-.moon-icon.moon-icon-button:active:hover,
-.moon-icon-toggle.active {
-  background-position: center -75px;
-  color: #ffffff;
-}
-.moon-icon.moon-icon-button.active.small,
-.moon-icon.moon-icon-button:active:hover.small,
-.moon-icon-toggle.active.small {
-  background-position: center -50px;
-}
-.moon-icon.moon-icon-button.active.disabled,
-.moon-icon.moon-icon-button:active:hover.disabled,
-.moon-icon-toggle.active.disabled {
-  background-position: center 0;
-}
 .moon-icon.disabled {
   opacity: 0.6;
   filter: alpha(opacity=60);

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -636,22 +636,6 @@
   left: -14px;
   right: -14px;
 }
-.moon-icon.moon-icon-button.active,
-.moon-icon.moon-icon-button:active:hover,
-.moon-icon-toggle.active {
-  background-position: center -75px;
-  color: #4b4b4b;
-}
-.moon-icon.moon-icon-button.active.small,
-.moon-icon.moon-icon-button:active:hover.small,
-.moon-icon-toggle.active.small {
-  background-position: center -50px;
-}
-.moon-icon.moon-icon-button.active.disabled,
-.moon-icon.moon-icon-button:active:hover.disabled,
-.moon-icon-toggle.active.disabled {
-  background-position: center 0;
-}
 .moon-icon.disabled {
   opacity: 0.6;
   filter: alpha(opacity=60);


### PR DESCRIPTION
Remove the CSS class(related to IconButton) in Icon.less file for GF-54246.
It occur improper behavior due to override css class when the user tap the IconButton(in RC-2)
And, if it is removed, it doesn't make some problem on IconButton's behavior.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
