### PR TITLE
GF-57255: Make sure "seconds" field in video player current time does not round up to 60.

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -932,7 +932,7 @@ enyo.kind({
 	formatTime: function(inValue) {
 		var hour = Math.floor(inValue / (60*60));
 		var min = Math.floor((inValue / 60) % 60);
-		var sec = Math.round(inValue % 60);
+		var sec = Math.floor(inValue % 60);
 		if (this.durfmt) {
 			var val = {minute: min, second: sec};
 			if (hour) {

--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -376,7 +376,7 @@ enyo.kind({
 	formatTime: function(inValue) {
 		var hour = Math.floor(inValue / (60*60));
 		var min = Math.floor((inValue / 60) % 60);
-		var sec = Math.round(inValue % 60);
+		var sec = Math.floor(inValue % 60);
 		if (this.durfmt) {
 			var val = {minute: min, second: sec};
 			if (hour) {


### PR DESCRIPTION
Prevent seconds to be rounded up and formatted to 60 seconds. Applied Math.floor instead of Math.round for proper calculation.

Enyo-DCO-1.0-Signed-off-by: Stephen Choi (stephen.choi@lge.com)
