### PR TITLE
GF-58539: Handle very long input names in channel info.

### DIFF
--- a/css/ChannelInfo.less
+++ b/css/ChannelInfo.less
@@ -3,6 +3,7 @@
 	vertical-align:top;
 	text-align: right;
 	white-space: normal;
+  max-width: 800px;
 }
 .moon-video-player-channel-info-badges > * {
   margin: 3px 0px 3px 10px;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4232,6 +4232,7 @@
   vertical-align: top;
   text-align: right;
   white-space: normal;
+  max-width: 800px;
 }
 .moon-video-player-channel-info-badges > * {
   margin: 3px 0px 3px 10px;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4228,6 +4228,7 @@
   vertical-align: top;
   text-align: right;
   white-space: normal;
+  max-width: 800px;
 }
 .moon-video-player-channel-info-badges > * {
   margin: 3px 0px 3px 10px;

--- a/source/ChannelInfo.js
+++ b/source/ChannelInfo.js
@@ -34,7 +34,7 @@ enyo.kind({
 	//* @protected
 	defaultKind: "moon.ChannelInfoBadge",
 	components: [
-		{kind: "enyo.Control", name: "channelNo", classes: "moon-header-font moon-video-player-channel-info-no"},
+		{kind: "moon.MarqueeText", name: "channelNo", classes: "moon-header-font moon-video-player-channel-info-no"},
 		{kind: "moon.MarqueeText", name: "channelName", classes: "moon-video-player-channel-info-name"},
 		{kind: "enyo.Control", name: "client", classes: "moon-video-player-channel-info-badges"}
 	],


### PR DESCRIPTION
## Issue

There can be very long input names, which are currently being placed in the channel number field.
## Fix

Add a max-width for `ChannelInfo`, and change the channel number to be a `MarqueeText` control. The max-width is being set to approximately 50% (not counting the wedge wrapper of banner) of the width of a 1080p display (800px + 60px margin + 100px padding = 960px; the current implementation prevents a straightforward way of using actual percentages).

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
