### PR TITLE
Added extra space for video duration in video player when in Portuguese.

### DIFF
--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -111,10 +111,16 @@ enyo.kind({
 			this.$.beginTickText.setContent(this.formatTime(0));
 
 			var loc = new ilib.Locale(),
-				language = loc.getLanguage();
-			if (language === 'ja') {
-				this.set("beginPosition", this.get("beginPosition") + 0.05 );
-				this.set("endPosition", this.get("endPosition") - 0.05 );
+				language = loc.getLanguage(),
+				// Hash of languages and the additional % widths they'll need to not run off the edge.
+				langWidths = {
+					ja: 0.05,
+					pt: 0.05
+				};
+
+			if (langWidths[language]) {
+				this.set("beginPosition", this.get("beginPosition") + langWidths[language] );
+				this.set("endPosition", this.get("endPosition") - langWidths[language] );
 			}
 		}
 


### PR DESCRIPTION
Also updated source to support a table of languages and widths to be applied.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
