### PR TITLE
BHV-7160: Fix issue with setting locale in TimePickerSample.

### DIFF
--- a/samples/TimePickerSample.js
+++ b/samples/TimePickerSample.js
@@ -47,7 +47,7 @@ enyo.kind({
 		var opt = inEvent.selected.content,
 			val = (opt == "Use Default Locale") ? null : opt;
 		this.$.datepicker.setLocale(val);
-		this.$.picker.setLocale(val);
+		this.$.timepicker.setLocale(val);
 		this.$.disabledPicker.setLocale(val);
 		this.$.result.setContent("locale changed to " + opt);
 		return true;


### PR DESCRIPTION
## Issue

There is an exception thrown when setting the locale in the `TimePickerSample`.
## Fix

Correct the invalid kind reference when locale is set.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
