### PR TITLE
ANG-2680: Allow for multiple, consecutive spaces in MarqueeItem.

### DIFF
--- a/css/Marquee.less
+++ b/css/Marquee.less
@@ -20,6 +20,7 @@
 		text-overflow: ellipsis;
 		overflow: hidden;
 		width: 100%;
+	    white-space: pre !important;
 		
 		transition-property: transform;
 		-moz-transition-property: transform;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -798,6 +798,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   width: 100%;
+  white-space: pre !important;
   transition-property: transform;
   -moz-transition-property: transform;
   -webkit-transition-property: -webkit-transform;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -798,6 +798,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   width: 100%;
+  white-space: pre !important;
   transition-property: transform;
   -moz-transition-property: transform;
   -webkit-transition-property: -webkit-transform;

--- a/samples/ButtonSample.js
+++ b/samples/ButtonSample.js
@@ -8,67 +8,69 @@ enyo.kind({
 
 				{kind: "moon.Divider", content: "Buttons:"},
 				{kind: "moon.TooltipDecorator", components: [
-					{name: "A Button", kind: "moon.Button", minWidth: false, content: "A", ontap: "buttonTapped"},
+					{name: "aButton", kind: "moon.Button", minWidth: false, content: "A", ontap: "buttonTapped"},
 					{kind: "moon.Tooltip", content:"minWidth: false"}
 				]},
 				{kind: "moon.TooltipDecorator", components: [
-					{name: "B Button", kind: "moon.Button", content: "B", ontap: "buttonTapped"},
+					{name: "bButton", kind: "moon.Button", content: "B", ontap: "buttonTapped"},
 					{kind: "moon.Tooltip", content:"minWidth: true"}
 				]},
-				{name: "Button", kind: "moon.Button", content: "Button", ontap: "buttonTapped"},
-				{name: "Disabled Button", kind: "moon.Button", disabled: true, content: "Disabled Button", ontap: "buttonTapped"},
-				{name: "Long Button", kind: "moon.Button", content: "Looooooooooooooooong Button", ontap: "buttonTapped"},
+				{name: "button", kind: "moon.Button", content: "Button", ontap: "buttonTapped"},
+				{name: "disabledButton", kind: "moon.Button", disabled: true, content: "Disabled Button", ontap: "buttonTapped"},
+				{name: "longButton", kind: "moon.Button", content: "Looooooooooooooooong Button", ontap: "buttonTapped"},
+				{name: "spacesButton", kind: "moon.Button", content: "Button   with   extra   spaces", ontap: "buttonTapped"},
 				{tag: "br"},
 				{tag: "br"},
 
 				{kind: "moon.Divider", content: "Small Buttons:"},
-				{name: "Small A Button", kind: "moon.Button", small: true, minWidth: false, content: "A", ontap: "buttonTapped"},
-				{name: "Small B Button", kind: "moon.Button", small: true, content: "B", ontap: "buttonTapped"},
-				{name: "Small Button", kind: "moon.Button", small: true, content: "Button", ontap: "buttonTapped"},
-				{name: "Small Disabled Button", kind: "moon.Button", small: true, disabled: true, content: "Disabled Button", ontap: "buttonTapped"},
-				{name: "Small Long Button", kind: "moon.Button", small: true, content: "Loooooooooooooooooooooooong Button", ontap: "buttonTapped"},
+				{name: "smallAButton", kind: "moon.Button", small: true, minWidth: false, content: "A", ontap: "buttonTapped"},
+				{name: "smallBButton", kind: "moon.Button", small: true, content: "B", ontap: "buttonTapped"},
+				{name: "smallButton", kind: "moon.Button", small: true, content: "Button", ontap: "buttonTapped"},
+				{name: "smallDisabledButton", kind: "moon.Button", small: true, disabled: true, content: "Disabled Button", ontap: "buttonTapped"},
+				{name: "smallLongButton", kind: "moon.Button", small: true, content: "Loooooooooooooooooooooooong Button", ontap: "buttonTapped"},
+				{name: "smallSpacesButton", kind: "moon.Button", small:true, content: "Button   with   extra   spaces", ontap: "buttonTapped"},
 				{kind: "moon.ToggleItem", classes: "tap-area-toggle-container", content: "Show Tap Area", onActivate: "showSmallButtonTapArea"},
 				{tag: "br"},
 				{tag: "br"},
 
 				{kind: "moon.Divider", content: "Captioned Buttons:"},
 				{kind: "moon.CaptionDecorator", side: "top", content: "Pow", components: [
-					{name: "Captioned Button A", kind: "moon.Button", content: "A", ontap: "buttonTapped"}
+					{name: "captionedAButton", kind: "moon.Button", content: "A", ontap: "buttonTapped"}
 				]},
 				{kind: "moon.CaptionDecorator", side: "right", content: "Boom", components: [
-					{name: "Captioned Button B", kind: "moon.Button", content: "B", ontap: "buttonTapped"}
+					{name: "captionedBButton", kind: "moon.Button", content: "B", ontap: "buttonTapped"}
 				]},
 				{kind: "moon.CaptionDecorator", side: "bottom", content: "Crash", components: [
-					{name: "Captioned Button C", kind: "moon.Button", content: "C", ontap: "buttonTapped"}
+					{name: "captionedCButton", kind: "moon.Button", content: "C", ontap: "buttonTapped"}
 				]},
 				{kind: "moon.CaptionDecorator", side: "left", content: "Bang", components: [
-					{name: "Captioned Button D", kind: "moon.Button", content: "D", ontap: "buttonTapped"}
+					{name: "captionedDButton", kind: "moon.Button", content: "D", ontap: "buttonTapped"}
 				]},
 				{tag: "br"},
 				{tag: "br"},
 
 				{kind: "moon.Divider", content: "Captioned Buttons with showOnFocus option:"},
 				{kind: "moon.CaptionDecorator", side: "top", showOnFocus: true, content: "Pow", components: [
-					{name: "showOnFocus Caption Top", kind: "moon.Button", content: "Top", ontap: "buttonTapped"}
+					{name: "showOnFocusCaptionTopButton", kind: "moon.Button", content: "Top", ontap: "buttonTapped"}
 				]},
 				{kind: "moon.CaptionDecorator", side: "bottom", showOnFocus: true, content: "Crash", components: [
-					{name: "showOnFocus Caption Bottom", kind: "moon.Button", content: "Bottom", ontap: "buttonTapped"}
+					{name: "showOnFocusCaptionBottomButton", kind: "moon.Button", content: "Bottom", ontap: "buttonTapped"}
 				]},
 				{style: "display:inline-block;", classes:"moon-2h"},
 				{kind: "moon.CaptionDecorator", side: "left", showOnFocus: true, content: "Bang", components: [
-					{name: "showOnFocus Caption Left", kind: "moon.Button", content: "Left", ontap: "buttonTapped"}
+					{name: "showOnFocusCaptionLeftButton", kind: "moon.Button", content: "Left", ontap: "buttonTapped"}
 				]},
 				{kind: "moon.CaptionDecorator", side: "right", showOnFocus: true, content: "Boom", components: [
-					{name: "showOnFocus Caption Right", kind: "moon.Button", content: "Right", ontap: "buttonTapped"}
+					{name: "showOnFocusCaptionRightButton", kind: "moon.Button", content: "Right", ontap: "buttonTapped"}
 				]},
 				{tag: "br"},
 				{tag: "br"},
 
 				{kind: "moon.Divider", content: "Grouped Buttons:"},
 				{kind: "enyo.Group", classes: "moon-button-sample-group", components: [
-					{name: "Apple Button", kind: "moon.Button", content: "Apple", ontap: "buttonTapped"},
-					{name: "Banana Button", kind: "moon.Button", content: "Banana", ontap: "buttonTapped"},
-					{name: "Saskatoonberry Button", kind: "moon.Button", content: "Saskatoonberry", ontap: "buttonTapped"}
+					{name: "appleButton", kind: "moon.Button", content: "Apple", ontap: "buttonTapped"},
+					{name: "bananaButton", kind: "moon.Button", content: "Banana", ontap: "buttonTapped"},
+					{name: "saskatoonberryButton", kind: "moon.Button", content: "Saskatoonberry", ontap: "buttonTapped"}
 				]}
 			]}
 		]},
