### PR TITLE
GF-59506: Reset marquee after being unhidden.

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -258,6 +258,14 @@ moon.MarqueeItem = {
 			this._marquee_invalidateMetrics();
 		};
 	}),
+	showingChangedHandler: enyo.inherit(function(sup) {
+		return function() {
+			sup.apply(this, arguments);
+			if (this.showing) {
+				this._marquee_reset();
+			}
+		};
+	}),
 	_marquee_invalidateMetrics: function() {
 		this._marquee_distance = null;
 		this._marquee_fits = null;
@@ -270,10 +278,7 @@ moon.MarqueeItem = {
 		if (this.$.marqueeText) {
 			this.$.marqueeText.setContent(this.content);
 		}
-		this._marquee_invalidateMetrics();
-		if (this._marquee_puppetMaster) {
-			this._marquee_puppetMaster.resetMarquee();
-		}
+		this._marquee_reset();
 	},
 	//* If this control needs to marquee, lets the event originator know.
 	_marquee_requestMarquee: function(inSender, inEvent) {
@@ -384,6 +389,12 @@ moon.MarqueeItem = {
 	//* Flips distance value for RTL support
 	_marquee_adjustDistanceForRTL: function(inDistance) {
 		return this.rtl ? inDistance : inDistance * -1;
+	},
+	_marquee_reset: function() {
+		this._marquee_invalidateMetrics();
+		if (this._marquee_puppetMaster) {
+			this._marquee_puppetMaster.resetMarquee();
+		}
 	}
 };
 


### PR DESCRIPTION
## Issue

Marquees do not restart themselves after being unhidden.
## Fix

Provide `showingChangedHandler` function in `moon.MarqueeItem` mixin to reset marquee when unhidden.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
