### PR TITLE
Upgrade ListAction activation button with the icon property, like moon.Icon

### DIFF
--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -58,7 +58,8 @@ enyo.kind({
 	],
 	bindings: [
 		{from: ".open", to: ".$.drawer.open"},
-		{from: ".iconSrc", to: ".$.activator.src"}
+		{from: ".iconSrc", to: ".$.activator.src"},
+		{from: ".icon", to: ".$.activator.icon"}
 	],
 	create: function() {
 		this.inherited(arguments);


### PR DESCRIPTION
Now the ListAction activation icon button can also use font-icons the same way that moon.Icon and moon.IconButton do. 
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
