### PR TITLE
ANG-4775: Use enyo.perfNow instead of enyo.now on StyleAnimator and check duration to make sure animation ends

### DIFF
--- a/source/StyleAnimator.js
+++ b/source/StyleAnimator.js
@@ -359,7 +359,7 @@ enyo.kind({
 	_durationChecker: function(inName) {
 		var animation = this.getAnimation(inName);
 
-		animation.durationCheckerJob = undefined;
+		animation.durationCheckerJob = null;
 
 		if (animation.state === "paused") {
 			return;


### PR DESCRIPTION
The StyleAnimator can go into infinite loop because duration check based on enyo.now can be negative. So, changing enyo.now to enyo.perfNow on StyleAnimator. 

And, also adding duration checker to make sure that all the animations are in finished status on duration timeout.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
