### PR TITLE
BHV-6842: [DataListSample] Allow for Scroll to Index function to be reused when list is not scrolled.

### DIFF
--- a/samples/DataListSample.js
+++ b/samples/DataListSample.js
@@ -51,7 +51,8 @@ enyo.kind({
 	},
 	scrollToIndex: function (sender, event) {
 		var newIndex = sender.getValue();
-		if (this.isScrolled && newIndex) {
+		if (this.isScrolled || newIndex !== this.currentIndex) {
+			this.currentIndex = newIndex;
 			this.$.drawers.closeDrawers();
 			this.$.repeater.scrollToIndex(newIndex);
 			this.isScrolled = false;


### PR DESCRIPTION
## Issue

A previous fix to allow the `Scroll to Index` feature of the `DataListSample` to function when the list had been scrolled introduced a regression where the `Scroll to Index` feature could not be reused unless scrolling had occurred.
## Fix

We now allow the `scrollToIndex` method to be called when either scrolling has occurred, or if the current index differs than the desired index.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
