### PR TITLE
BHV-719: Allow Spotlight to move to controls outside scroller when 5-way moving from paging controls.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -46,7 +46,7 @@ enyo.kind({
 	],
 	components: [
 		{name: "clientContainer", classes: "moon-scroller-client-wrapper", components: [
-			{name: "viewport", classes:"moon-scroller-viewport", components: [
+			{name: "viewport", spotlight: "container", classes:"moon-scroller-viewport", components: [
 				{name: "client", classes: "enyo-touch-scroller matrix-scroll-client matrix3dsurface"}
 			]}
 		]},


### PR DESCRIPTION
## Issue

When `spotlightPagingControls` is `true` and a 5-way move up is attempted with one of the paging controls spotted, an item in the list (vertical orientation) will be spotted, instead of a control above the list.
## Fix

The `spotlight` setting of the viewport is set to `container` so that the list items are not considered siblings when calculating nearest neighbors for the paging controls.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
