### PR TITLE
Make sure moon.Marquee whitespace rule is not overridden. >> master

### DIFF
--- a/css/Marquee.less
+++ b/css/Marquee.less
@@ -1,33 +1,37 @@
 .moon-marquee {
     width: auto;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: nowrap !important;
     overflow: hidden;
-}
-.moon-marquee span {
-	pointer-events: none !important;
-}
-.moon-marquee-text-wrapper {
-	width: 100%;
-	pointer-events: none;
-	width: auto;
-	overflow: hidden;
-}
-.moon-marquee-text {
-	pointer-events: none;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	width: 100%;
-	
-	transition-property: transform;
-	-moz-transition-property: transform;
-	-webkit-transition-property: -webkit-transform;
-	-o-transition-property: transform;
-	
-	transition-timing-function: linear;
-	-webkit-transition-timing-function: linear;
-}
-.animate-marquee {
-	text-overflow: clip;
-	overflow: visible;
+
+	span {
+		pointer-events: none !important;
+	}
+
+	.moon-marquee-text-wrapper {
+		width: 100%;
+		pointer-events: none;
+		width: auto;
+		overflow: hidden;
+	}
+
+	.moon-marquee-text {
+		pointer-events: none;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		width: 100%;
+		
+		transition-property: transform;
+		-moz-transition-property: transform;
+		-webkit-transition-property: -webkit-transform;
+		-o-transition-property: transform;
+		
+		transition-timing-function: linear;
+		-webkit-transition-timing-function: linear;
+	}
+
+	.animate-marquee {
+		text-overflow: clip;
+		overflow: visible;
+	}
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -780,19 +780,19 @@
 .moon-marquee {
   width: auto;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: nowrap !important;
   overflow: hidden;
 }
 .moon-marquee span {
   pointer-events: none !important;
 }
-.moon-marquee-text-wrapper {
+.moon-marquee .moon-marquee-text-wrapper {
   width: 100%;
   pointer-events: none;
   width: auto;
   overflow: hidden;
 }
-.moon-marquee-text {
+.moon-marquee .moon-marquee-text {
   pointer-events: none;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -804,7 +804,7 @@
   transition-timing-function: linear;
   -webkit-transition-timing-function: linear;
 }
-.animate-marquee {
+.moon-marquee .animate-marquee {
   text-overflow: clip;
   overflow: visible;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -780,19 +780,19 @@
 .moon-marquee {
   width: auto;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: nowrap !important;
   overflow: hidden;
 }
 .moon-marquee span {
   pointer-events: none !important;
 }
-.moon-marquee-text-wrapper {
+.moon-marquee .moon-marquee-text-wrapper {
   width: 100%;
   pointer-events: none;
   width: auto;
   overflow: hidden;
 }
-.moon-marquee-text {
+.moon-marquee .moon-marquee-text {
   pointer-events: none;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -804,7 +804,7 @@
   transition-timing-function: linear;
   -webkit-transition-timing-function: linear;
 }
-.animate-marquee {
+.moon-marquee .animate-marquee {
   text-overflow: clip;
   overflow: visible;
 }


### PR DESCRIPTION
While we’re at it, make other marquee-related selectors more robust by increasing specificity.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
