### PR TITLE
GF-60463: The last character of program titles is not fully shown in Vid...

### DIFF
--- a/css/VideoInfoHeader.less
+++ b/css/VideoInfoHeader.less
@@ -12,6 +12,8 @@
 	font-size: 126px;
 	margin-bottom: 0;
 	white-space: nowrap;
+	-webkit-font-kerning:normal;
+	font-kerning:normal;
 }
 .moon-video-player-info-subtitle {
 	.moon-sub-header-text;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4145,6 +4145,8 @@
   font-size: 126px;
   margin-bottom: 0;
   white-space: nowrap;
+  -webkit-font-kerning: normal;
+  font-kerning: normal;
 }
 .moon-video-player-info-subtitle {
   font-family: "MuseoSans 700";

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4141,6 +4141,8 @@
   font-size: 126px;
   margin-bottom: 0;
   white-space: nowrap;
+  -webkit-font-kerning: normal;
+  font-kerning: normal;
 }
 .moon-video-player-info-subtitle {
   font-family: "MuseoSans 700";


### PR DESCRIPTION
...eoInfoHeader

Removing "letter-spacing:-0.05em;" per Brooke Peterson's comment.

If letter-spacing:-0.05em; is the problem, just remove it or change to
letter-spacing:normal
In moonstone the video infor header "letter-spacing:-0.05em;" was
removed a few month back when we introduced new kerned Miso. SO just
remove it, thanks.

Fixing: http://jira2.lgsvl.com/browse/GF-60463

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