@@ -80,17 +82,19 @@ enyo.kind({
 	},
 	showSmallButtonTapArea: function(inSender, inEvent) {
 		if (inEvent.checked) {
-			this.$["Small A Button"].addClass("visible-tap-area");
-			this.$["Small B Button"].addClass("visible-tap-area");
-			this.$["Small Button"].addClass("visible-tap-area");
-			this.$["Small Disabled Button"].addClass("visible-tap-area");
-			this.$["Small Long Button"].addClass("visible-tap-area");
+			this.$.smallAButton.addClass("visible-tap-area");
+			this.$.smallBButton.addClass("visible-tap-area");
+			this.$.smallButton.addClass("visible-tap-area");
+			this.$.smallDisabledButton.addClass("visible-tap-area");
+			this.$.smallLongButton.addClass("visible-tap-area");
+			this.$.smallSpacesButton.addClass("visible-tap-area");
 		} else {
-			this.$["Small A Button"].removeClass("visible-tap-area");
-			this.$["Small B Button"].removeClass("visible-tap-area");
-			this.$["Small Button"].removeClass("visible-tap-area");
-			this.$["Small Disabled Button"].removeClass("visible-tap-area");
-			this.$["Small Long Button"].removeClass("visible-tap-area");
+			this.$.smallAButton.removeClass("visible-tap-area");
+			this.$.smallBButton.removeClass("visible-tap-area");
+			this.$.smallButton.removeClass("visible-tap-area");
+			this.$.smallDisabledButton.removeClass("visible-tap-area");
+			this.$.smallLongButton.removeClass("visible-tap-area");
+			this.$.smallSpacesButton.removeClass("visible-tap-area");
 		}
 	}
 });

