### PR TITLE
BHV-8917: Remove for...in loop

### DIFF
--- a/source/DataList.js
+++ b/source/DataList.js
@@ -202,7 +202,7 @@ moon.DataListSpotlightSupport = {
 				? [this.$.page1, this.$.page2] : [this.$.page2, this.$.page1];
 
 		// Explore the controls in the current pages
-		for (pageIndex in pages) {
+		for (pageIndex = 0; pageIndex < pages.length; pageIndex++) {
 			page = pages[pageIndex];
 			if (inDirection === 1) {
 				// Loop through children in each page top-down


### PR DESCRIPTION
## Issue

When there are no additional pages to generate (i.e. edge of list bounds), an unexpected page object is still evaluated, resulting in an error.
## Fix

Convert an inappropriate and unnecessary `for...in` loop to a standard `for` loop.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
