### PR TITLE
GF-58780: Release captured events of moon.Popup when showing occurs during a hide animation.

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -147,6 +147,14 @@ enyo.kind({
 				// need to call this early to prevent race condition where animationEnd
 				// originated from a "hide" context but we are already in a "show" context
 				this.animationEnd = enyo.nop;
+				// if we are currently animating the hide transition, release
+				// the events captured when popup was initially shown
+				if (this.isAnimatingHide) {
+					if (this.captureEvents) {
+						this.release();
+					}
+					this.isAnimatingHide = false;
+				}
 			}
 			this.activator = enyo.Spotlight.getCurrent();
 			moon.Popup.count++;
@@ -163,12 +171,6 @@ enyo.kind({
 
 		if (this.animate) {
 			if (this.showing) {
-				// if we are currently animating the hide transition, release
-				// the events captured when popup was initially shown
-				if (this.isAnimatingHide) {
-					this.release();
-					this.isAnimatingHide = false;
-				}
 				this.inherited(arguments);
 				this.animateShow();
 			} else {


### PR DESCRIPTION
## Issue

As a `moon.Popup` is currently being hidden, if it is set to showing while the hide animation is still occurring, there is a race condition that results in a disproportionate number of event capture vs. release calls being made, and thus the popup is stuck in a state where it is incorrectly capturing events after it is hidden.
## Fix

We maintain a flag `isAnimatingHide`, and if a show is triggered while this flag is `true`, we effectively "complete" the hide by releasing the previously captured events and resetting the `isAnimatingHide` flag. Note that we cannot simply nop the `animationEnd` method as the capture API pushes events into an array and the release only removes the first instance of the target/event it finds; there are existing captured events from initially showing the popup, and the showing that was just triggered will add another set of duplicate captured events.

Additionally, the nop of the `animationEnd` method has been moved to the very beginning of the `showingChanged` method as there is a potential race condition with a showing event being triggered (`this.showing` becomes `true`) and the `animationEnd` method being called from a previous hide transition, which would effectively capture, instead of release, events based on the value of `this.showing` being `true`. I did some basic benchmarking and noted that in its original location in the code, there was a 3 to 6ms delay between `this.showing` being set to `true` and the nop of `animationEnd`. When moving this to the beginning of its current conditional (L166), there was a ~1ms delay. At its new location, there is a ~0.1ms delay.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
