### PR TITLE
GF-58661: Remove animate effect when list is reset.

### DIFF
--- a/source/DataList.js
+++ b/source/DataList.js
@@ -172,6 +172,7 @@ enyo.kind({
 					this.updateBounds(list);
 					list.refresh();
 				}
+				list.$.scroller.scrollTo(0, 0, false);
 			};
 		}),
 		updateBounds: enyo.inherit(function (sup) {
@@ -195,7 +196,7 @@ enyo.kind({
 					this.updateBounds(list);
 					list.refresh();
 				}
-				list.$.scroller.scrollTo(0, 0);
+				list.$.scroller.scrollTo(0, 0, false);
 			};
 		}),
 		updateBounds: enyo.inherit(function (sup) {


### PR DESCRIPTION
As I describe in Jira task, scroll bounds changing make some problem in current ScrollMath.js
To resolve this issue, we can simply use animation off scrolling.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
