### PR TITLE
GF-55494: Update scrollBounds with x and y direction

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -586,6 +586,9 @@ enyo.kind({
 					? -1
 					: 0;
 
+		scrollBounds.xDir = xDir;
+		scrollBounds.yDir = yDir;
+
 		switch (xDir) {
 		case 0:
 			x = this.getScrollLeft();
@@ -647,7 +650,7 @@ enyo.kind({
 			}
 			break;
 		}
-		
+
 		// If x or y changed, scroll to new position
 		if (x !== this.getScrollLeft() || y !== this.getScrollTop()) {
 			this.scrollTo(x, y, animate);


### PR DESCRIPTION
Even though animateToScroll is called, x and y direction for
scrollBounds are not updated.
Because of this reason, didScroll() in VerticalDelegates.js could not decide proper scroll direction.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
