### PR TITLE
BHV-754 Fix sequential left key input during transition from index 1.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -357,8 +357,15 @@ enyo.kind({
 				return true;
 			}
 			// If leaving to the left and we are at the first panel, hide panels
-			else if (this.toIndex === null && this.showing && (this.useHandle === true) && this.handleShowing) {
-				this.hide();
+			else if (this.showing && (this.useHandle === true) && this.handleShowing) {
+				if (this.toIndex === null) {
+					this.hide();
+				}
+				// If left key input is occurred during transition, this.toIndex is not updated yet.
+				// It still addresses previous toIndex. So we reserve hiding as pushing queueIndex
+				else {
+					this.queuedIndex = -1;
+				}
 				return true;
 			}
 		}
@@ -598,7 +605,11 @@ enyo.kind({
 
 		this.transitionInProgress = false;
 
-		if (this.queuedIndex !== null) {
+		// queuedIndex becomes -1 when left key input is occurred 
+		// during transition from index 1 to 0.
+		if (this.queuedIndex === -1) {
+			this.hide();
+		} else if (this.queuedIndex !== null) {
 			this.setIndex(this.queuedIndex);
 		}
 


### PR DESCRIPTION
Currently, sequential key inputs during panels transition are queuing.
And last key input will be conducted after transition is finished.

But specific case, queuing doesn't happen well and last key input could be ignored.
Because, this.toIndex is updated when finishTransition event fired.

To reproduce this case, plz open AlwaysViewingPanelsWithVideoSample.html
If we give 2 times LEFT key input from index 2, 
it will call two times setIndex() and queueIndex is set properly.
However if we starting from index 1, second LEFT key doesn't call setIndex(). 
So last LEFT key input doesn't get into queue.

To resolve this matter, I add enforced condition statement onSpotlightPanelLeave()

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
