### PR TITLE
BHV-8482: Prevent slider from being spotlight-unhighlighted...

### DIFF
--- a/source/Slider.js
+++ b/source/Slider.js
@@ -349,6 +349,7 @@ enyo.kind({
 		if (inEvent.horizontal) {
 			inEvent.preventDefault();
 			this.dragging = true;
+			enyo.Spotlight.freeze();
 			this.$.knob.addClass("active");
 			this.showKnobStatus();
 			return true;
@@ -397,6 +398,7 @@ enyo.kind({
 		}
 
 		this.dragging = false;
+		enyo.Spotlight.unfreeze();
 		this.set("value",v);
 		this.sendChangeEvent({value: this.getValue()});
 		inEvent.preventTap();
@@ -446,9 +448,7 @@ enyo.kind({
 		return true;
 	},
 	spotBlur: function() {
-		if (this.dragging) {
-			return true;
-		} else {
+		if (!this.dragging) {
 			if (this.$.knob) {
 				this.$.knob.removeClass("spotselect");
 			}


### PR DESCRIPTION
... if the pointer moves away during a drag operation.

This was a regression due to a change in Spotlight, which fixed BHV-732. Spotlight used to unhighlight in onSpotlightBlur, which meant that Slider could prevent the unhighlight from happening by returning true in its handler for onSpotlightBlur; but now unhighlight happens directly on unspot, so there's no opportunity to cancel. Our new approach is to freeze Spotlight during our drag operation, which prevents unspot from happening during drag and therefore achieves the effect we want.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
