### PR TITLE
BHV-5119: [Perf] moon.Panels - avoid full panels resize on pushPanel

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -137,7 +137,7 @@ enyo.kind({
 			oPanels[nPanel].render();
 		}
 		this.reflow();
-		for (nPanel in oPanels) {
+		for (nPanel = 0; nPanel < oPanels.length; ++nPanel) {
 			oPanels[nPanel].resized();
 		}
 		this.setIndex(lastIndex+1);


### PR DESCRIPTION
Background: Currently moon.Panels pushPanel API calls this.resize() after rendering the panel, which is the easiest way to a.) reflow the arranger to get the new panel in position, and b.) cause the layouts of each panel to be reflowed, in case the addition of the new panel (esp. in the case of joined panels) caused other panels to be resized by the arranger.  However, in most cases this is very wasteful, since in the vast majority of cases already rendered panels will not actually be resized by the operation.

Task: Refactor moon.Panels to avoid calling resize (which waterfalls the onresized event to all children), and instead perform resize operations more selectively only on those panels whose size is known to have been changed by the push operation.

Acceptance criteria:
- Revised implementation that avoids brute-force resize
- Benchmarks showing before/after improvement on panel create/render time in various scenarios

This fix is doing...
1) Call this.reflow() instead of this.resized() to just rearrange panels without resize all panels.
2) Resize only the pushed panels.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
