### PR TITLE
GF-54890-defect Fixed

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -114,7 +114,9 @@ enyo.kind({
 	popPanels: function(inIndex) {
 		var panels = this.getPanels();
 		inIndex = inIndex || panels.length - 1;
-		this.setIndex(inIndex - 1);
+		if (this.getIndex() >= inIndex) {
+			this.setIndex(inIndex - 1);
+		}
 
 		while (panels.length > inIndex && inIndex >= 0) {
 			panels[panels.length - 1].destroy();


### PR DESCRIPTION
issue: Panels are not displaying after using popPanel()
cause: in moon.Panels ,popPanels() method destroys all the panels equal
or greater than the specified index without setting the index to a
correct value.
solution:  index value is set  before destroying the panels.
Enyo-DCO-1.1-Signed-off-by: RajyavardhanP rajyavardhan.p@lge.com
