### PR TITLE
BHV-752: Undepress button when hidden.

### DIFF
--- a/source/Button.js
+++ b/source/Button.js
@@ -99,5 +99,11 @@ enyo.kind({
 		} else {
 			this.removeClass('min-width');
 		}
+	},
+	showingChanged: function() {
+		this.inherited(arguments);
+		if (!this.showing && this.hasClass('pressed')) {
+			this.undepress();
+		}
 	}
 });


### PR DESCRIPTION
## Issue

If there is one spottable `moon.Button` in the view and the `tap` event hides this button, when you 5-way select this button (causing it to hide) and programmatically unhide it, the `pressed` state of the button is still active.
## Fix

When a `moon.Button` is hidden, we deactivate the `pressed` state if it is currently in that state.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
