### PR TITLE
Fix for: BHV-8478

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -294,6 +294,7 @@ enyo.kind({
 	],
 	create: function() {
 		this.inherited(arguments);
+		this.srcChanged();
 		this.createInfoControls();
 		this.inlineChanged();
 		this.showInfoChanged();


### PR DESCRIPTION
Ensure we are calling `srcChanged()` where expected since it was removed from Control as a default behavior.
