### PR TITLE
GF-58344: Don't capture events in tooltip; tooltip hide/show is handled ...

### DIFF
--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -37,6 +37,7 @@ enyo.kind({
 		defaultLeft: 10
 	},
 	//* @protected
+	captureEvents: false,
 	handlers: {
 		onRequestShowTooltip: "requestShow",
 		onRequestHideTooltip: "requestHide"


### PR DESCRIPTION
...by TooltipDecorator enter/leave, don't need to capture events for detecting outside tap.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
