### PR TITLE
Reset marquee whenever a marquee child's showing state changes, regardle...

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -176,13 +176,18 @@ moon.MarqueeSupport = {
 		if ((this.marqueeOnSpotlight && this._marquee_isFocused) || 
 			(this.marqueeOnHover && this._marquee_isHovered) || 
 			this.marqueeOnRender) {
-			this.stopMarquee();
-			this.startMarquee();
+			// Batch multiple requests to reset from children being hidden/shown
+			this.startJob("resetMarquee", "_resetMarquee", 10);
 		}
 	},
 
 	//* @protected
 
+	//* Stops and restarts the marquee animations
+	_resetMarquee: function() {
+		this.stopMarquee();
+		this.startMarquee();
+	},
 	//* Waterfalls request for child animations to build up _this.marqueeWaitList_.
 	_marquee_buildWaitList: function() {
 		this.marqueeWaitList = [];


### PR DESCRIPTION
...ss of whether it's being shown or hidden.

Previously, we were only resetting when a child was being shown, which caused any sibling marquees to stop rolling.

Also, short-circuit in requestMarquee when we're not showing, to avoid unnecessary DOM measurement.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
