### PR TITLE
BHV-2416: Facade allowHtmlHeader to breadcrumb's allowHtml property

### DIFF
--- a/source/Panel.js
+++ b/source/Panel.js
@@ -82,6 +82,7 @@ enyo.kind({
 		{from: ".subTitleBelow", to: ".$.header.subTitleBelow"},
 		{from: ".smallHeader", to: ".$.header.small"},
 		{from: ".allowHtmlHeader", to: ".$.header.allowHtml"},
+		{from: ".allowHtmlHeader", to: ".$.breadcrumbText.allowHtml"},
 		{from: ".headerBackgroundSrc", to: ".$.header.backgroundSrc"},
 		{from: ".headerBackgroundPosition", to: ".$.header.backgroundPosition"}
 	],


### PR DESCRIPTION
... to match the header text.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
