### PR TITLE
GF-58469: Fix issue with spotlight jumping from a closing drawer to first element on page

### DIFF
--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -172,7 +172,9 @@ enyo.kind({
 	toggleActive: function() {
 		if (this.getOpen()) {
 			this.setActive(false);
-			enyo.Spotlight.spot(this.$.headerWrapper);
+			if (!enyo.Spotlight.getPointerMode()) {
+				enyo.Spotlight.spot(this.$.headerWrapper);
+			}
 		} else {
 			this.setActive(true);
 		}

--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -107,6 +107,7 @@ enyo.kind({
 		var open = this.getOpen();
 		this.addRemoveClass("open", open);
 		this.$.drawer.setOpen(open);
+		this.$.drawer.spotlightDisabled = !open;
 		if (this.generated) {
 			this.stopHeaderMarquee();
 		}

--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -225,7 +225,6 @@ enyo.kind({
 	},
 	//* Closes drawer and selects header.
 	selectAndClose: function() {
-		this.$.drawer.spotlightDisabled = true; // prevent side-effects of spotting items in a drawer that is closing
 		this.setActive(false);
 		if (!enyo.Spotlight.getPointerMode() && enyo.Spotlight.getCurrent() && enyo.Spotlight.getCurrent().isDescendantOf(this)) {
 			enyo.Spotlight.spot(this.$.headerWrapper);
@@ -241,10 +240,5 @@ enyo.kind({
 	},
 	stopHeaderMarquee: function() {
 		this.$.headerWrapper.stopMarquee();
-	},
-	drawerAnimationEnd: function() {
-		this.inherited(arguments);
-		this.$.drawer.spotlightDisabled = false;
-		return true;
 	}
 });


### PR DESCRIPTION
## Issue

When an item in an `ExpandablePicker` is selected and the user continues to 5way down, `Spotlight` jumps to the first element on the page. This occurs because the items are hidden upon selection, so there is a moment in time where the drawer is rolling up where there is no currently spotted control and the last spotted control is no longer spottable, which causes `Spotlight` to spot the first child of the root in response to 5way movement.
## Fix

We now disable `Spotlight` via the `spotlightDisabled` flag for the `ExpandablePicker`'s drawer when it is closing, and reenable when the drawer animation is complete.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
