### PR TITLE
BHV-8930: Much simpler panels show/hide animation with improved speed and no measurements

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -719,7 +719,6 @@ enyo.kind({
 	},
 	//* Sets hide state without animation.
 	_directHide: function() {
-		var x = this.getOffscreenXPosition();
 		this.$.handleWrapper.addClass("hidden");
 		this.$.showHideHandle.removeClass("right");
 		this.applyHideAnimation(true);


### PR DESCRIPTION
Dropped using the style animator entirely, and instead use 100% CSS transform measurement.

Bonus:
- No dom measurement
- Faster/better performance
- Simpler code
- Simpler CSS
- No dynamically generated CSS
