### PR TITLE
GF-59969: Added "useNative: false" property to the TimePicker's hour-picker...

### DIFF
--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -129,6 +129,7 @@ enyo.kind({
 			type: "time",
 			time: "h",
 			clock: clockPref !== "locale" ? clockPref : undefined,
+			useNative: false,
 			timezone: "local"
 		};
 		if (this.locale) {


### PR DESCRIPTION
...so it matches the minutes picker.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
