### PR TITLE
GF-59128: Call moon.MarqueeItem's dispatchEvent super before handling ev...

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -239,13 +239,15 @@ moon.MarqueeItem = {
 	classes: "moon-marquee",
 	dispatchEvent: enyo.inherit(function (sup) {
 		return function(sEventName, oEvent, oSender) {
+			if (sup.apply(this, arguments)) {
+				return true;
+			}
 			if (oEvent && !oEvent.delegate) {
 				var handler = this._marqueeItem_Handlers[sEventName];
 				if (handler && this[handler](oSender, oEvent)) {
 					return true;
 				}
 			}
-			return sup.apply(this, arguments);
 		};
 	}),
 	_marquee_enabled: true,


### PR DESCRIPTION
...ents, to give moon.MarqueeSupport the chance to block events, in the case that both are mixed into the same kind.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
