### PR TITLE
GF-58781: ExpandableInput, provide focus after animation end

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -72,6 +72,8 @@ enyo.kind({
 			enyo.Spotlight.spot(this.$.headerWrapper);
 		} else {
 			this.setActive(true);
+			enyo.Spotlight.unspot();
+			enyo.Spotlight.freeze();
 		}
 	},
 	//* Focuses the _moon.Input_ when the input decorator receives focus.
@@ -110,6 +112,7 @@ enyo.kind({
 		this.$.headerWrapper.stopMarquee();
 	},
 	drawerAnimationEnd: function() {
+		enyo.Spotlight.unfreeze();
 		this.focusInput();
 		this.inherited(arguments);
 	}


### PR DESCRIPTION
Fixing http://jira2.lgsvl.com/browse/GF-58781

This issue is reported from First use app and VKB team requested to
modify ExpandableInput to give focus when it is finish animation.

Problem:

When focus is moved to input filed in WebKit, the input field's position
will be tracked and calculated if that position is overlapped with VKB
area.

However, when animation works after focusing like ExpandableInput,
WebKit uses the position previously used before changing animation to
see if there's any overlapped area.

Therefore, the position after animation is overlapped with VKB area but
WebKit has no idea about it.

This issue occurrs when ExpandableInput is on the border of VKB area.
- position before ExpandableInput animation : posion not overlapping VKB
- position after ExpandableInput animation : position overlapping VKB

In order to see exactly if the position is overlapped, focus should be
able to move after expandableInput animation is complited.

Reproduction of this issue is available through 'Service Area Postal
Code' in 'Get Ready to watch TV page' of FirstUse app of Europe TV.
