### PR TITLE
GF-55832: Use enyo.perfNow monotonic timestamp instead of enyo.now, to a...

### DIFF
--- a/source/StyleAnimator.js
+++ b/source/StyleAnimator.js
@@ -288,7 +288,7 @@ enyo.kind({
 		this.applyTransitions(inName, 0);
 		animation.state = "playing";
 		animation.timeElapsed = 0;
-		animation.startTime = enyo.now();
+		animation.startTime = enyo.perfNow();
 	},
 	//* @protected
 	applyValues: function(inValues) {
@@ -358,7 +358,7 @@ enyo.kind({
 	//* Steps through each playing animation.
 	_step: function() {
 		var playingAnimations = false,
-			now = enyo.now(),
+			now = enyo.perfNow(),
 			animation,
 			elapsed,
 			i;


### PR DESCRIPTION
...void issues with system clock changing.

_Note:_ Requires https://github.com/enyojs/enyo/pull/601 to be merged first.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
