### PR TITLE
Fix for GF-59582: Only move focus to a GridList item if that item has a ...

### DIFF
--- a/source/GridList.js
+++ b/source/GridList.js
@@ -286,7 +286,7 @@ enyo.kind({
 			var nd = enyo.Spotlight.getPointerMode() || this._getNodeParent(n);
 			if (nd) {
 				if (nCurrent !== null) {
-					this._blurNode(this, nCurrent);
+					this._blurNode(nCurrent);
 				}
 				this._focusNode(n);
 				this._nCurrentSpotlightItem = n;


### PR DESCRIPTION
...node.

Previously, when rapidly paging through the list, we’d sometimes try to focus a not-yet-existent node and the list would stop scrolling with an error.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
