### PR TITLE
GF-59128: Call moon.MarqueeItem's dispatchEvent super before handling ev...

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -239,13 +239,15 @@ moon.MarqueeItem = {
 	classes: "moon-marquee",
 	dispatchEvent: enyo.inherit(function (sup) {
 		return function(sEventName, oEvent, oSender) {
+			if (sup.apply(this, arguments)) {
+				return true;
+			}
 			if (oEvent && !oEvent.delegate) {
 				var handler = this._marqueeItem_Handlers[sEventName];
 				if (handler && this[handler](oSender, oEvent)) {
 					return true;
 				}
 			}
-			return sup.apply(this, arguments);
 		};
 	}),
 	_marquee_enabled: true,


### PR DESCRIPTION
...ents, to give moon.MarqueeSupport the chance to block events, in the case that both are mixed into the same kind.

The issue is related to the order the mixins are applied (and thus the order that events are handled by the dispatchEvent code in each mixin). moon.MarqueeSupport has code to stop propagation of onRequestMarquee events being waterfalled from above itself (see line 36-38). However, if moon.MarqueeSupport and moon.MarqueeItem are mixed in together on the same kind (like moon.Divider) and moon.MarqueeItem is mixed in last, it is the first to handle events and won't benefit from moon.MarqueeSupport blocking the event.

So, we just need to call the super on dispatchEvent from moon.MarqueeItem FIRST, to give moon.MarqueeSupport a chance to block the event first. If the developer adds the mixins in the opposite order (["moon.MarqueeItem", "moon.MarqueeSupport"), it will still work, since moon.MarqueeSupport will get the first look at the event and return true). 

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
