### PR TITLE
ANG-7045: Fix moon.Calendar calculation of month days.

### DIFF
--- a/source/Calendar.js
+++ b/source/Calendar.js
@@ -34,7 +34,10 @@ enyo.kind({
 	},
 	valueChanged: function() {
 		if (typeof ilib !== "undefined") {
-			var date = ilib.Date.newInstance({unixtime: (this.value.getDate() - 1) * (24*60*60*1000)});
+			var date = ilib.Date.newInstance({
+				unixtime: this.value.getTime(),
+				timezone: "local"
+			});
 			this.setContent(this._tf.format(date));
 		} else {
 			this.setContent(this.value.getDate());
@@ -395,8 +398,7 @@ enyo.kind({
 	*/
 	getMonthLength: function(inYear, inMonth) {
 		if (typeof ilib !== "undefined") {
-			var d = ilib.Date.newInstance({unixtime: this.value.getTime()});
-			var cal = ilib.Cal.newInstance({name: d.getCalendar()});
+			var cal = ilib.Cal.newInstance();
 			return cal.getMonLength(inMonth + 1, inYear);
 		} else {
 			return 32 - new Date(inYear, inMonth, 32).getDate();


### PR DESCRIPTION
## Issue

With upcoming `ilib` changes that fix known issues with Gregorian month days, `moon.Calendar` is now updated to take advantage of this fix.
## Fix

Remove the "-1" adjustment of the month day in favor of passing in the unixtime with local timezone. Also, implement more efficient way of initializing calendar instance.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
