### PR TITLE
ANG-6861: After call setDisable(false), an accordion doesn't open when it was disabled by setDisable(true) from open status.

### DIFF
--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -117,7 +117,7 @@ enyo.kind({
 
 		this.addRemoveClass("disabled", disabled);
 		if (disabled) {
-			this.setOpen(false);
+			this.setActive(false);
 		}
 	},
 	activeChanged: function() {


### PR DESCRIPTION
The properties for this action, 'open' and 'active', will make a bug from 'toggleActive' function in moon.ExpandableListItem.
When 'disabledChanged' is called by changing 'disabled' property, It only handles 'open' property using 'setOpen' function.
In this PR, the bug is fixed using 'setActive' function in 'disabledChanged' handler.

DCO-1.1-Signed-Off-By: Jungchae Kim jungchae.kim@lge.com
