### PR TITLE
ANG-2680: Allow for multiple, consecutive spaces in caption of GridListImageItem.

### DIFF
--- a/css/GridList.less
+++ b/css/GridList.less
@@ -20,6 +20,7 @@
 	}
 	.caption {
 		.moon-sub-header-text;
+		white-space: pre !important;
 	}
 	&.no-center {
 		.caption, 

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -2001,6 +2001,7 @@
   font-style: normal;
   letter-spacing: 0;
   color: #a6a6a6;
+  white-space: pre !important;
 }
 .moon-gridlist-imageitem.no-center .caption,
 .moon-gridlist-imageitem.no-center .sub-caption {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -2001,6 +2001,7 @@
   font-style: normal;
   letter-spacing: 0;
   color: #4b4b4b;
+  white-space: pre !important;
 }
 .moon-gridlist-imageitem.no-center .caption,
 .moon-gridlist-imageitem.no-center .sub-caption {


### PR DESCRIPTION
## Issue

Multiple, consecutive spaces are condensed into one space for the caption of a `GridListImageItem`.
## Fix

We set the `white-space` property value to `pre` for the caption.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
