### PR TITLE
Fix for: BHV-8484

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -203,7 +203,15 @@ enyo.kind({
 	},
 
 	//* @protected
-
+	create: enyo.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			
+			// we need to ensure our handler has the opportunity to modify the flow during
+			// initialization
+			this.showingChanged();
+		};
+	}),
 	initComponents: function() {
 		this.applyPattern();
 		this.inherited(arguments);
@@ -636,6 +644,9 @@ enyo.kind({
 				enyo.Spotlight.spot(this.getActive());
 			}
 			else {
+				// in this case, our display flag will have been set to none so we need to clear
+				// that even though the showing flag will remain false
+				this.applyStyle('display', null);
 				this.resetHandleAutoHide();
 				this._hide();
 			}


### PR DESCRIPTION
Optimizations for Control initialization removed the unnecessary `showingChanged()` call that Panels had overloaded and expected. It also has an irregular handling of the `showing` flag as it can be `false` but still never apply the `display: none;` style property. This fix allows the expected behavior to continue.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
