### PR TITLE
ANG-5236: Add node null check on IntegerPicker

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -81,7 +81,10 @@ enyo.kind({
 	},
 	refreshScrollState: function() {
 		this.updateScrollBounds();
-		this.$.scroller.scrollToNode(this.$.repeater.fetchRowNode(this.value - this.min));
+		var node = this.$.repeater.fetchRowNode(this.value - this.min);
+		if (node) {
+			this.$.scroller.scrollToNode(node);
+		}
 	},
 	setupItem: function(inSender, inEvent) {
 		var index = inEvent.index;
@@ -97,7 +100,10 @@ enyo.kind({
 		this.$.repeater.render();
 		//asynchronously scroll to the current node, this works around a potential scrolling glitch
 		enyo.asyncMethod(this.bindSafely(function(){
-			this.$.scroller.scrollToNode(this.$.repeater.fetchRowNode(this.value - this.min));
+			var node = this.$.repeater.fetchRowNode(this.value - this.min);
+			if (node) {
+				this.$.scroller.scrollToNode(node);
+			}
 		}));
 	},
 	valueChanged: function(inOld) {


### PR DESCRIPTION
Fixing: http://jira2.lgsvl.com/browse/ANG-5236

The node can be null when value is out of range.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
