### PR TITLE
GF-59723: Blocking 5-way key input during inTransition.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -248,6 +248,9 @@ enyo.kind({
 	spotlightDown: function(oSender, oEvent) {
 		if (oEvent.originator.name === "breadcrumbBackground" || this.inTransition()) { return true; }
 	},
+	spotlightUp: function(oSender, oEvent) {
+		if (oEvent.originator.name === "breadcrumbBackground" || this.inTransition()) { return true; }
+	},
 	//* Responds to tap on show/hide handle.
 	handleTap: function() {
 		enyo.Spotlight.unspot();


### PR DESCRIPTION
5-key input during panel transition makes spotlight have improper focus.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
