### PR TITLE
BHV-753: Waterfall onShowingChanged event in Panels.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -612,7 +612,7 @@ enyo.kind({
 				this.resetHandleAutoHide();
 				this._hide();
 			}
-			this.waterfallShowingChanged(inOldValue);
+			this.sendShowingChangedEvent(inOldValue);
 		}
 		else {
 			this.inherited(arguments);


### PR DESCRIPTION
## Issue

When a `Panels` control is hidden, followed by its parent being hidden, if this is reversed (parent is shown, followed by the `Panels` control being shown), the marquee is stuck.
## Fix

This issue only occurs when hiding the parent after hiding the `Panels` control because hiding `Panels` does not set `display:none`; hiding the parent actually hides the `Panels` control, which causes the marquee transition to stop. When the parent is unhidden, the `onShowingChanged` is not yet waterfalled to the marquee because `Panels` has property `showing:false`, and when `Panels` is unhidden, the `onShowingChanged` is never waterfalled in the overridden `showingChanged` handler of `Panels`, so we make a call to the new `sendShowingChangedEvent` function.
## Notes

This PR is dependent on an Enyo PR: https://github.com/enyojs/enyo/pull/678

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
