### PR TITLE
ANG-8600: Apply ilib number format on SimpleIntegerPicker value

### DIFF
--- a/source/SimpleIntegerPicker.js
+++ b/source/SimpleIntegerPicker.js
@@ -140,10 +140,12 @@ enyo.kind({
 	build: function() {
 		var indices = this.indices = {},
 			values = this.values = [],
-			ilibNumFmt = new ilib.NumFmt({locale: new ilib.LocaleInfo().locale, useNative: false});
+			ilibNumFmt = (typeof ilib !== "undefined") ? new ilib.NumFmt({locale: new ilib.LocaleInfo().locale, useNative: false}) : null,
+			fmtValue;
 
 		for (var i = 0, v = this.min; v <= this.max; i++, v += this.step) {
-			this.createComponent({content: ilibNumFmt.format(v) + " " + this.unit, value: v});
+			fmtValue = ilibNumFmt ? ilibNumFmt.format(v) : v;
+			this.createComponent({content: fmtValue + " " + this.unit, value: v});
 			values[i] = v;
 			indices[v] = i;
 			if (this.step <= 0) {


### PR DESCRIPTION
The SimpleIntegerPicker should support ilib formatting based on system locale.

Fixing http://jira2.lgsvl.com/browse/ANG-8600

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
