### PR TITLE
BHV-1368: Add wrapper div around ExpandableListItem header.

### DIFF
--- a/source/Accordion.js
+++ b/source/Accordion.js
@@ -42,6 +42,7 @@ enyo.kind({
 	classes: "moon-accordion",
 	components: [
 		{name: "headerWrapper", kind: "moon.Item", classes: "moon-accordion-header-wrapper", onSpotlightFocus: "headerFocus", ontap: "expandContract", components: [
+			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: "headerContainer", classes: "moon-expandable-list-item-header moon-accordion-arrow", components: [
 				{name: "header", kind: "moon.MarqueeText"}
 			]}

--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -67,6 +67,7 @@ enyo.kind({
 	defaultOrdering: null, // set in subkind
 	components: [
 		{name: "headerWrapper", kind: "moon.Item", classes: "moon-date-picker-header-wrapper", onSpotlightFocus: "headerFocus", ontap: "expandContract", components: [
+			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: "headerContainer", classes: "moon-expandable-list-item-header moon-expandable-picker-header", components: [
 				{name: "header", kind: "moon.MarqueeText"}
 			]},

--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -31,6 +31,7 @@ enyo.kind({
 
 	components: [
 		{name: "headerWrapper", kind: "moon.Item", classes: "moon-expandable-picker-header-wrapper", onSpotlightFocus: "headerFocus", ondown: "headerDown", ontap: "expandContract", components: [
+			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: "headerContainer", classes: "moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-input-header", components: [
 				{name: "header", kind: "moon.MarqueeText"}
 			]},

--- a/source/ExpandableIntegerPicker.js
+++ b/source/ExpandableIntegerPicker.js
@@ -49,6 +49,7 @@ enyo.kind({
 	},
 	components: [
 		{name: "headerWrapper", kind: "moon.Item", classes: "moon-expandable-picker-header-wrapper", onSpotlightFocus: "headerFocus", ontap: "expandContract", components: [
+			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: "headerContainer", classes: "moon-expandable-list-item-header moon-expandable-picker-header", components: [
 				{name: "header", kind: "moon.MarqueeText"}
 			]},

--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -82,6 +82,7 @@ enyo.kind({
 		onDrawerAnimationEnd: "drawerAnimationEnd"
 	},
 	components: [
+		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 		{name: "headerContainer", classes: "moon-expandable-picker-header", components: [
 			{name: "header", kind: "moon.Item", onSpotlightFocus: "headerFocus", ontap: "expandContract"}
 		]},

--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -78,6 +78,7 @@ enyo.kind({
 	selectAndCloseDelayMS: 600,
 	components: [
 		{name: "headerWrapper", kind: "moon.Item", classes: "moon-expandable-picker-header-wrapper", onSpotlightFocus: "headerFocus", ontap: "expandContract", components: [
+			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: "headerContainer", classes: "moon-expandable-list-item-header moon-expandable-picker-header", components: [
 				{name: "header", kind: "moon.MarqueeText"}
 			]},


### PR DESCRIPTION
## Issue

In RTL mode, Webkit utilizes `padding-left` inconsistently when calculating `scrollWidth` for an element, causing text within a certain range (usually just beyond what can be displayed without a marquee) to not marquee.
## Fix

We bypass the use of padding for the `MarqueeItem` and instead wrap with a div that we apply padding to.
## Notes

In RTL mode, Webkit will ignore `padding-left` up to a certain point, returning a `scrollWidth` value that is either equal to the content width, the `clientWidth`, or the total horizontal padding, whichever is greater.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
