### PR TITLE
GF-59152: Do not call preventDefault in capture when we have a modal scrim.

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -12,6 +12,7 @@ enyo.kind({
 	floating  : true,
 	_bounds   : null,
 	spotlight : "container",
+	allowDefault: true,
 
 	handlers: {
 		onRequestScrollIntoView   : "_preventEventBubble",
@@ -212,13 +213,11 @@ enyo.kind({
 		if (this.floating && (this.scrim || (this.modal && this.scrimWhenModal))) {
 			var scrim = this.getScrim();
 			if (inShow && this.modal && this.scrimWhenModal) {
-				this.allowDefault = true;
 				// move scrim to just under the popup to obscure rest of screen
 				var i = this.getScrimZIndex();
 				this._scrimZ = i;
 				scrim.showAtZIndex(i);
 			} else {
-				this.allowDefault = false;
 				scrim.hideAtZIndex(this._scrimZ);
 			}
 			enyo.call(scrim, "addRemoveClass", [this.scrimClassName, scrim.showing]);


### PR DESCRIPTION
## Issue

A focused input in a popup does not hide the VKB when tapping in the scrim area.
## Fix

Utilizing the `allowDefault` flag of `Popup`, we set this to `true` when we have a modal scrim, so that the VKB will be hidden, while the modal scrim will still prevent user input from passing through to the controls beneath.

This PR is dependent on this `Enyo` PR: https://github.com/enyojs/enyo/pull/656

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
