### PR TITLE
BHV-725: VideoTransportSlider now watches the enyo event "move"

### DIFF
--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -97,7 +97,7 @@ enyo.kind({
 		this.inherited(arguments);
 		this.$.popup.setAutoDismiss(false);		//* Always showing popup
 		this.$.popup.captureEvents = false;		//* Hot fix for bad originator on tap, drag ...
-		this.$.tapArea.onmousemove = "preview";
+		this.$.tapArea.onmove = "preview";
 		this.$.tapArea.onenter = "enterTapArea";
 		this.$.tapArea.onleave = "leaveTapArea";
 		//* Extend components


### PR DESCRIPTION
...instead of the DOM event "mousemove". This allows the scroller to track the mouse position even when the screen is being scaled for lower resolutions, instead of the cursor being consistently off-its-mark.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
