### PR TITLE
GF-60073: Additional fixes to handle spotlight issues with list re-generation

### DIFF
--- a/source/DataList.js
+++ b/source/DataList.js
@@ -161,7 +161,17 @@ enyo.kind({
 	var exts = {
 		refresh: enyo.inherit(function (sup) {
 			return function (list) {
+				var current = enyo.Spotlight.getCurrent(),
+					focusedIndex = -1;
+				if (current && current.isDescendantOf(list)) {
+					focusedIndex = list.getIndexFromChild(current);
+					enyo.Spotlight.unspot();
+				}
 				sup.apply(this, arguments);
+				if (focusedIndex > -1) {
+					focusedIndex = (focusedIndex < list.collection.length-1) ? focusedIndex : list.collection.length-1;
+					enyo.Spotlight.spot(list.childForIndex(focusedIndex));
+				}
 				list.$.scroller.resized();
 			};
 		}),

--- a/source/Panel.js
+++ b/source/Panel.js
@@ -324,7 +324,7 @@ enyo.kind({
 	postTransitionComplete: function() {
 		this.growing = false;
 		this.doPostTransitionComplete();
-		this.resized();
+		this.reflow();
 	},
 	animationComplete: function(inSender, inEvent) {
 		switch (inEvent.animation.name) {


### PR DESCRIPTION
Only do reflow() at panel post transition (resized of all child contents is unnecessary).  Add unspot/respot logic to DataList refresh, similar to modelsAdded/Removed, to ensure spotlight stays within the list when refreshing/resizing/

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
