### PR TITLE
BHV-6710: Set font explicitly for Spinner balls.

### DIFF
--- a/css/Spinner.less
+++ b/css/Spinner.less
@@ -134,19 +134,20 @@
 	.moon-spinner-text {
 		float: left;
 		line-height: @moon-spinner-size;
-		margin: 0 2ex 0 0.5ex;
+		margin: 0 2.6ex 0 0;
 	}
 }
 .enyo-locale-right-to-left .moon-spinner {
-	.moon-spinner-ball-decorator {
-		-webkit-transform: scaleX(-1);
-	}
+	// This allows for the spinner to spin in a counter-clockwise direction in RTL mode
+	// .moon-spinner-ball-decorator {
+	// 	-webkit-transform: scaleX(-1);
+	// }
 	.moon-spinner-ball-decorator {
 		float: right;
 	}
 	.moon-spinner-text {
 		float: right;
-		margin-left: 2ex;
-		margin-right: 0.5ex;
+		margin-left: 2.6ex;
+		margin-right: 0;
 	}
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3089,18 +3089,15 @@
 .moon-spinner .moon-spinner-text {
   float: left;
   line-height: 73px;
-  margin: 0 2ex 0 0.5ex;
-}
-.enyo-locale-right-to-left .moon-spinner .moon-spinner-ball-decorator {
-  -webkit-transform: scaleX(-1);
+  margin: 0 2.6ex 0 0;
 }
 .enyo-locale-right-to-left .moon-spinner .moon-spinner-ball-decorator {
   float: right;
 }
 .enyo-locale-right-to-left .moon-spinner .moon-spinner-text {
   float: right;
-  margin-left: 2ex;
-  margin-right: 0.5ex;
+  margin-left: 2.6ex;
+  margin-right: 0;
 }
 .moon-panel {
   -webkit-transform: scale3d(1, 1, 1);

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3086,18 +3086,15 @@
 .moon-spinner .moon-spinner-text {
   float: left;
   line-height: 73px;
-  margin: 0 2ex 0 0.5ex;
-}
-.enyo-locale-right-to-left .moon-spinner .moon-spinner-ball-decorator {
-  -webkit-transform: scaleX(-1);
+  margin: 0 2.6ex 0 0;
 }
 .enyo-locale-right-to-left .moon-spinner .moon-spinner-ball-decorator {
   float: right;
 }
 .enyo-locale-right-to-left .moon-spinner .moon-spinner-text {
   float: right;
-  margin-left: 2ex;
-  margin-right: 0.5ex;
+  margin-left: 2.6ex;
+  margin-right: 0;
 }
 .moon-panel {
   -webkit-transform: scale3d(1, 1, 1);


### PR DESCRIPTION
## Issue

In a non-latin locale, a different font is used, which causes the balls of the Spinner to render differently than intended.
## Fix

We explicitly set the font for the Spinner balls. Also, we preserve a clockwise spinner direction for RTL mode as well.
## Notes

A few adjustments for the spinner text position were made as well, to match the original Spinner, but this could be slightly off if a different font other than MuseoSans is used for the text. I would appreciate extra checking of this change. :)

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
