### PR TITLE
Bhv 754 Fix sequential left key input during transition from index 1.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -564,7 +564,7 @@ enyo.kind({
 		this.inherited(arguments);
 
 		this.transitionInProgress = false;
-		// queedIndex become -1 when left key input is occurred during transition from index 1 to 0.
+		// queuedIndex becomes -1 when left key input is occurred during transition from index 1 to 0.
 		if (this.queuedIndex === -1) {
 			this.hide();
 		} else if (this.queuedIndex !== null) {


### PR DESCRIPTION
Currently, sequential key inputs during panels transition are queuing.
And last key input will be conducted after transition is finished.

But specific case, queuing doesn't happen well and last key input could be ignored.
Because, this.toIndex is updated when finishTransition event fired.

To reproduce this case, plz open AlwaysViewingPanelsWithVideoSample.html
If we give 2 times LEFT key input from index 2, 
it will call two times setIndex() and queueIndex is set properly.
However if we starting from index 1, second LEFT key doesn't call setIndex(). 
So last LEFT key input doesn't get into queue.

To resolve this matter, I add enforced condition statement onSpotlightPanelLeave()

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
