### PR TITLE
Off screen breadcrumb should not get focus - RC

### DIFF
--- a/samples/DrawerSample.js
+++ b/samples/DrawerSample.js
@@ -57,6 +57,27 @@ enyo.kind({
 							{kind: "moon.Item", content: "Item Three", ontap: "next"},
 							{kind: "moon.Item", content: "Item Four", ontap: "next"},
 							{kind: "moon.Item", content: "Item Five", ontap: "next"}
+						]},
+						{title: "Thrid", classes: "moon-7h", components: [
+							{kind: "moon.Item", content: "Item One", ontap: "next"},
+							{kind: "moon.Item", content: "Item Two", ontap: "next"},
+							{kind: "moon.Item", content: "Item Three", ontap: "next"},
+							{kind: "moon.Item", content: "Item Four", ontap: "next"},
+							{kind: "moon.Item", content: "Item Five", ontap: "next"}
+						]},
+						{title: "Fourth", classes: "moon-7h", components: [
+							{kind: "moon.Item", content: "Item One", ontap: "next"},
+							{kind: "moon.Item", content: "Item Two", ontap: "next"},
+							{kind: "moon.Item", content: "Item Three", ontap: "next"},
+							{kind: "moon.Item", content: "Item Four", ontap: "next"},
+							{kind: "moon.Item", content: "Item Five", ontap: "next"}
+						]},
+						{title: "Fifth", classes: "moon-7h", components: [
+							{kind: "moon.Item", content: "Item One", ontap: "next"},
+							{kind: "moon.Item", content: "Item Two", ontap: "next"},
+							{kind: "moon.Item", content: "Item Three", ontap: "next"},
+							{kind: "moon.Item", content: "Item Four", ontap: "next"},
+							{kind: "moon.Item", content: "Item Five", ontap: "next"}
 						]}
 					]
 				}

--- a/source/Panel.js
+++ b/source/Panel.js
@@ -88,6 +88,7 @@ enyo.kind({
 
 	headerComponents: [],
 	isBreadcrumb: false,
+	isOffscreen: false,
 	isHeaderCollapsed: false,
 	shrinking: false,
 	growing: false,
@@ -142,9 +143,9 @@ enyo.kind({
 	layoutKindChanged: function() {
 		this.$.panelBody.setLayoutKind(this.getLayoutKind());
 	},
-	//* When _this.isBreadcrumb_ changes, updates spottability.
-	isBreadcrumbChanged: function() {
-		if (this.isBreadcrumb) {
+	//* Updates spottability.
+	updatesSpottability: function() {
+		if (this.isBreadcrumb && !this.isOffscreen) {
 			this.addSpottableBreadcrumbProps();
 		} else {
 			this.removeSpottableBreadcrumbProps();
@@ -238,6 +239,8 @@ enyo.kind({
 	// Called directly by moon.Panels
 	initPanel: function(inInfo) {
 		this.set("isBreadcrumb", inInfo.breadcrumb);
+		this.set("isOffscreen", inInfo.offscreen);
+		this.updatesSpottability();
 		if (this.isBreadcrumb) {
 			this.needsToShrink = true;
 		}
@@ -277,6 +280,8 @@ enyo.kind({
 			}
 		}
 		this.set("isBreadcrumb", inInfo.breadcrumb);
+		this.set("isOffscreen", inInfo.offscreen);
+		this.updatesSpottability();
 		this.startMarqueeAsNeeded(inInfo);
 	},
 	shrinkAnimation: function() {


### PR DESCRIPTION
Fixing http://jira2.lgsvl.com/browse/GF-57968

This issue is reported from SmartShare App and all apps which is using
more then three panel can face this problem.

Problem:
1) Create activity panels sample with 4 panels and a drawer.
2) Move to 4th panel and press left key after focusing on drawer.
3) Breadcrumb of 1st panel is get focused which is not visible.

Reason:
Breadcrumb itself is spotlight true when it is in breadcrumb status.
Off screen breadcrumbs are actually on the left side from the drawer, so
it can get focus.

Solution:
Check visibility after panel transition and updates spottability.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
