### PR TITLE
BHV-7870: The right area of gridlist is covered by scroll bar

### DIFF
--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -27,7 +27,7 @@ enyo.kind({
 			};
 		}),
 		scrollToIndex: function (list, i) {
-			// This function recurses, so make sure we are scrolling to a valid index, 
+			// This function recurses, so make sure we are scrolling to a valid index,
 			// otherwise childForIndex will never return a control
 			if ((i < 0) || (i >= list.collection.length)) {
 				return;
@@ -47,7 +47,7 @@ enyo.kind({
 				list.$.scroller.scrollToControl(c, false, false);
 			} else {
 				var idx = list.$.page1.index;
-				
+
 				// attempting to line them up in a useful order
 				// given the direction from where our current index is
 				if (idx < p) {
@@ -58,7 +58,7 @@ enyo.kind({
 					list.$.page2.index = p + 1;
 				}
 				list.refresh();
-								
+
 				this.scrollToIndex(list, i);
 			}
 		},
@@ -79,7 +79,7 @@ enyo.kind({
 					c = list.$.scroller.$.strategy.$.clientContainer;
 				if (v && (list.$.scroller.getVertical() == "scroll" || (b.height > b.clientHeight))) {
 					var cs = enyo.dom.getComputedStyle(c.hasNode());
-					list.boundsCache.width = w - (parseInt(cs["padding-right"]) + parseInt(cs["padding-left"]));
+					list.boundsCache.width = w - (parseInt(cs["padding-right"], 10) + parseInt(cs["padding-left"], 10));
 				}
 			};
 		})


### PR DESCRIPTION
moon.DataGridList.updateBounds function uses only scroller's width value instead of padding-right value of scroller's client-wrapper
Annd scroller width is 60px and padding-right value is 70px. So, DataGridList's bound width becomes 10px bigger than value that it should be

```
list.boundsCache.width = w-v.hasNode().offsetWidth
```

```
.moon-scroller-client-wrapper.v-scroll-enabled {
  padding-right: 70px;
}
```

DCO-1.1-Signed-Off-By: SoonGil Choi soongil.choi@lge.com
