### PR TITLE
Fix for: BHV-8483

### DIFF
--- a/source/CheckboxItem.js
+++ b/source/CheckboxItem.js
@@ -68,6 +68,7 @@ enyo.kind({
 	],
 	create: function() {
 		this.inherited(arguments);
+		this.contentChanged();
 		this.disabledChanged();
 		this.checkboxOnRightChanged();
 	},


### PR DESCRIPTION
Content was not showing up in CheckboxItems because it was relying on an arbitrary call to `contentChanged()` during the initialization of a Control. Here we can simply add the call to simulate the same outcome for the overloaded behavior.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
