### PR TITLE
ANG-576: When in pointer mode, spot ExpandableInput header after closing drawer.

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -30,7 +30,7 @@ enyo.kind({
 	lockBottom: true,
 
 	components: [
-		{name: "headerWrapper", kind: "moon.Item", classes: "moon-expandable-picker-header-wrapper", onSpotlightFocus: "headerFocus", ontap: "expandContract", components: [
+		{name: "headerWrapper", kind: "moon.Item", classes: "moon-expandable-picker-header-wrapper", onSpotlightFocus: "headerFocus", ontap: "expandContract", ondown: "headerDown", components: [
 			{name: "header", kind: "moon.MarqueeText", classes: "moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-input-header"},
 			{name: "currentValue", kind: "moon.MarqueeText", classes: "moon-expandable-picker-current-value"}
 		]},
@@ -69,12 +69,14 @@ enyo.kind({
 		if (this.getOpen()) {
 			this.setActive(false);
 			this.$.clientInput.blur();
-			enyo.Spotlight.spot(this.$.headerWrapper);
 		} else {
 			this.setActive(true);
 			enyo.Spotlight.unspot();
 			enyo.Spotlight.freeze();
 		}
+	},
+	headerDown: function() {
+		enyo.Spotlight.unfreeze();
 	},
 	//* Focuses the _moon.Input_ when the input decorator receives focus.
 	inputFocus: function(inSender, inEvent) {


### PR DESCRIPTION
## Issue

In pointer mode, tapping the header of an open `ExpandableInput` does not cause the header to be spotted as the `ExpandableInput` closes its drawer.
## Fix

There is a redundant call that programmatically spots the header (which unspots the already-spotted header and does not re-spot the header due to a conditional check based on being in pointer mode), as the tap triggered by the user will already spot the header. 

Additionally, to fix a previously suppressed issue (initially cannot 5-way move after closing drawer), we unfreeze `Spotlight` when the header is pressed. 

The long explanation:
This issue was suppressed because focus would not return to the header, so a 5-way move would spot the first child of the root. Because the header is frozen, the code in `onMouseMove` (called from `onMouseDown`) would not successfully spot the header, but would set the value of `_oLastMouseMoveTarget`. Subsequently in `onMouseDown`, the header would be unfrozen and spotting would occur, which would trigger an `onSpotlightBlur` (via `unspot`) that sets `_oLastMouseMoveTarget` to `null`. This leaves `Spotlight` in a state where a 5-way move will spot the last (last is the currently spotted header in this case) control and seemingly not do anything, before a subsequent 5-way move will correctly move in the desired direction.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
