### PR TITLE
ANG-4207: remove animation effect.

### DIFF
--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -67,7 +67,7 @@ enyo.kind({
 				sup.apply(this, arguments);
 				this.updateMetrics(list);
 				list.refresh();
-				list.$.scroller.scrollTo(0, 0);
+				list.$.scroller.scrollTo(0, 0, false);
 			};
 		}),
 		updateBounds: enyo.inherit(function (sup) {


### PR DESCRIPTION
We removed animation effect from DataList but DataGridList still has it.
Animation effect is useless when reset() is called.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
