### PR TITLE
BHV-709: Popup.tap has been renamed to Popup.capturedTap

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -108,8 +108,8 @@ enyo.kind({
 		this.downEvent = inEvent;
 	},
 	//* If _this.downEvent_ is set to a spotlight event, skips normal popup
-	//* _tap()_ code.
-	tap: function(inSender, inEvent) {
+	//* capturedTap()_ code.
+	capturedTap: function(inSender, inEvent) {
 		if (!this.downEvent || (this.downEvent.type !== "onSpotlightSelect")) {
 			return this.inherited(arguments);
 		}


### PR DESCRIPTION
...to coincide with the rename of enyo.Popup method name change.

This PR may require extensive additional testing, due to what it's changing.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
