### PR TITLE
BHV-2112: Facade the allowHtml property of moon.GridListImageItem onto its children...

### DIFF
--- a/source/GridListImageItem.js
+++ b/source/GridListImageItem.js
@@ -20,6 +20,10 @@ enyo.kind({
 		caption: { kind:"moon.MarqueeText" },
 		subCaption: { kind:"moon.MarqueeText" }
 	},
+	bindings: [
+		{from: ".allowHtml", to: ".$.caption.allowHtml"},
+		{from: ".allowHtml", to: ".$.subCaption.allowHtml"}
+	],
 	handlers: {
 		onSpotlightFocus: "focused"
 	},


### PR DESCRIPTION
... so they can display HTML instead of only plain text.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
