### PR TITLE
GF-58381: Fix issue with small amount of pointer movement stopping holdpulse events

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -149,11 +149,11 @@ enyo.kind({
 		return true;
 	},
 	downPrevious: function(inSender, inEvent) {
-		inEvent.configureHoldPulse({stopStrategy: "control", delay: 300});
+		inEvent.configureHoldPulse({endHold: "onLeave", delay: 300});
 		this.previous(inSender, inEvent);
 	},
 	downNext: function(inSender, inEvent) {
-		inEvent.configureHoldPulse({stopStrategy: "control", delay: 300});
+		inEvent.configureHoldPulse({endHold: "onLeave", delay: 300});
 		this.next(inSender, inEvent);
 	},
 	updateOverlays: function() {

--- a/source/SimpleIntegerPicker.js
+++ b/source/SimpleIntegerPicker.js
@@ -116,11 +116,11 @@ enyo.kind({
 		return true;
 	},
 	downPrevious: function(inSender, inEvent) {
-		inEvent.configureHoldPulse({stopStrategy: "control", delay: 300});
+		inEvent.configureHoldPulse({endHold: "onLeave", delay: 300});
 		this.previous();
 	},
 	downNext: function(inSender, inEvent) {
-		inEvent.configureHoldPulse({stopStrategy: "control", delay: 300});
+		inEvent.configureHoldPulse({endHold: "onLeave", delay: 300});
 		this.next();
 	},
 	//* Facades the currently active panel.

--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -250,11 +250,11 @@ enyo.kind({
 		}
 	},
 	downLeft: function(inSender, inEvent) {
-		inEvent.configureHoldPulse({stopStrategy: "control", delay: 300});
+		inEvent.configureHoldPulse({endHold: "onLeave", delay: 300});
 		this.left();
 	},
 	downRight: function(inSender, inEvent) {
-		inEvent.configureHoldPulse({stopStrategy: "control", delay: 300});
+		inEvent.configureHoldPulse({endHold: "onLeave", delay: 300});
 		this.right();
 	},
 	//* @public


### PR DESCRIPTION
## Issue

A small amount of pointer movement will stop `holdpulse` events from continuing to be sent. This affects controls that subscribe to the `holdpulse` event for repeated actions when the user holds down the selection.
## Fix

We now configure the options for `holdpulse` that are exposed via a `configureHoldPulse` function in the `down` event, setting the `endHold` value to `onLeave` so that `holdpulse` will only stop when the pointer leaves the control, instead of relying on the hysteresis calculations (`endHold` value of `onMove`). We also configure the `delay` to 300, instead of the default 200. Lastly, for `SimpleIntegerPicker` and `SimplePicker`, we subscribe to `down` instead of `tap` for the previous/next buttons to be consistent with `IntegerPicker` and fix an issue with an initial delay and double-firing of previous/next upon release.

This PR is dependent on an Enyo PR to be pulled first: https://github.com/enyojs/enyo/pull/648.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
