### PR TITLE
ANG-2398: Fix moon.DataList to support rtl in horizontal case

### DIFF
--- a/source/DataList.js
+++ b/source/DataList.js
@@ -112,7 +112,7 @@ moon.DataListSpotlightSupport = {
 				cb.top += pb.top;
 				cb.left += pb.left;
 				// Return the first spottable child whose top/left are inside the viewport
-				if ((cb.top >= inScrollBounds.top) && (cb.left >= inScrollBounds.left)) {
+				if ((cb.top >= inScrollBounds.top) && ((this.rtl ? (inScrollBounds.width - (cb.left + cb.width)) : cb.left) >= inScrollBounds.left)) {
 					if (enyo.Spotlight.isSpottable(c)) {
 						return c;
 					}


### PR DESCRIPTION
ANG-2398: Fix DataList to support rtl in horizontal case

This fix makes getFirstVisibleChild return normal value in horizontal & rtl case.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
