### PR TITLE
BHV-6685: Adjust z-index of DataGridList item when spotted/unspotted.

### DIFF
--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -12,14 +12,14 @@ enyo.kind({
 	spotlight: true,
 	scrollerOptions: { kind: "moon.Scroller", vertical:"scroll", horizontal: "hidden" },
 	handlers: {
-		onSpotlightFocus : "spotlightFocus",
-		onSpotlightBlur  : "spotlightBlur"
+		onSpotlightFocus : "handleSpotlightFocus",
+		onSpotlightBlur  : "handleSpotlightBlur"
 	},
-	spotlightFocus: function(inSender, inEvent) {
+	handleSpotlightFocus: function(inSender, inEvent) {
 		var zIndex = parseInt(enyo.dom.getComputedStyleValue(inEvent.originator.hasNode(), "z-index"), 10) || 0;
 		inEvent.originator.applyStyle("z-index", zIndex + 1);
 	},
-	spotlightBlur: function(inSender, inEvent) {
+	handleSpotlightBlur: function(inSender, inEvent) {
 		setTimeout(this.bindSafely(function() {
 			inEvent.originator.applyStyle("z-index", null);
 		}), 0);


### PR DESCRIPTION
## Issue

When a DataGridList item contains a Marquee, there is a significant delay in starting and stopping the Marquee, and more generally the transition. This caused delays in responding to user input and scrolling through lists.
## Fix

Upon spotting of a DataGridList item, we set the `z-index` property to a value one larger than the current value. Rather than calculating the `z-index` value of every item, we make the assumption that all items in the DataGridList will have the same `z-index` value; alternatively we can keep track of the highest `z-index` value when the DataGridList is rendered and set the `z-index` of the spotted item to one larger than that, but it seems like a very rare case that there would be different `z-index` values for items in a grid and adds unnecessary overhead upon creation. Let me know if we should reconsider this assumption.

When unspotted, we remove our previously applied `z-index` style, using a setTimeOut with 0 delay so that we ensure this executes after the transition has ended, which is critical to maintaining performance.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
