### PR TITLE
BHV-747: Do not animate slider when constrainToBgProgress is true and unclamped value is greater than bgProgress.

### DIFF
--- a/source/Slider.js
+++ b/source/Slider.js
@@ -244,13 +244,13 @@ enyo.kind({
 		}
 	},
 	valueChanged : function(preValue, inValue){
-		var unClampedValue = inValue;
 		if (!this.dragging) {
+			var allowAnimation = this.constrainToBgProgress && inValue <= this.bgProgress || !this.constrainToBgProgress;
 			if (this.constrainToBgProgress) {
 				inValue = this.clampValue(this.min, this.bgProgress, inValue); // Moved from animatorStep
 				inValue = (this.increment) ? this.calcConstrainedIncrement(inValue) : inValue;
 			}
-			if (this.animate && (this.constrainToBgProgress && unClampedValue <= this.bgProgress || !this.constrainToBgProgress)) {
+			if (this.animate && allowAnimation) {
 				this.animateTo(preValue, inValue);
 			} else {
 				this._setValue(inValue);


### PR DESCRIPTION
## Issue

When `constrainToBgProgress` is `true`, the slider animation can be seen animating outside the bounds of the current background progress.
## Fix

Only animate the slider if the current (and pre-clamped) slider value is less than the background progress value.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
