### PR TITLE
GF-60069: Allow sequential left key input during transition

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -560,7 +560,8 @@ enyo.kind({
 		this.inherited(arguments);
 
 		this.transitionInProgress = false;
-
+		// queueIndex is '-1' means that there is LEFT key input during transition
+		// and current index is '0'
 		if (this.queuedIndex === -1) {
 			this.hide();
 		} else if (this.queuedIndex !== null) {	


### PR DESCRIPTION
Currently, sequential key inputs during panels transition are queuing.
And last key input will be conducted after transition is finished.

But some case, queuing doesn't happen well and last key input could be ignored.
Because, queuing process in in setIndex().

To reproduce this case, plz open AlwaysViewingPanelsWithVideoSample.html
If we give 2 times LEFT key input from index 2, 
it will call two times setIndex() and queueIndex is set properly.
However starting from index 1, second LEFT key doesn't call setIndex(). 
So last LEFT key input doesn't get into queue.

To resolve this matter, I add another queuing process in onSpotlightPanelLeave()
*If we can have enough sanity test, queuing process can be totally move to there.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
