### PR TITLE
GF-58400: Fixed bug with AlwaysViewing Panel forgetting previously spotted item.

### DIFF
--- a/source/Panel.js
+++ b/source/Panel.js
@@ -197,12 +197,12 @@ enyo.kind({
 	},
 	addSpottableBreadcrumbProps: function() {
 		this.$.breadcrumbBackground.set("spotlight", true);
-		this.set("spotlightDisabled", true);
+		this.spotlightDisabled = true;
 	},	
 	removeSpottableBreadcrumbProps: function() {
 		this.$.breadcrumbBackground.set("spotlight", false);
 		this.$.breadcrumbBackground.removeClass("spotlight");
-		this.set("spotlightDisabled", false);
+		this.spotlightDisabled = false;
 	},
 	shrinkAsNeeded: function() {
 		if (this.needsToShrink) {


### PR DESCRIPTION
## Issue

As a user navigates through joined panels in an `AlwaysViewing` pattern, and spots an item that is not the first item within each panel, when they return to these panels, the first item (and not the item they had previously spotted) is spotted. For a set of 7 panels, this behavior starts occurring when returning to the 4th panel after navigating from the 7th, 6th, and 5th panels. When panels are collapsed, `spotlight` is set to `false`, but their child controls are still spottable. Thus, when on panel 7 and performing a 5way left, `Spotlight` calculates the first item of panel 4 as the nearest neighbor, momentarily spots it, and then proceeds with normal panel program flow, which spots panel 6. When we eventually reach panel 4, the first item is incorrectly spotted. Note that these panel numbers may differ based on screen resolution: in general, the left-most visible breadcrumb will have its first item spotted on a 5way left.
## Fix

We set the `spotlightDisabled` flag instead of the `spotlight` flag when toggling the breadcrumb (and thus the collapsed) state of the panel, so that none of the panel's children are spottable when collapsed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
