### PR TITLE
Drawers overlaid on top of a video player make the video controls inaccessible

### DIFF
--- a/css/Drawers.less
+++ b/css/Drawers.less
@@ -118,11 +118,11 @@
 	width:100%;
 }
 
-/* If a video player or other controls are behind the drawers, let events pass straight trough to them. */
-.moon-drawers {
-	pointer-events: none;
-}
-.moon-drawers-activator-wrapper,
-.moon-drawers-drawer-container {
+/* If a video player or other controls are behind the drawers, let events pass straight through to them. */
+.moon-drawers > * {
 	pointer-events: all;
+}
+.moon-drawers,
+.moon-drawers-client {
+	pointer-events: none;
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3477,13 +3477,13 @@
   height: 100%;
   width: 100%;
 }
-/* If a video player or other controls are behind the drawers, let events pass straight trough to them. */
-.moon-drawers {
-  pointer-events: none;
-}
-.moon-drawers-activator-wrapper,
-.moon-drawers-drawer-container {
+/* If a video player or other controls are behind the drawers, let events pass straight through to them. */
+.moon-drawers > * {
   pointer-events: all;
+}
+.moon-drawers,
+.moon-drawers-client {
+  pointer-events: none;
 }
 /* Scrim.css */
 .moon-scrim {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3473,13 +3473,13 @@
   height: 100%;
   width: 100%;
 }
-/* If a video player or other controls are behind the drawers, let events pass straight trough to them. */
-.moon-drawers {
-  pointer-events: none;
-}
-.moon-drawers-activator-wrapper,
-.moon-drawers-drawer-container {
+/* If a video player or other controls are behind the drawers, let events pass straight through to them. */
+.moon-drawers > * {
   pointer-events: all;
+}
+.moon-drawers,
+.moon-drawers-client {
+  pointer-events: none;
 }
 /* Scrim.css */
 .moon-scrim {


### PR DESCRIPTION
Fix by letting events pass straight trough the translucent parts of drawers to the background elements.
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
