### PR TITLE
BHV-6683: Prevent unnecessary relayout by clipping overflow.

### DIFF
--- a/css/GridListImageItem.less
+++ b/css/GridListImageItem.less
@@ -5,7 +5,7 @@
 .moon-gridlist-imageitem {
 	width: 100%;
 	height: 100%;
-	overflow: visible;
+	overflow: hidden;
 	background-clip: padding-box;
 	border: 5px solid transparent;
 	.caption, 

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1933,7 +1933,7 @@
 .moon-gridlist-imageitem {
   width: 100%;
   height: 100%;
-  overflow: visible;
+  overflow: hidden;
   background-clip: padding-box;
   border: 5px solid transparent;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1933,7 +1933,7 @@
 .moon-gridlist-imageitem {
   width: 100%;
   height: 100%;
-  overflow: visible;
+  overflow: hidden;
   background-clip: padding-box;
   border: 5px solid transparent;
 }


### PR DESCRIPTION
## Issue

`GridListImageItem` propagates a layout change to all its ancestors when it contains a `Marquee`, which can negatively affect performance (to a smaller degree).
## Fix

We set `overflow:hidden` so that a relayout is not run on ancestors of `GridListImageItem`. I'm curious if anything would be taking advantage of the original style `overflow:visible`, though that would seem unlikely as it would result in an odd-looking `GridListImageItem`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
