### PR TITLE
Remove unnecessary if-checks in MoonScrollStrategy.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -322,12 +322,7 @@ enyo.kind({
 	scrollMathScroll: function() {
 		this.inherited(arguments);
 
-		if (this.hovering) {
-			this.enableDisablePageControls();
-		} else {
-			this.hidePageControls();
-		}
-
+		this.enableDisablePageControls();
 		this.showHideScrollColumns(true);
 	},
 	//* Scrolls to specific x/y positions within the scroll area.


### PR DESCRIPTION
The `scrollMathScroll` method is doing more work than necessary. The `enableDisablePageControls` method already does a `this.hovering` check, and fires the `hidePageControls` method if it's not hovering. This change flattens this method and removes unnecessary redundancy.

This is non-urgent and not based on an issue-ticket; just a minor optimization.
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
