### PR TITLE
ANG-6861: After call setDisable(false), an accordion doesn't open when i...

### DIFF
--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -114,6 +114,7 @@ enyo.kind({
 		if (this.generated) {
 			this.stopHeaderMarquee();
 		}
+		this.setActive(open);
 	},
 	disabledChanged: function() {
 		var disabled = this.getDisabled();


### PR DESCRIPTION
Related with ANG-6861, accordion will not close after calling setOpen(true) follow previous bug fix.
Above problem was reported by HQ developer who checked the tv guide app. For fixing the problem,  moon.ExpandableListItem handle active property when open property is changed.
