### PR TITLE
Added a set of options to moon.Panels.pushPanels() to make it more convenient

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -115,8 +115,14 @@ enyo.kind({
 		this.setIndex(lastIndex+1);
 		return oPanel;
 	},
-	//* Creates multiple panels on top of the stack and updates index to select
-	//* the last one created.
+	/**
+		Creates multiple panels on top of the stack and updates index to select
+		the last one created. Supports an optional options object as the third parameter.
+		{
+			setIndex: <indexNumber>,	// The panel index number to immediately switch to.
+			transition: true	// Whether to transition or jump directly to the next panel.
+		}
+	*/
 	pushPanels: function(inInfos, inCommonInfo, inOptions) { // added
 		if (!inOptions) { inOptions = {}; }
 		var lastIndex = this.getPanels().length - 1,


### PR DESCRIPTION
### New Options
- setIndex: automatically switch to any panel after creation.
- transition: default true, ability to disable the transition, and jump immediately to the new panel index.

_Existing functionality is unaltered._
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
