### PR TITLE
BHV-731: Fix issue with "Scroll To Index" in moon.DataList sample.

### DIFF
--- a/samples/DataListSample.js
+++ b/samples/DataListSample.js
@@ -10,7 +10,7 @@ enyo.kind({
 						{content: "horizontal"}
 					], style: "vertical-align: top;"},
 					{name: "recordCount", kind: "moon.ExpandableInput", content: "Record Count", value: 1000, onchange: "updateRecords", style: "vertical-align: top;"},
-					{name: "scrollIndex", kind: "moon.ExpandableInput", value: 0, content: "Scroll to Index", onchange: "scrollToIndex", style: "vertical-align: top;"},
+					{name: "scrollIndex", kind: "moon.ExpandableInput", value: 0, content: "Scroll to Index", onblur: "scrollToIndex", style: "vertical-align: top;"},
 					{name: "debugging", kind: "moon.ExpandablePicker", selectedIndex: 0, content: "Page Debugging", components: [
 						{value: false, content: "off"},
 						{value: true, content: "on"}
@@ -50,8 +50,15 @@ enyo.kind({
 		return add;
 	},
 	scrollToIndex: function (sender, event) {
-		this.$.drawers.closeDrawers();
-		this.$.repeater.scrollToIndex(sender.getValue());
+		var newIndex = sender.getValue();
+		if (this.isScrolled && newIndex) {
+			this.$.drawers.closeDrawers();
+			this.$.repeater.scrollToIndex(newIndex);
+			this.isScrolled = false;
+		}
+	},
+	scrollStopped: function() {
+		this.isScrolled = true;
 	},
 	toggleShowing: function (sender) {
 		var showing = ! this.$.repeater.getShowing();
@@ -101,5 +108,5 @@ enyo.kind({
 			{from: ".model.disabled", to: ".$.button.disabled"},
 			{from: ".model.on", to: ".$.button.value", oneWay: false}
 		]}
-	]}
+	], onScrollStop: "scrollStopped"}
 });


### PR DESCRIPTION
## Issue

If the "Scroll To Index" `ExpandableInput` is used to navigate to a specific index, and then scrolling is performed, using "Scroll To Index" will not navigate to the originally navigated index unless the index is changed in the input.
## Fix

Handle the `onblur` instead of the `onchange` event and detect if scrolling has occurred.
## Notes

This adds some code to handle an edge-case; we can weigh the tradeoffs of making these changes or leaving the existing behavior as this may cloud the intention and directness of the original sample.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
