### PR TITLE
BHV-5887: Prevent Spotlight from highlighting controls during panel transition.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -385,6 +385,7 @@ enyo.kind({
 		if (this.shouldArrange()) {
 			if (this.animate) {
 				this.transitionInProgress = true;
+				enyo.Spotlight.mute(this);
 				this.triggerPreTransitions();
 			}
 			else {
@@ -539,7 +540,7 @@ enyo.kind({
 		this.inherited(arguments);
 
 		// Spot the active panel
-		if (this.hasNode()) {
+		if (this.hasNode() && !this.animate) {
 			enyo.Spotlight.spot(this.getActive());
 		}
 
@@ -584,6 +585,8 @@ enyo.kind({
 		if (this.queuedIndex !== null) {
 			this.setIndex(this.queuedIndex);
 		}
+
+		enyo.Spotlight.unmute(this);
 	},
 	/**
 		Override the default _getShowing()_ behavior to avoid setting _this.showing_


### PR DESCRIPTION
## Issue

Controls can be spotted during a panel transition, which can trigger unnecessary repaints.
## Fix

We utilize the `Muter` in `Spotlight` to mute Spotlight events during panel transitions.
## Notes

This PR is dependent on a Spotlight PR: https://github.com/enyojs/spotlight/pull/126

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
