### PR TITLE
GF-60194: Leave scroller a spotlight container even when spotlightPaging...

### DIFF
--- a/source/Scroller.js
+++ b/source/Scroller.js
@@ -114,9 +114,6 @@ enyo.kind({
 		this.scrollWheelMovesFocusChanged();
 	},
 	spotlightPagingControlsChanged: function() {
-		// Since spotlightPagingControls is used when there are no focusable
-		// children, turn off container handling in that case.
-		this.spotlight = this.spotlightPagingControls ? false : "container";
 		this.$.strategy.set("spotlightPagingControls", this.spotlightPagingControls);
 	},
 	scrollWheelMovesFocusChanged: function() {


### PR DESCRIPTION
...Controls:true, since containers are now no longer focusable if they have no children, eliminating the need to change the setting.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
