### PR TITLE
Remove MoonGridFlyweightRepeater.js in package.js

### DIFF
--- a/source/package.js
+++ b/source/package.js
@@ -12,7 +12,6 @@ enyo.depends(
 	"SimplePicker.js",
 	"SimpleIntegerPicker.js",
 	"GridListImageItem.js",
-	"MoonGridFlyweightRepeater.js",
 	"Checkbox.js",
 	"CheckboxItem.js",
 	"ToggleText.js",


### PR DESCRIPTION
Remove MoonGridFlyweightRepeater.js in package.js

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