--- a/samples/HeaderSample.js
+++ b/samples/HeaderSample.js
@@ -8,27 +8,35 @@ enyo.kind({
 				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png", ontap:"likeBig"},
 				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-next.png", ontap:"shareBig"}
 			]},
-			{style:"height:20px;"},
+			{classes: "moon-1v"},
 			{kind: "moon.Header", name:"smallHeader", content: "Small Header", small: true, titleAbove: "03", titleBelow: "Sub Header", subTitleBelow:"Sub-sub Header", components: [
 				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png", ontap:"likeSmall"},
 				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-next.png", ontap:"shareSmall"}
 			]},
-			{style:"height:20px;"},
-			{kind: "moon.Header", content: "Header 헤더 ヘッダ ylätunniste כותרת رأس Kopfzeile", titleAbove: "02", titleBelow: "Header 헤더 ヘッダ ylätunniste כותרת رأس Kopfzeile Header 헤더 ヘッダ ylätunniste כותרת رأس Kopfzeile Header 헤더 ヘッダ ylätunniste כותרת رأس Kopfzeile", subTitleBelow: "Titles will truncate/marquee"},
+			{classes: "moon-1v"},
 			{kind: "moon.Header", content: "Varied Alignment", titleAbove: "02", titleBelow: "Panel actions can be positioned on left or right", components: [
 				{kind: "moon.Button", small:true, content:"Left", classes:"moon-header-left"},
 				{kind: "moon.Button", small:true, content:"aligned", classes:"moon-header-left"},
 				{kind: "moon.Button", small:true, content:"Right"},
 				{kind: "moon.Button", small:true, content:"Aligned"}
 			]},
-			{style:"height:20px;"},
+			{classes: "moon-1v"},
 			{kind: "moon.Header", name:"switchHeader", content: "Static Title", placeholder:"Type Here", titleAbove: "03", titleBelow: "Header title can be changed to an input", subTitleBelow:"Press 'Switch Mode' button, which sets 'inputMode:true'", components: [
-				{kind: "moon.Button", small:true, content:"Switch Mode", ontap : "switchMode"}
+				{kind: "moon.Button", small:true, content:"Switch Mode", ontap: "switchMode", header: "switchHeader"}
 			]},
+			{classes: "moon-1v"},
 			{kind: "moon.Header", name:"imageHeader", content: "Header with Image", titleAbove: "02", titleBelow: "Sub Header", subTitleBelow:"Sub-sub Header", fullBleedBackground:true, backgroundSrc: "http://lorempixel.com/g/1920/360/abstract/2/", components: [
 				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png", classes:"moon-header-left"},
 				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png"},
 				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-next.png"}
+			]},
+			{classes: "moon-1v"},
+			{kind: "moon.Header", name:"marqueeHeader", content: "Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span>", allowHtml:true, titleAbove: "02", titleBelow: "Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span> Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span>   Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span>   Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span>", subTitleBelow: "Titles will truncate/marquee", components: [
+				{kind: "moon.Button", small:true, content:"Switch Mode", ontap: "switchMode", header: "marqueeHeader"}
+			]},
+			{classes: "moon-1v"},
+			{kind: "moon.Header", name:"marqueeHeaderSmall", small:true, content: "Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span>", allowHtml:true, titleAbove: "02", titleBelow: "Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span> Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span>   Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span>   Header   헤더    ヘッダ    ylätunniste    כותרת    رأس    Kopfzeile  ẫ Ẫ گ Ů <span style='text-transform:none'>j p q g</span>", subTitleBelow: "Titles will truncate/marquee", components: [
+				{kind: "moon.Button", small:true, content:"Switch Mode", ontap: "switchMode", header: "marqueeHeaderSmall"}
 			]}
 		]}
 	],
@@ -45,6 +53,7 @@ enyo.kind({
 		this.$.smallHeader.setSubTitleBelow("Please share Enyo.");
 	},
 	switchMode: function(inSender, inEvent) {
-		this.$.switchHeader.setInputMode(!this.$.switchHeader.getInputMode());
+		var header = this.$[inSender.header];
+		header.setInputMode(!header.getInputMode());
 	}
 });

--- a/samples/ItemSample.js
+++ b/samples/ItemSample.js
@@ -9,7 +9,8 @@ enyo.kind({
 					{kind: "moon.Item", content: "Item 1"},
 					{kind: "moon.Item", content: "Item 2"},
 					{kind: "moon.Item", content: "Item 3"},
-					{kind: "moon.Item", content: "Item with very long text that should truncate"}
+					{kind: "moon.Item", content: "Item with very long text that should truncate"},
+					{kind: "moon.Item", content: "Item   with   extra   spaces   that   should   truncate"}
 				]
 			}
 		]}


### PR DESCRIPTION
## Issue

Multiple, consecutive spaces are collapsed into one space in a number of controls, including the caption of a `GridListImageItem` and the title of a `VideoPlayer`.
## Fix

We make a general fix for all `MarqueeItem` controls and set the `white-space` property value to `pre`. I went through all the `Moonstone` samples and didn't notice any side effects from this modification.
## Notes

This also addresses GF-61555.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
