### PR TITLE
GF-59421: Reduce unnecessary unspot() call

### DIFF
--- a/source/DataList.js
+++ b/source/DataList.js
@@ -21,7 +21,8 @@ moon.DataListSpotlightSupport = {
 			// looping as new pages come up
 			var spot;
 			if (enyo.Spotlight.getPointerMode() &&
-				((spot = enyo.Spotlight.getCurrent()) && (spot === this || spot.isDescendantOf(this)))) {
+				((spot = enyo.Spotlight.getCurrent()) && (spot === this || spot.isDescendantOf(this)))
+				&& spot.hasClass("spotlight")) {
 				enyo.Spotlight.unspot();
 				this._unspotSinceSpot = true;
 			}


### PR DESCRIPTION
In pointerMode, last focused list item should unspotted to prevent
looping as new pages come up.
However, current condition statement is not enough because upspot() does
not change enyo.Spotligth.getCurrent().
It just remove spotlight class.
If we do not call unnecessary unspot(), more condition check should be
added
