### PR TITLE
GF-59223: Improve the reliability of locale-specific font definitions.

### DIFF
--- a/source/moon-fonts.js
+++ b/source/moon-fonts.js
@@ -86,7 +86,7 @@
 			else {
 				styleElem.innerHTML = '';
 			}
-		}
+		};
 
 		enyo.updateLocale = function() {
 			funEnyoLocaleChanged.apply(this,arguments);


### PR DESCRIPTION
Locale specific fonts are now re-evaluated every time enyo.updateLocale() is executed, allowing the fonts to stay in-sync with the currently set locale.
- This hooks up the locale-specific font code with the enyo.updateLocale() method. This is fired afterward.
- For the above feature to be supported, this change is dependent on https://github.com/enyojs/enyo-ilib/pull/39
- This commit includes a structural-indention change caused by wrapping code in a named function. Please diff with ignoring whitespace changes for best results.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
