### PR TITLE
BHV-757: Remove unnecessary call that stops hideTopOverlay job.

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -125,7 +125,6 @@ enyo.kind({
 		} else {
 			return;
 		}
-		this.stopJob("hideTopOverlay");
 		this.$.bottomOverlay.addClass("selected");
 		if (inEvent.originator != this.$.upArrow) {
 			this.startJob("hideBottomOverlay", "hideBottomOverlay", 350);


### PR DESCRIPTION
## Issue

A quick up-down causes the `selected` state of the up arrow to remain active indefinitely.
## Fix

There is a call to stop the `hideTopOverlay` job whenever the down (previous) arrow is pressed; this call does not seem to have any current effect and I could not find anything in the history related to this call being made to address another issue.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
