### PR TITLE
GF-61229: At the end of video stream, the knob indicate unexpected position

### DIFF
--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -255,7 +255,8 @@ enyo.kind({
 		this._updateKnobPosition(inValue);
 	},
 	_updateKnobPosition: function(inValue) {
-		var p = this._calcPercent(inValue);
+		var p = this.clampValue(this.min, this.max, inValue);
+		p = this._calcPercent(p);
 		var slider = this.inverseToSlider(p);
 		this.$.knob.applyStyle("left", slider + "%");
 		this.$.popup.addRemoveClass("moon-slider-popup-flip-h", slider > 50);


### PR DESCRIPTION
WHEN current time is bigger than duration, the knob deviate from slider.
Because, Progress and BgProgress  values are clamped in moon.ProgressBar, but the knob position is not clamped.
So, I have added clamping 'inValue' for knob position.
