### PR TITLE
GF-60878: Specifying defaultSpotlightDown/Up on paging controls of moon....

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -51,18 +51,18 @@ enyo.kind({
 			]}
 		]},
 		{name: "vColumn", classes: "moon-scroller-v-column", components: [
-			{name: "pageUpControl", kind: "moon.PagingControl", defaultSpotlightDisappear:"pageDownControl", side: "top", onPaginateScroll: "paginateScroll", onPaginate: "paginate"},
+			{name: "pageUpControl", kind: "moon.PagingControl", defaultSpotlightDisappear: "pageDownControl", defaultSpotlightDown: "pageDownControl", side: "top", onPaginateScroll: "paginateScroll", onPaginate: "paginate"},
 			{name: "vthumbContainer", classes: "moon-scroller-thumb-container moon-scroller-vthumb-container", components: [
 				{name: "vthumb", kind: "moon.ScrollThumb", classes: "moon-scroller-vthumb hidden", axis: "v"}
 			]},
-			{name: "pageDownControl", kind: "moon.PagingControl", defaultSpotlightDisappear:"pageUpControl", side: "bottom", onPaginateScroll: "paginateScroll", onPaginate: "paginate"}
+			{name: "pageDownControl", kind: "moon.PagingControl", defaultSpotlightDisappear: "pageUpControl", defaultSpotlightUp: "pageUpControl", side: "bottom", onPaginateScroll: "paginateScroll", onPaginate: "paginate"}
 		]},
 		{name: "hColumn", classes: "moon-scroller-h-column", components: [
-			{name: "pageLeftControl", kind: "moon.PagingControl", defaultSpotlightDisappear:"pageRightControl", side: "left", onPaginateScroll: "paginateScroll", onPaginate: "paginate"},
+			{name: "pageLeftControl", kind: "moon.PagingControl", defaultSpotlightDisappear: "pageRightControl", defaultSpotlightRight: "pageRightControl", side: "left", onPaginateScroll: "paginateScroll", onPaginate: "paginate"},
 			{name: "hthumbContainer", classes: "moon-scroller-thumb-container moon-scroller-hthumb-container", components: [
 				{name: "hthumb", kind: "moon.ScrollThumb", classes: "moon-scroller-hthumb hidden", axis: "h"}
 			]},
-			{name: "pageRightControl", kind: "moon.PagingControl", defaultSpotlightDisappear:"pageLeftControl", side: "right", onPaginateScroll: "paginateScroll", onPaginate: "paginate"}
+			{name: "pageRightControl", kind: "moon.PagingControl", defaultSpotlightDisappear: "pageLeftControl", defaultSpotlightLeft: "pageLeftControl", side: "right", onPaginateScroll: "paginateScroll", onPaginate: "paginate"}
 		]},
 		{kind: "Signals", onSpotlightModeChanged: "spotlightModeChanged", isChrome: true}
 	],


### PR DESCRIPTION
...Scroller

Fixing http://jira2.lgsvl.com/browse/GF-60878

This issue is reported from SmartShare and have Q issue regarding to
this.
Reproduce:
1) Open DataGridList Sample and move focus down to items on second page.
2) Move focus to paging controls. (paging down control)
3) Press up key.
Problem:
Focus is not moving to paging up control
Expected result:
Focus is moves to paging up control
We can get this result by simply set defaultSpotlightUp/Down property on
Paging Up/Down controls.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
