### PR TITLE
BHV-743: Adjust scroller edge when navigating to first or last row.

### DIFF
--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -27,9 +27,9 @@ enyo.kind({
 	},
 	handleSpotlightFocused: function(inSender, inEvent) {
 		if (!enyo.Spotlight.getPointerMode()) {
-			if (inEvent.index < this._indexBoundFirstRow) {
+			if (inEvent.index < this.indexBoundFirstRow) {
 				this.$.scroller.scrollToTop();
-			} else if (inEvent.index > this._indexBoundLastRow) {
+			} else if (inEvent.index > this.indexBoundLastRow) {
 				this.$.scroller.scrollToBottom();
 			}
 		}


### PR DESCRIPTION
## Issue

The "up" paging control is not deactivated when the top of the list is reached via 5-way (and likewise, the "down" paging control is not deactivated when the bottom of the list is reached).
## Fix

We pre-compute the index bounds for the first and last rows, and compare the currently spotted/focused item's index with these bounds, scrolling to the top or bottom accordingly. Additionally, I consciously chose to break out the column value into a separate variable `columnSize` for the sake of code readability, as we could have just used `this._indexBoundFirstRow` instead.
## Notes

Open question for review - will there be any side effects, UX or otherwise, from programmatically scrolling to the top/bottom in these cases (versus trying to adjust the bounds which the paging controls consider to be the "top" and "bottom")?

This PR is dependent on an Enyo PR: https://github.com/enyojs/enyo/pull/729

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
