### PR TITLE
BHV-3613: Ensure a list that is focused before render transfers focus to...

### DIFF
--- a/source/DataList.js
+++ b/source/DataList.js
@@ -37,14 +37,22 @@ moon.DataListSpotlightSupport = {
 	_indexToFocus: -1,
 	_subChildToFocus: null,
 	didRender: function () {
-		// Since we delay rendering (potentially spottable) children by default, spotlight on the list is
-		// true by default; once we render, we check if the list was focused and if so, transfer
-		// focus to the first spottable child inside
+		// Lists are set to spotlight:true by default, which allows them to receive focus before
+		// children are rendered; once rendred, it becomes spotlight:false, and the code below 
+		// ensures spotlight is transferred inside the list once rendering is complete
 		this.spotlight = false;
+		// If there is a queued index to focus (or an initialFocusIndex), focus that item now that
+		// the list is rendered
 		var index = (this._indexToFocus > -1) ? this._indexToFocus : this.initialFocusIndex;
 		if (index > -1) {
 			this.focusOnIndex(index);
 			this._indexToFocus = -1;
+		} else {
+			// Otherwise, check if the list was focused and if so, transfer focus to the first 
+			// spottable child inside
+			if (enyo.Spotlight.getCurrent() == this) {
+				enyo.Spotlight.spot(this);
+			}
 		}
 	},
 	didScroll: enyo.inherit(function (sup) {


### PR DESCRIPTION
... first spottable child once rendered if no specific index is otherwise set to be focused.

DCO-1.1-Signed-Off-By: Kevin Schaaf kevin.schaaf@lge.com
