### PR TITLE
ANG-6861:  After call setDisable(false), an accordion doesn't open when i...

### DIFF
--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -111,6 +111,7 @@ enyo.kind({
 		this.addRemoveClass("open", open);
 		this.$.drawer.setOpen(open);
 		this.$.drawer.spotlightDisabled = !open;
+		this.setActive(open);
 	},
 	disabledChanged: function() {
 		var disabled = this.getDisabled();


### PR DESCRIPTION
...t was disabled by setDisable(true) from open status.

Related with ANG-6861, accordion will not close after calling setOpen(true) follow previous bug fix.
So, handle active property when open property is changed.

DCO-1.1-Signed-Off-By: Jungchae Kim jungchae.kim@lge.com
