### PR TITLE
GF-59490: moon.Item does not allow mutiple line text or marquee when it has components inside

### DIFF
--- a/css/Item.less
+++ b/css/Item.less
@@ -10,7 +10,7 @@
 	position: relative;
 }
 .moon-item.allow-wrap {
-	white-space: normal;
+	white-space: normal !important;
 }
 
 .enyo-locale-non-latin .moon-item {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1247,7 +1247,7 @@
   position: relative;
 }
 .moon-item.allow-wrap {
-  white-space: normal;
+  white-space: normal !important;
 }
 .enyo-locale-non-latin .moon-item {
   font-family: "Moonstone LG Display";

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1247,7 +1247,7 @@
   position: relative;
 }
 .moon-item.allow-wrap {
-  white-space: normal;
+  white-space: normal !important;
 }
 .enyo-locale-non-latin .moon-item {
   font-family: "Moonstone LG Display";


### PR DESCRIPTION
## Issue

The `white-space: nowrap !important` declaration in the `moon-marquee` class overrides the `white-space: normal` declaration in the `allow-wrap` class for `moon.Item`.
## Fix

Added `!important` to the `white-space: normal` declaration in the `allow-wrap` class.

The `allow-wrap` class is added if `moon.Item` has more than one child, and I couldn't think of a scenario where we would want to marquee multiple components as a whole when the individual components can control their own marqueeing.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
