### PR TITLE
BHV-2417: Set moon.Icons to center text-align when inside moon.Header client area

### DIFF
--- a/css/Header.less
+++ b/css/Header.less
@@ -100,7 +100,8 @@
 	text-align: left;	/* fallback in case text-align:start isn't supported */
 	text-align: start;	/* CSS3 for RTL support */
 }
-.moon-header-client > .moon-button {
+.moon-header-client > .moon-button,
+.moon-header-client > .moon-icon {
   text-align: center;	/* Overrides the text-align property  for button */
 }
 

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1929,7 +1929,8 @@
   /* CSS3 for RTL support */
 
 }
-.moon-header-client > .moon-button {
+.moon-header-client > .moon-button,
+.moon-header-client > .moon-icon {
   text-align: center;
   /* Overrides the text-align property  for button */
 

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1929,7 +1929,8 @@
   /* CSS3 for RTL support */
 
 }
-.moon-header-client > .moon-button {
+.moon-header-client > .moon-button,
+.moon-header-client > .moon-icon {
   text-align: center;
   /* Overrides the text-align property  for button */
 


### PR DESCRIPTION
There was a change to Header.less which assigned all children of a moon-header-client element to be "start" aligned. moon.Buttons had an explicit override rule to allow them to retain their centered alignment. Adding moon-icon to this rule-set extended this to moon.Icon and moon.IconButton kinds.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
