### PR TITLE
GF-61237: Calling super method for transitionEnd only when the originator is moon.Popup

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -194,7 +194,7 @@ enyo.kind({
 			this.$.spotlightDummy.spotlight = false;
 			// Spot ourselves, unless we're already spotted
 			var current = enyo.Spotlight.getCurrent(); 
-			if (current === null || typeof current == "undefined" || (current && !current.isDescendantOf(this))) {
+			if (!current || !current.isDescendantOf(this)) {
 				if (enyo.Spotlight.isSpottable(this)) {
 					enyo.Spotlight.spot(this);
 				} else {


### PR DESCRIPTION
Fixing http://jira2.lgsvl.com/browse/GF-61237

When a popup have components which is fires ontransitionend event like scroller, the popup is calling showingChanged handler of enyo.Popup which is captures events and not releasing it.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
