### PR TITLE
Make sure CSS box-sizing: border-box has -moz version too

### DIFF
--- a/css/ContextualPopup.less
+++ b/css/ContextualPopup.less
@@ -10,9 +10,7 @@
 	background-clip: padding-box;
 	-webkit-background-clip: padding-box;
 	-moz-background-clip: padding-box;
-	box-sizing: border-box;
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
+	.border-box;
 	background-color: @moon-contextual-popup-bg-color;
 	&.reserve-close {
 		padding-right: @moon-icon-button-small-size + 10px;

--- a/css/ExpandableInput.less
+++ b/css/ExpandableInput.less
@@ -1,7 +1,7 @@
 .moon-expandable-input {
 	.moon-input-decorator {
 		width: 100%;
-		box-sizing: border-box;
+		.border-box;
 		margin-top: @moon-spotlight-outset;
 		margin-bottom: @moon-spotlight-outset;
 	}

--- a/css/ExpandableListItem.less
+++ b/css/ExpandableListItem.less
@@ -10,8 +10,8 @@
 /* Header */
 .moon-expandable-list-item-header {
 	margin-bottom: 0px;
-	box-sizing: border-box;
-	max-width: 100%;	
+	.border-box;
+	max-width: 100%;
 }
 .moon-expandable-list-item-header.disabled {
 	opacity: 1;

--- a/css/Header.less
+++ b/css/Header.less
@@ -112,7 +112,7 @@
 }
 .moon-small-header .moon-header-title-wrapper {
 	padding-left: 0;
-	box-sizing: border-box;
+	.border-box;
 	max-height: 155px;
 }
 .enyo-locale-right-to-left .moon-small-header .moon-header-title-wrapper {
@@ -122,7 +122,7 @@
 	max-height: 40px;
 }
 .moon-small-header .moon-header-sub-title-below {
-	max-height: 40px;	
+	max-height: 40px;
 }
 .hidden-title .moon-header-title,
 .hidden-title .moon-header-title-below,

--- a/css/IconButton.less
+++ b/css/IconButton.less
@@ -1,6 +1,6 @@
 /* IconButton.css */
 .moon-icon-button {
-	box-sizing: border-box;
+	.border-box;
 	width: @moon-icon-button-size;
 	height: @moon-icon-button-size;
 	border-radius: @moon-icon-button-size/2;

--- a/css/Input.less
+++ b/css/Input.less
@@ -22,13 +22,8 @@
 .moon-input-decorator.moon-disabled .moon-input {
 	cursor: default;
 }
-.moon-input-decorator > input::-webkit-input-placeholder {
-	color: @moon-input-placeholder-color;
-}
-.moon-input-decorator > input:-moz-placeholder {
-	color: @moon-input-placeholder-color;
-}
-/* IE10 */
+.moon-input-decorator > input::-webkit-input-placeholder,
+.moon-input-decorator > input::-moz-placeholder,
 .moon-input-decorator > input:-ms-input-placeholder {
 	color: @moon-input-placeholder-color;
 }

--- a/css/InputDecorator.less
+++ b/css/InputDecorator.less
@@ -6,21 +6,21 @@
 	border-radius: 34px;
 	border: @moon-input-border-width solid transparent;
 	background-color: @moon-input-decorator-bg-color;
-	box-sizing:border-box;
+	.border-box;
 }
 
 
 .enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator){
-  padding:5px 30px 9px;
+	padding:5px 30px 9px;
 }
 .moon-textarea-decorator {
-  .moon-divider-text;
-  margin: 5px;
-  padding: 9px 14px;
-  border-radius: 10px;
-  border: @moon-input-border-width solid transparent;
-  background-color: @moon-input-decorator-bg-color;
-  box-sizing:border-box;
+	.moon-divider-text;
+	margin: 5px;
+	padding: 9px 14px;
+	border-radius: 10px;
+	border: @moon-input-border-width solid transparent;
+	background-color: @moon-input-decorator-bg-color;
+	.border-box;
 }
 
 

--- a/css/InputHeader.less
+++ b/css/InputHeader.less
@@ -3,7 +3,7 @@
 	padding: 0px;
 	border: 0px;
 	width: 100%;
-	box-sizing: border-box;
+	.border-box;
 	background-color: transparent;
 }
 .moon-input-header .moon-input-header-input-decorator > .moon-input {
@@ -12,7 +12,7 @@
 	padding-left: 1px;
 	padding-right: 1px;
 	display: inline-block;
-	box-sizing: border-box;
+	.border-box;
 	line-height: 1em;
 	color: @moon-input-header-text-color;
 	width: 100%;

--- a/css/InputHeader.less
+++ b/css/InputHeader.less
@@ -26,13 +26,17 @@
 .moon-input-header .moon-input.moon-header-title {
 	position: static;
 }
-.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder {
+.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder,
+.moon-input-header .moon-input.moon-header-title::-moz-placeholder,
+.moon-input-header .moon-input.moon-header-title::-ms-input-placeholder {
 	color: @moon-input-header-placeholder-color;
 	margin-top:15px;
 	line-height: 1.25em;
 	text-transform: uppercase;
 }
-.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder {
+.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight .moon-input::-moz-placeholder,
+.moon-input-header-input-decorator.spotlight .moon-input::-ms-input-placeholder {
 	color: @moon-spotlight-text-color;
 }
 .moon-input-header-input-decorator.spotlight > .moon-input {
@@ -42,6 +46,8 @@
 .moon-input-header-input-decorator.spotlight.moon-focused > .moon-input {
 	background: none;
 }
-.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder {
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-moz-placeholder,
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-ms-input-placeholder {
 	color: @moon-input-header-placeholder-color;
 }

--- a/css/ListActions.less
+++ b/css/ListActions.less
@@ -49,7 +49,7 @@
 	width: 300px;		/* Do not change - used in JS */
 	min-width: 300px;	/* Do not change - used in JS */
 	float: right;
-	box-sizing: border-box;
+	.border-box;
 }
 .enyo-locale-right-to-left .moon-list-actions-menu {
 	float: left;
@@ -75,5 +75,5 @@
 }
 
 .moon-list-actions.stacked .enyo-fittable-rows-layout > * {
-	height: auto !important;	
+	height: auto !important;
 }

--- a/css/ObjectActionDecorator.less
+++ b/css/ObjectActionDecorator.less
@@ -4,10 +4,10 @@
 		display: inline-block;
 		text-align:center;
 		.moon-objaction-actions {
-			opacity: 0; 
+			opacity: 0;
 			text-align: center;
 			padding: 0  @moon-spotlight-outset;
-			box-sizing: border-box;
+			.border-box;
 		}
 		.moon-objaction-actions.stretch > * {
 			width: 100%;
@@ -17,12 +17,12 @@
 		display: block;
 		.moon-objaction-client {
 			display: table-cell;
-			width: 100%; 
+			width: 100%;
 			padding-right: @moon-spotlight-outset;
 		}
 		.moon-objaction-actions {
 			display: table-cell;
-			opacity: 0; 
+			opacity: 0;
 			white-space: nowrap;
 			vertical-align: middle;
 			padding-right: @moon-spotlight-outset;

--- a/css/Panel.less
+++ b/css/Panel.less
@@ -16,7 +16,7 @@
 .moon-panel-content-wrapper {
 	-webkit-transform: scale3d(1,1,1);
 	z-index: 2;
-	box-sizing: border-box;
+	.border-box;
 }
 .moon-panel-body {
 	overflow: hidden;
@@ -51,7 +51,7 @@
 	height: 360px;
 	width: 100%;
 	padding: 0 @moon-spotlight-outset @moon-spotlight-outset @moon-spotlight-outset;
-	box-sizing: border-box;
+	.border-box;
 }
 .moon-panel-mini-header {
 	margin-top: 25px;

--- a/css/Panels.less
+++ b/css/Panels.less
@@ -1,16 +1,16 @@
 /* Panels */
 .moon-panels.activity,
 .moon-panels.always-viewing {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    box-sizing: border-box;
-    padding: 20px 10px;
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	.border-box;
+	padding: 20px 10px;
 	overflow: visible;
 	-webkit-transform: translate3d(0, 0, 0);
 	pointer-events: none;
 	* {
-		pointer-events: auto;		
+		pointer-events: auto;
 	}
 	.moon-panel {
 		height: auto;
@@ -67,10 +67,10 @@
 	left: -10px;
 	height: 100%;
 	width: 100%;
-    background-repeat: no-repeat;
+	background-repeat: no-repeat;
 	background-position: center;
-    background-color: @moon-panels-spot-bg-color;
-    background-image: @moon-panels-caret-white-left-icon;
+	background-color: @moon-panels-spot-bg-color;
+	background-image: @moon-panels-caret-white-left-icon;
 	-webkit-transform: translate3d(0, 0, 0);
 	transition: -webkit-transform 0.2s linear, opacity 0.2s linear;
 	opacity: 1;

--- a/css/Popup.less
+++ b/css/Popup.less
@@ -4,7 +4,7 @@
     bottom: 0;
     width: 100%;
 	padding: 40px;
-    box-sizing: border-box;    
+	.border-box;
     overflow: hidden;
     &.animate {
 		-webkit-transition: -webkit-transform 0.4s ease;
@@ -44,7 +44,7 @@
 			padding-right: 40px;
 			padding-left: @moon-icon-button-small-size + 10px;
 		}
-	}	
+	}
 	.moon-popup-close {
 		right: auto;
 		left: 10px;

--- a/css/RichText.less
+++ b/css/RichText.less
@@ -38,10 +38,10 @@
   margin-top: 4px;
   margin-bottom: 0px;
   background-color: @moon-input-decorator-bg-color;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 .moon-textarea-decorator .moon-richtext:focus::-webkit-scrollbar-thumb:vertical {
   height: 10px;
   background-color: @moon-active-border-color;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }

--- a/css/Scroller.less
+++ b/css/Scroller.less
@@ -1,6 +1,6 @@
 .moon-scroller-client-wrapper,
 .moon-scroller-viewport {
-	box-sizing: border-box;
+	.border-box;
 	height: 100%;
 	overflow: hidden;
 }
@@ -17,8 +17,7 @@
     transform-origin: center center;
     -webkit-transform-style: flat;
     transform-style: flat;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
+	.border-box;
     -webkit-tap-highlight-color: transparent;
     pointer-events: auto;
     -webkit-user-select: none;
@@ -44,7 +43,7 @@
 	transition: opacity 0.1s linear;
 	-moz-transition: opacity 0.1s linear;
 	-webkit-transition: opacity 0.1s linear;
-	
+
 	transform: translateZ(1px);
 	-o-transform: translateZ(1px);
 	-ms-transform: translateZ(1px);

--- a/css/SimpleIntegerPicker.less
+++ b/css/SimpleIntegerPicker.less
@@ -14,7 +14,7 @@
 .moon-simple-integer-picker > * {
   display: inline-block;
   vertical-align: middle;
-  box-sizing: border-box;
+  .border-box;
 }
 
 .moon-simple-integer-picker.spotlight {
@@ -26,7 +26,7 @@
 .moon-simple-integer-picker.spotlight .moon-simple-integer-picker-button {
 	color: @moon-spotlight-text-color;
 }
-.moon-simple-integer-picker-button {	
+.moon-simple-integer-picker-button {
   width: @moon-picker-button-width;
   height: @moon-picker-button-width;
   border-radius: @moon-picker-button-width/2;  border: 0;
@@ -38,7 +38,7 @@
   z-index: 2;
   color: @moon-sub-header-text-color;
   background: transparent @moon-scroller-icon no-repeat center 0;
- 
+
 }
 
 .moon-simple-integer-picker-client {

--- a/css/SimplePicker.less
+++ b/css/SimplePicker.less
@@ -1,7 +1,7 @@
 .moon-simple-picker {
 	display: inline-block;
 	max-width: 350px;
-	box-sizing: border-box;
+	.border-box;
 	padding: 0 @moon-picker-button-width + 10px;
 	position: relative;
 	height: @moon-picker-button-width;
@@ -20,7 +20,7 @@
 	width: 100%;
 	overflow: hidden;
 	position: relative;
-	box-sizing: border-box;
+	.border-box;
 }
 .moon-simple-picker-client {
 	white-space: nowrap;
@@ -34,13 +34,13 @@
 .moon-simple-picker-client > * {
 	display: inline-block;
 	vertical-align: middle;
-	box-sizing: border-box;
+	.border-box;
 	width: 100%;
 	line-height: @moon-picker-button-width;
 	height: @moon-picker-button-width;
 	color: @moon-simple-picker-item-text-color;
-	white-space:nowrap; 
-	text-align: center; 
+	white-space:nowrap;
+	text-align: center;
 }
 .moon-simple-picker-client.disabled, .moon-simple-picker-button[disabled] {
 	opacity: @moon-disabled-opacity;

--- a/css/Table.less
+++ b/css/Table.less
@@ -2,7 +2,7 @@
 
 /*.moon-table {
 	padding-right: 2em;
-	box-sizing: border-box;
+	.border-box;
 }*/
 
 .moon-table-row.spotlight {

--- a/css/TextArea.less
+++ b/css/TextArea.less
@@ -35,10 +35,10 @@
   margin-top: 4px;
   margin-bottom: 0px;
   background-color: @moon-input-decorator-bg-color;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 .moon-textarea-decorator .moon-textarea:focus::-webkit-scrollbar-thumb:vertical {
   height: 10px;
   background-color: @moon-active-border-color;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }

--- a/css/VideoControlFullscreen.less
+++ b/css/VideoControlFullscreen.less
@@ -1,13 +1,13 @@
 /* --- Fullscreen control --- */
 .moon-video-fullscreen-control {
-	box-sizing: border-box;
+	.border-box;
 	background-color: @moon-video-player-fullscreen-bg-color;
 	transition: background-color 0.1s linear;
 	-webkit-transition: background-color 0.1s linear;
 	-moz-transition: background-color 0.1s linear;
 }
 .moon-video-fullscreen-control.scrim {
-	box-sizing: border-box;
+	.border-box;
 	background-color: fadeout(@moon-video-player-fullscreen-bg-color, 85%);
 }
 

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -2504,12 +2504,12 @@
   margin-top: 4px;
   margin-bottom: 0px;
   background-color: #ffffff;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 .moon-textarea-decorator .moon-richtext:focus::-webkit-scrollbar-thumb:vertical {
   height: 10px;
   background-color: #a6a6a6;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 /*ContextualPopupButton.css*/
 .contextual-popup-button,
@@ -2731,12 +2731,12 @@
   margin-top: 4px;
   margin-bottom: 0px;
   background-color: #ffffff;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 .moon-textarea-decorator .moon-textarea:focus::-webkit-scrollbar-thumb:vertical {
   height: 10px;
   background-color: #a6a6a6;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 /* List Actions */
 .moon-list-actions {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -718,6 +718,7 @@
 /* IconButton.css */
 .moon-icon-button {
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   width: 85px;
   height: 85px;
   border-radius: 42.5px;
@@ -812,6 +813,7 @@
   display: inline-block;
   max-width: 350px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   padding: 0 70px;
   position: relative;
   height: 60px;
@@ -831,6 +833,7 @@
   overflow: hidden;
   position: relative;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-simple-picker-client {
   white-space: nowrap;
@@ -845,6 +848,7 @@
   display: inline-block;
   vertical-align: middle;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   width: 100%;
   line-height: 60px;
   height: 60px;
@@ -889,6 +893,7 @@
   display: inline-block;
   vertical-align: middle;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-simple-integer-picker.spotlight {
   background: #cf0652;
@@ -1572,6 +1577,7 @@
 .moon-expandable-list-item-header {
   margin-bottom: 0px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   max-width: 100%;
 }
 .moon-expandable-list-item-header.disabled {
@@ -1930,6 +1936,7 @@
 .moon-small-header .moon-header-title-wrapper {
   padding-left: 0;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   max-height: 155px;
 }
 .enyo-locale-right-to-left .moon-small-header .moon-header-title-wrapper {
@@ -2251,6 +2258,7 @@
   border: 5px solid transparent;
   background-color: #ffffff;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator) {
   padding: 5px 30px 9px;
@@ -2268,6 +2276,7 @@
   border: 5px solid transparent;
   background-color: #ffffff;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator),
 .enyo-locale-non-latin .moon-textarea-decorator {
@@ -2544,7 +2553,6 @@
   -webkit-background-clip: padding-box;
   -moz-background-clip: padding-box;
   box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   background-color: #686868;
 }
@@ -2782,6 +2790,7 @@
 
   float: right;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .enyo-locale-right-to-left .moon-list-actions-menu {
   float: left;
@@ -2941,6 +2950,7 @@
   -webkit-transform: scale3d(1, 1, 1);
   z-index: 2;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-panel-body {
   overflow: hidden;
@@ -2975,6 +2985,7 @@
   width: 100%;
   padding: 0 10px 10px 10px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-panel-mini-header {
   margin-top: 25px;
@@ -3031,6 +3042,7 @@
   width: 100%;
   height: 100%;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   padding: 20px 10px;
   overflow: visible;
   -webkit-transform: translate3d(0, 0, 0);
@@ -3260,7 +3272,7 @@
 /* Table.css */
 /*.moon-table {
 	padding-right: 2em;
-	box-sizing: border-box;
+	.border-box;
 }*/
 .moon-table-row.spotlight {
   background-color: #cf0652;
@@ -3276,6 +3288,7 @@
   border: 0px;
   width: 100%;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   background-color: transparent;
 }
 .moon-input-header .moon-input-header-input-decorator > .moon-input {
@@ -3291,6 +3304,7 @@
   padding-right: 1px;
   display: inline-block;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   line-height: 1em;
   color: #a6a6a6;
   width: 100%;
@@ -3460,6 +3474,7 @@
   width: 100%;
   padding: 40px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   overflow: hidden;
 }
 .moon-popup.animate {
@@ -3961,6 +3976,7 @@
 /* --- Fullscreen control --- */
 .moon-video-fullscreen-control {
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0.1);
   transition: background-color 0.1s linear;
   -webkit-transition: background-color 0.1s linear;
@@ -3968,6 +3984,7 @@
 }
 .moon-video-fullscreen-control.scrim {
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0);
 }
 /* ---- Header info styling ---- */
@@ -4444,6 +4461,7 @@
 .moon-scroller-client-wrapper,
 .moon-scroller-viewport {
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   height: 100%;
   overflow: hidden;
 }
@@ -4458,8 +4476,8 @@
   transform-origin: center center;
   -webkit-transform-style: flat;
   transform-style: flat;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
   pointer-events: auto;
   -webkit-user-select: none;
@@ -4551,6 +4569,7 @@
 .moon-expandable-input .moon-input-decorator {
   width: 100%;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   margin-top: 10px;
   margin-bottom: 10px;
 }
@@ -4580,6 +4599,7 @@
   text-align: center;
   padding: 0 10px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-objaction.vertical .moon-objaction-actions.stretch > * {
   width: 100%;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -2234,13 +2234,8 @@
 .moon-input-decorator.moon-disabled .moon-input {
   cursor: default;
 }
-.moon-input-decorator > input::-webkit-input-placeholder {
-  color: #868686;
-}
-.moon-input-decorator > input:-moz-placeholder {
-  color: #868686;
-}
-/* IE10 */
+.moon-input-decorator > input::-webkit-input-placeholder,
+.moon-input-decorator > input::-moz-placeholder,
 .moon-input-decorator > input:-ms-input-placeholder {
   color: #868686;
 }
@@ -3319,13 +3314,17 @@
 .moon-input-header .moon-input.moon-header-title {
   position: static;
 }
-.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder {
+.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder,
+.moon-input-header .moon-input.moon-header-title::-moz-placeholder,
+.moon-input-header .moon-input.moon-header-title::-ms-input-placeholder {
   color: #333333;
   margin-top: 15px;
   line-height: 1.25em;
   text-transform: uppercase;
 }
-.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder {
+.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight .moon-input::-moz-placeholder,
+.moon-input-header-input-decorator.spotlight .moon-input::-ms-input-placeholder {
   color: #ffffff;
 }
 .moon-input-header-input-decorator.spotlight > .moon-input {
@@ -3335,7 +3334,9 @@
 .moon-input-header-input-decorator.spotlight.moon-focused > .moon-input {
   background: none;
 }
-.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder {
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-moz-placeholder,
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-ms-input-placeholder {
   color: #333333;
 }
 .moon-drawer-handle {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -2502,12 +2502,12 @@
   margin-top: 4px;
   margin-bottom: 0px;
   background-color: #ffffff;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 .moon-textarea-decorator .moon-richtext:focus::-webkit-scrollbar-thumb:vertical {
   height: 10px;
   background-color: #a6a6a6;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 /*ContextualPopupButton.css*/
 .contextual-popup-button,
@@ -2728,12 +2728,12 @@
   margin-top: 4px;
   margin-bottom: 0px;
   background-color: #ffffff;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 .moon-textarea-decorator .moon-textarea:focus::-webkit-scrollbar-thumb:vertical {
   height: 10px;
   background-color: #a6a6a6;
-  -webkit-border-radius: 10px;
+  border-radius: 10px;
 }
 /* List Actions */
 .moon-list-actions {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -2233,13 +2233,8 @@
 .moon-input-decorator.moon-disabled .moon-input {
   cursor: default;
 }
-.moon-input-decorator > input::-webkit-input-placeholder {
-  color: #868686;
-}
-.moon-input-decorator > input:-moz-placeholder {
-  color: #868686;
-}
-/* IE10 */
+.moon-input-decorator > input::-webkit-input-placeholder,
+.moon-input-decorator > input::-moz-placeholder,
 .moon-input-decorator > input:-ms-input-placeholder {
   color: #868686;
 }
@@ -3315,13 +3310,17 @@
 .moon-input-header .moon-input.moon-header-title {
   position: static;
 }
-.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder {
+.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder,
+.moon-input-header .moon-input.moon-header-title::-moz-placeholder,
+.moon-input-header .moon-input.moon-header-title::-ms-input-placeholder {
   color: #b1b1b1;
   margin-top: 15px;
   line-height: 1.25em;
   text-transform: uppercase;
 }
-.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder {
+.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight .moon-input::-moz-placeholder,
+.moon-input-header-input-decorator.spotlight .moon-input::-ms-input-placeholder {
   color: #ffffff;
 }
 .moon-input-header-input-decorator.spotlight > .moon-input {
@@ -3331,7 +3330,9 @@
 .moon-input-header-input-decorator.spotlight.moon-focused > .moon-input {
   background: none;
 }
-.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder {
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-moz-placeholder,
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-ms-input-placeholder {
   color: #b1b1b1;
 }
 .moon-drawer-handle {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -718,6 +718,7 @@
 /* IconButton.css */
 .moon-icon-button {
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   width: 85px;
   height: 85px;
   border-radius: 42.5px;
@@ -812,6 +813,7 @@
   display: inline-block;
   max-width: 350px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   padding: 0 70px;
   position: relative;
   height: 60px;
@@ -831,6 +833,7 @@
   overflow: hidden;
   position: relative;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-simple-picker-client {
   white-space: nowrap;
@@ -845,6 +848,7 @@
   display: inline-block;
   vertical-align: middle;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   width: 100%;
   line-height: 60px;
   height: 60px;
@@ -889,6 +893,7 @@
   display: inline-block;
   vertical-align: middle;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-simple-integer-picker.spotlight {
   background: #cf0652;
@@ -1572,6 +1577,7 @@
 .moon-expandable-list-item-header {
   margin-bottom: 0px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   max-width: 100%;
 }
 .moon-expandable-list-item-header.disabled {
@@ -1930,6 +1936,7 @@
 .moon-small-header .moon-header-title-wrapper {
   padding-left: 0;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   max-height: 155px;
 }
 .enyo-locale-right-to-left .moon-small-header .moon-header-title-wrapper {
@@ -2250,6 +2257,7 @@
   border: 5px solid transparent;
   background-color: #ffffff;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator) {
   padding: 5px 30px 9px;
@@ -2267,6 +2275,7 @@
   border: 5px solid transparent;
   background-color: #ffffff;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator),
 .enyo-locale-non-latin .moon-textarea-decorator {
@@ -2542,7 +2551,6 @@
   -webkit-background-clip: padding-box;
   -moz-background-clip: padding-box;
   box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   background-color: #686868;
 }
@@ -2779,6 +2787,7 @@
 
   float: right;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .enyo-locale-right-to-left .moon-list-actions-menu {
   float: left;
@@ -2938,6 +2947,7 @@
   -webkit-transform: scale3d(1, 1, 1);
   z-index: 2;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-panel-body {
   overflow: hidden;
@@ -2972,6 +2982,7 @@
   width: 100%;
   padding: 0 10px 10px 10px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-panel-mini-header {
   margin-top: 25px;
@@ -3028,6 +3039,7 @@
   width: 100%;
   height: 100%;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   padding: 20px 10px;
   overflow: visible;
   -webkit-transform: translate3d(0, 0, 0);
@@ -3256,7 +3268,7 @@
 /* Table.css */
 /*.moon-table {
 	padding-right: 2em;
-	box-sizing: border-box;
+	.border-box;
 }*/
 .moon-table-row.spotlight {
   background-color: #cf0652;
@@ -3272,6 +3284,7 @@
   border: 0px;
   width: 100%;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   background-color: transparent;
 }
 .moon-input-header .moon-input-header-input-decorator > .moon-input {
@@ -3287,6 +3300,7 @@
   padding-right: 1px;
   display: inline-block;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   line-height: 1em;
   color: #4b4b4b;
   width: 100%;
@@ -3456,6 +3470,7 @@
   width: 100%;
   padding: 40px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   overflow: hidden;
 }
 .moon-popup.animate {
@@ -3957,6 +3972,7 @@
 /* --- Fullscreen control --- */
 .moon-video-fullscreen-control {
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0.1);
   transition: background-color 0.1s linear;
   -webkit-transition: background-color 0.1s linear;
@@ -3964,6 +3980,7 @@
 }
 .moon-video-fullscreen-control.scrim {
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0);
 }
 /* ---- Header info styling ---- */
@@ -4439,6 +4456,7 @@
 .moon-scroller-client-wrapper,
 .moon-scroller-viewport {
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   height: 100%;
   overflow: hidden;
 }
@@ -4453,8 +4471,8 @@
   transform-origin: center center;
   -webkit-transform-style: flat;
   transform-style: flat;
-  -webkit-box-sizing: border-box;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
   pointer-events: auto;
   -webkit-user-select: none;
@@ -4546,6 +4564,7 @@
 .moon-expandable-input .moon-input-decorator {
   width: 100%;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
   margin-top: 10px;
   margin-bottom: 10px;
 }
@@ -4575,6 +4594,7 @@
   text-align: center;
   padding: 0 10px;
   box-sizing: border-box;
+  -moz-box-sizing: border-box;
 }
 .moon-objaction.vertical .moon-objaction-actions.stretch > * {
   width: 100%;


### PR DESCRIPTION
In testing Moonstone on Firefox, I noticed a lot of buttons with the
wrong size.  This turned out to be a problem where Firefox hasn't yet
implemented a non-prefixed version of the CSS box-sizing rule.
We had some places where we had the -moz version, but the usage wasn't
consistent in Moonstone. I noticed that we had a .box-sizing CSS
selector, so I used Less's mixin support to replace all the explicit
border-box uses with that rule.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)