### PR TITLE
ENYO-3944: Add Sampler support for IE8

### DIFF
--- a/source/moon-fonts.js
+++ b/source/moon-fonts.js
@@ -140,8 +140,12 @@
 			if (!styleElem) {
 				styleElem = document.createElement("style");
 				styleElem.setAttribute("id", styleId);
-				// ENYO-3944: Using getElementsByTagName('head') for IE8 Sampler support
-				document.getElementsByTagName('head')[0].appendChild(styleElem);
+				if (enyo.platform.ie === 8) {
+					// ENYO-3944: Using getElementsByTagName('head') for IE8 Sampler support
+					document.getElementsByTagName('head')[0].appendChild(styleElem);
+				} else {
+					document.head.appendChild(styleElem);
+				}
 			}
 
 			// Build all the fonts so they could be explicitly called


### PR DESCRIPTION
Moonstone is loaded into the Sampler, which has support for IE8. This requires Moonstone to be a little more supportive.
This is PR 2 for JIRA: ENYO-3944.
Related PR: https://github.com/enyojs/enyo-ilib/pull/60
Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas jeremy.thomas@lge.com
