### PR TITLE
ENYO-3074: Removed calls to preventTap in dragfinish handlers

### DIFF
--- a/source/Slider.js
+++ b/source/Slider.js
@@ -370,7 +370,6 @@ enyo.kind({
 		this.dragging = false;
 		this.set("value",v);
 		this.sendChangeEvent({value: this.getValue()});
-		inEvent.preventTap();
 		this.$.knob.removeClass("active");
 		this.hideKnobStatus();
 		return true;

--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -346,7 +346,6 @@ enyo.kind({
 				v = (this.increment) ? this.calcIncrement(v) : v;
 				this._setValue(v);
 			}
-			inEvent.preventTap();
 			// this.hideKnobStatus();
 			this.doSeekFinish({value: v});
 		}


### PR DESCRIPTION
## Issue

A `tap` event will be sent after a `dragfinish` event in a dragging context. The synthesized `dragfinish` no longer provides a `preventTap` method as part of this fix.
## Fix

Calls to `preventTap` have been removed from controls that handle `dragfinish`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
