### PR TITLE
Added "dismissOnEnter" support to input-headers.

### DIFF
--- a/samples/HeaderSample.js
+++ b/samples/HeaderSample.js
@@ -25,6 +25,7 @@ enyo.kind({
 				{kind: "moon.Button", small:true, content:"Switch Mode", ontap: "switchMode", header: "switchHeader"}
 			]},
 			{classes: "moon-1v"},
+			{kind: "moon.Header", name:"inputHeaderDismiss", inputMode: true, dismissOnEnter: true, content: "Input-style Header", placeholder:"Type Here", titleAbove: "03", titleBelow: "InputHeader blurs-focus when pressing Enter", subTitleBelow:"", onchange:"handleChange"},
 			{kind: "moon.Header", name:"imageHeader", content: "Header with Image", titleAbove: "02", titleBelow: "Sub Header", subTitleBelow:"Sub-sub Header", fullBleedBackground:true, backgroundSrc: "http://lorempixel.com/g/1920/360/abstract/2/", components: [
 				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png", classes:"moon-header-left"},
 				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png"},
@@ -55,5 +56,8 @@ enyo.kind({
 	switchMode: function(inSender, inEvent) {
 		var header = this.$[inSender.header];
 		header.setInputMode(!header.getInputMode());
+	},
+	handleChange: function(inSender, inEvent) {
+		this.$.inputHeaderDismiss.set("subTitleBelow", "Changed: " + inSender.getValue());
 	}
 });

--- a/source/Header.js
+++ b/source/Header.js
@@ -29,6 +29,8 @@ enyo.kind({
 		fullBleedBackground: false,
 		//* If true, title will be an input
 		inputMode: false,
+		//* When true, blur on Enter keypress (if focused)
+		dismissOnEnter: false,
 		//* Text to display when the input is empty
 		placeholder: "",
 		//* The value of the input
@@ -69,7 +71,7 @@ enyo.kind({
 			}, {
 				name: "inputDecorator",
 				kind: "moon.InputDecorator",
-				classes: 'moon-input-header-input-decorator',
+				classes: "moon-input-header-input-decorator",
 				canGenerate: false,
 				components: [{
 					name: "titleInput",
@@ -94,11 +96,10 @@ enyo.kind({
 		kind: "enyo.StyleAnimator",
 		onComplete: "animationComplete"
 	}],
-	bindings: [{
-		from: ".value",
-		to: ".$.titleInput.value",
-		oneWay: false
-	}],
+	bindings: [
+		{from: ".value", to: ".$.titleInput.value", oneWay: false},
+		{from: ".dismissOnEnter", to: ".$.titleInput.dismissOnEnter"}
+	],
 	create: function() {
 		this.inherited(arguments);
 		this.smallChanged();


### PR DESCRIPTION
Updated HeaderSample with example.
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com

Conflicts:
    samples/HeaderSample.js
