### PR TITLE
BHV-7280: Remove cruft that was preventing active panel spotting

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -554,7 +554,7 @@ enyo.kind({
 		this.inherited(arguments);
 
 		// Spot the active panel
-		if (this.hasNode() && !this.animate) {
+		if (this.hasNode()) {
 			enyo.Spotlight.spot(this.getActive());
 		}
 


### PR DESCRIPTION
## Issue

When navigating between panels with 5-way, the active panel does not get spotted.
## Fix

Removed a crufty conditional check that was originally in place to prevent dual-spotting, which was alleviated by a more general `Spotlight` fix that has already been integrated.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
