### PR TITLE
GF-58554: Accordion remember last focused item.

### DIFF
--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -75,7 +75,7 @@ enyo.kind({
 	},
 	//* @protected
 	classes: "moon-expandable-list-item",
-	spotlight: "container",
+	spotlight: false,
 	defaultKind: "moon.Item",
 	handlers: {
 		onSpotlightDown: "spotlightDown",


### PR DESCRIPTION
GF-58554: 5-way(up/down) key on AccordionSample move differently according to last focused item.

ExpandableListItem don't need to remember last focused item.

@gouniLee modified ExpandableListItem's spotlight property for fixing GF-44975(moonstone/pull/836).

I restore that code and insert a alternative for it in enyo.Spotlight.Decorator.Container

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
