### PR TITLE
BHV-2446: Check that focus has actually left the scroller before hiding scroll columns.

### DIFF
--- a/source/Scroller.js
+++ b/source/Scroller.js
@@ -76,6 +76,7 @@ enyo.kind({
 		onSpotlightScrollDown:"spotlightWheel",
 		onSpotlightContainerEnter: "spotlightHello",
 		onSpotlightFocus: "spotlightHello",
+		onSpotlightBlur: "spotlightControlChanged",
 		onSpotlightContainerLeave: "spotlightGoodbye"
 	},
 	//* If true, scroll events are not allowed to propagate
@@ -145,9 +146,13 @@ enyo.kind({
 	},
 	// When 5-way focus leaves scroller, hide the scroll columns
 	spotlightGoodbye: function(inSender, inEvent) {
-		if (inEvent.originator === this && this.$.strategy.showHideScrollColumns) {
+		if (inEvent.originator === this && this.$.strategy.showHideScrollColumns && 
+			this.lastSpottedControl !== enyo.Spotlight.getCurrent()) {
 			this.$.strategy.showHideScrollColumns(false);
 		}
+	},
+	spotlightControlChanged: function(inSender, inEvent) {
+		this.lastSpottedControl = inEvent.originator;
 	},
 	previewDomEvent: function(inEvent) {
 		if (this.scrollWheelMovesFocus) {


### PR DESCRIPTION
## Issue

When pressing a 5-way direction key inside a scroller (i.e. `moon.DataList`), the scroll columns will be hidden even if focus doesn't end up leaving the scroller.
## Fix

When the `onSpotlightContainerLeave` event is handled, we check that the currently spotted control is not the same control that was spotted when leaving the container.
## Notes

Can someone check my logic here - the `onSpotlightContainerLeave` event is sent to the originating container after the next control is spotted, as `onSpotlightContainerLeave` is dispatched via the `onSpotlightFocused` event of that container. This should always occur after `onSpotlightFocus` has spotted the next control, but I wanted to make sure there weren't any potential timing issues.

This PR is related to a Spotlight PR: https://github.com/enyojs/spotlight/pull/125

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
