### PR TITLE
GF-58780: Queue showing of moon.Popup when hide is animating.

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -141,11 +141,11 @@ enyo.kind({
 	showCloseButtonChanged: function() {
 		this.configCloseButton();
 	},
-	setShowing: function(inOldValue) {
+	setShowing: function(inValue) {
 		// queue setShowing if we are currently in the process of hiding and are trying to show the popup
-		if (this.showing && this.animate && this.isAnimating) {
+		if (inValue && this.animate && this.isAnimating) {
 			this.animationEndCommand = function() {
-				this.setShowing(inOldValue);
+				this.setShowing(inValue);
 			};
 		} else {
 			this.inherited(arguments);


### PR DESCRIPTION
## Issue

As a `moon.Popup` is currently being hidden, if it is set to being shown, there is a race condition involving the internal showing state of the popup, resulting in events (i.e. tap) being captured even after the popup is hidden.
## Fix

If the popup is currently begin hidden and it is set to being shown, the showing method is queued to be run after the hide animation is fully complete.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
