### PR TITLE
GF-61350: Prevent using outdated scroll position when scroller size changes.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -557,7 +557,7 @@ enyo.kind({
 	animateToControl: function(inControl, inScrollFullPage, animate) {
 		var controlBounds  = inControl.getAbsoluteBounds(),
 			absoluteBounds = this.$.viewport.getAbsoluteBounds(),
-			scrollBounds   = this.getScrollBounds(),
+			scrollBounds   = this._getScrollBounds(),
 			offsetTop,
 			offsetLeft,
 			offsetHeight,
@@ -603,7 +603,7 @@ enyo.kind({
 
 		switch (xDir) {
 		case 0:
-			x = this.clampX();
+			x = this.getScrollLeft();
 			break;
 		case 1:
 			// If control requested to be scrolled all the way to the viewport's left, or if the control
@@ -633,7 +633,7 @@ enyo.kind({
 
 		switch (yDir) {
 		case 0:
-			y = this.clampY();
+			y = this.getScrollTop();
 			break;
 		case 1:
 			// If control requested to be scrolled all the way to the viewport's top, or if the control


### PR DESCRIPTION
## Issue

For `ExpandableInputPickerSample`, the `ScrollThumb` appears below the bottom arrow when the picker is closed.
## Fix

When we call `setupBounds` in the `requestScrollIntoView` handler, the scroll position is synced via a `scrollTo` call in `clampScrollPosition`. In the subsequent `animateToControl` call, the getter `getScrollBounds` actually stops the scroll via a `stop` call. We now use the `_getScrollBounds` call instead, which does not issue a `stop` call.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
