### PR TITLE
GF-59736: Prevent characters being cut off in video progress slider in Japanese

### DIFF
--- a/css/VideoPlayerSlider.less
+++ b/css/VideoPlayerSlider.less
@@ -72,13 +72,9 @@
 }
 
 .moon-video-transport-slider-indicator-wrapper {
-	width: 12.5%;
 	height: 82px;
 	top: 0;
 	position: absolute;
-}
-.enyo-locale-ja .moon-video-transport-slider-indicator-wrapper {
-	width: 22.5%;
 }
 .moon-video-transport-slider-indicator-wrapper.start {
 	left: 0px;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3783,13 +3783,9 @@
   display: inline-block;
 }
 .moon-video-transport-slider-indicator-wrapper {
-  width: 12.5%;
   height: 82px;
   top: 0;
   position: absolute;
-}
-.enyo-locale-ja .moon-video-transport-slider-indicator-wrapper {
-  width: 22.5%;
 }
 .moon-video-transport-slider-indicator-wrapper.start {
   left: 0px;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3779,13 +3779,9 @@
   display: inline-block;
 }
 .moon-video-transport-slider-indicator-wrapper {
-  width: 12.5%;
   height: 82px;
   top: 0;
   position: absolute;
-}
-.enyo-locale-ja .moon-video-transport-slider-indicator-wrapper {
-  width: 22.5%;
 }
 .moon-video-transport-slider-indicator-wrapper.start {
   left: 0px;

--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -77,11 +77,11 @@ enyo.kind({
 	},
 	//* @protected
 	tickComponents: [
-		{classes: "moon-video-transport-slider-indicator-wrapper start", components: [
+		{name: "startWrapper", classes: "moon-video-transport-slider-indicator-wrapper start", components: [
 			{name: "beginTickBar", classes: "moon-video-transport-slider-indicator-bar-left"},
 			{name: "beginTickText", classes: "moon-video-transport-slider-indicator-text", content: "00:00"}
 		]},
-		{classes: "moon-video-transport-slider-indicator-wrapper end", components: [
+		{name: "endWrapper", classes: "moon-video-transport-slider-indicator-wrapper end", components: [
 			{name: "endTickBar", classes: "moon-video-transport-slider-indicator-bar-right"},
 			{name: "endTickText", classes: "moon-video-transport-slider-indicator-text", content: "00:00"}
 		]}
@@ -117,6 +117,9 @@ enyo.kind({
 				this.set("endPosition", this.get("endPosition") - 0.05 );
 			}
 		}
+
+		this.beginPositionChanged();
+		this.endPositionChanged();
 	},
 	createTickComponents: function() {
 		this.createComponents(this.tickComponents, {owner: this, addBefore: this.$.tapArea});
@@ -191,6 +194,16 @@ enyo.kind({
 	setRangeEnd: function(inValue) {
 		this.rangeEnd = this.clampValue(this.getMin(), this.getMax(), inValue);
 		this.rangeEndChanged();
+	},
+	beginPositionChanged: function() {
+		// Set the width of the wrapper to twice the amount of it's position from the start.
+		this.$.startWrapper.applyStyle("width", (this.get("beginPosition") * 200) + "%");
+		this.updateSliderRange();
+	},
+	endPositionChanged: function() {
+		// Set the width of the wrapper to twice the amount of it's position from the end.
+		this.$.endWrapper.applyStyle("width", ((this.get("endPosition") - 1) * -200) + "%");
+		this.updateSliderRange();
 	},
 	showTickTextChanged: function() {
 		this.$.beginTickText.setShowing(this.getShowTickText());


### PR DESCRIPTION
Giving 5% extra space around the ends of the video progress slider for Japanese language.
Demystifying the magic values that position of the video transport slider by moving them into a kind-property.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
