### PR TITLE
ENYO-3600: Update documentation to not reference deprecated method.

### DIFF
--- a/source/Scroller.js
+++ b/source/Scroller.js
@@ -2,12 +2,11 @@
 	_moon.Scroller_ extends [enyo.Scroller](#enyo.Scroller), adding support for
 	5-way focus (Spotlight) and pagination buttons.
 
-	_moon.Scroller_ responds to the _onSpotlightFocused_ event by scrolling the
-	event originator into view. This ensures that 5-way (Spotlight) focused
-	controls are always in view.
-
-	In addition, _moon.Scroller_ responds to explicit/programmatic requests from
+	_moon.Scroller_ responds to explicit/programmatic requests from
 	controls to be scrolled into view via the _onRequestScrollIntoView_ event.
+	These requests are generally made in response to the _onSpotlightFocused_
+	event handled by these controls and ensures that 5-way (Spotlight) focused
+	controls are in view.
 
 	For more information, see the documentation on
 	[Scrollers](building-apps/layout/scrollers.html) in the Enyo Developer Guide.


### PR DESCRIPTION
This commit removed the deprecated method in question: https://github.com/enyojs/moonstone/commit/f8b87346e0b1e9bb1fcf39b36d27e511c7ea8719

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
