### PR TITLE
GF-59134: If scroll is not needed, hide thumb.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -407,10 +407,10 @@ enyo.kind({
 			this.scrollBounds = this._getScrollBounds();
 			this.setupBounds();
 			if (this.showVertical() || this.showHorizontal()) {
+				this.animateToControl(inEvent.originator, inEvent.scrollFullPage, inEvent.scrollInPointerMode || false);
 				if (this.$.scrollMath.bottomBoundary) {
 					this.alertThumbs();
 				}				
-				this.animateToControl(inEvent.originator, inEvent.scrollFullPage, inEvent.scrollInPointerMode || false);
 				this.scrollBounds = null;
 				return true;
 			} else {


### PR DESCRIPTION
Currently thumb is always visible if spotlightPagingControls is true.
Do not modify existing methods, I simply add condition statement to solve this matter.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
