### PR TITLE
BHV-9066: Reworked panel collapse/expand animation to use pure CSS

### DIFF
--- a/css/Panel.less
+++ b/css/Panel.less
@@ -39,7 +39,7 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
-	height: 200px;
+	height: 100%;
 	overflow: hidden;
 }
 .moon-panel-mini-header-wrapper {
@@ -109,5 +109,86 @@
 	.moon-panel-mini-header,
 	.moon-panel-mini-header-title-above {
 		color: @moon-white;
+	}
+}
+
+/* Panel animations */
+
+@-webkit-keyframes panel-outer {
+	0%   {-webkit-transform: translateZ(0) translateY(-100%);}
+	100% {-webkit-transform: translateZ(0) translateY(0);}
+}
+
+@-webkit-keyframes panel-inner {
+	0%   {-webkit-transform: translateZ(0) translateY(100%);}
+	100% {-webkit-transform: translateZ(0) translateY(0);}
+}
+
+@-webkit-keyframes breadcrumb-outer {
+	0%,       {-webkit-transform: translateZ(0) translateY(0%);}
+	36%, 100% {-webkit-transform: translateZ(0) translateY(100%);}
+}
+
+@-webkit-keyframes breadcrumb-inner {
+	0%        {-webkit-transform: translateZ(0) translateY(0%);}
+	36%, 100% {-webkit-transform: translateZ(0) translateY(-100%);}
+} 
+
+.moon-panel {
+	.moon-panel-viewport,
+	.moon-panel-content-wrapper,
+	.moon-panel-breadcrumb-viewport,
+	.moon-panel-mini-header-wrapper {
+		-webkit-transform: translateZ(0);
+		-webkit-animation-fill-mode: both;
+		-webkit-animation-timing-function: ease-in-out;
+	}
+	&.growing,
+	&.shrinking {
+		.moon-panel-viewport {
+			-webkit-animation-name: panel-outer;
+		}
+		.moon-panel-breadcrumb-viewport {
+			-webkit-animation-name: breadcrumb-outer;
+		}
+		.moon-panel-content-wrapper {
+			-webkit-animation-name: panel-inner;
+		}
+		.moon-panel-mini-header-wrapper {
+			-webkit-animation-name: breadcrumb-inner;
+		}
+	}
+	&.growing {
+		.moon-panel-viewport,
+		.moon-panel-content-wrapper,
+		.moon-panel-breadcrumb-viewport,
+		.moon-panel-mini-header-wrapper {
+			-webkit-animation-duration: 0.4s;
+		}
+	}
+	&.shrinking {
+		.moon-panel-viewport,
+		.moon-panel-content-wrapper,
+		.moon-panel-breadcrumb-viewport,
+		.moon-panel-mini-header-wrapper {
+			-webkit-animation-duration: 0.5s;
+			-webkit-animation-direction: reverse;
+		}
+	}
+	&.shrunken {
+		.moon-panel-viewport {
+			-webkit-transform: translateZ(0) translateY(-101%);
+		}
+		.moon-panel-content-wrapper {
+			-webkit-transform: translateZ(0) translateY(101%);
+		}
+	}
+	&:not(.shrunken) {
+		.moon-panel-breadcrumb-viewport {
+			-webkit-transform: translateZ(0) translateY(101%);
+		}
+		.moon-panel-mini-header-wrapper {
+			-webkit-transform: translateZ(0) translateY(-101%);
+		}
 	}
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3205,7 +3205,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  height: 200px;
+  height: 100%;
   overflow: hidden;
 }
 .moon-panel-mini-header-wrapper {
@@ -3266,6 +3266,90 @@
 .moon-panels.always-viewing .moon-panel-mini-header,
 .moon-panels.always-viewing .moon-panel-mini-header-title-above {
   color: #ffffff;
+}
+/* Panel animations */
+@-webkit-keyframes panel-outer {
+  0% {
+    -webkit-transform: translateZ(0) translateY(-100%);
+  }
+  100% {
+    -webkit-transform: translateZ(0) translateY(0);
+  }
+}
+@-webkit-keyframes panel-inner {
+  0% {
+    -webkit-transform: translateZ(0) translateY(100%);
+  }
+  100% {
+    -webkit-transform: translateZ(0) translateY(0);
+  }
+}
+@-webkit-keyframes breadcrumb-outer {
+  0% {
+    -webkit-transform: translateZ(0) translateY(0%);
+  }
+  36%,
+  100% {
+    -webkit-transform: translateZ(0) translateY(100%);
+  }
+}
+@-webkit-keyframes breadcrumb-inner {
+  0% {
+    -webkit-transform: translateZ(0) translateY(0%);
+  }
+  36%,
+  100% {
+    -webkit-transform: translateZ(0) translateY(-100%);
+  }
+}
+.moon-panel .moon-panel-viewport,
+.moon-panel .moon-panel-content-wrapper,
+.moon-panel .moon-panel-breadcrumb-viewport,
+.moon-panel .moon-panel-mini-header-wrapper {
+  -webkit-transform: translateZ(0);
+  -webkit-animation-fill-mode: both;
+  -webkit-animation-timing-function: ease-in-out;
+}
+.moon-panel.growing .moon-panel-viewport,
+.moon-panel.shrinking .moon-panel-viewport {
+  -webkit-animation-name: panel-outer;
+}
+.moon-panel.growing .moon-panel-breadcrumb-viewport,
+.moon-panel.shrinking .moon-panel-breadcrumb-viewport {
+  -webkit-animation-name: breadcrumb-outer;
+}
+.moon-panel.growing .moon-panel-content-wrapper,
+.moon-panel.shrinking .moon-panel-content-wrapper {
+  -webkit-animation-name: panel-inner;
+}
+.moon-panel.growing .moon-panel-mini-header-wrapper,
+.moon-panel.shrinking .moon-panel-mini-header-wrapper {
+  -webkit-animation-name: breadcrumb-inner;
+}
+.moon-panel.growing .moon-panel-viewport,
+.moon-panel.growing .moon-panel-content-wrapper,
+.moon-panel.growing .moon-panel-breadcrumb-viewport,
+.moon-panel.growing .moon-panel-mini-header-wrapper {
+  -webkit-animation-duration: 0.4s;
+}
+.moon-panel.shrinking .moon-panel-viewport,
+.moon-panel.shrinking .moon-panel-content-wrapper,
+.moon-panel.shrinking .moon-panel-breadcrumb-viewport,
+.moon-panel.shrinking .moon-panel-mini-header-wrapper {
+  -webkit-animation-duration: 0.5s;
+  -webkit-animation-direction: reverse;
+}
+.moon-panel.shrunken .moon-panel-viewport {
+  -webkit-transform: translateZ(0) translateY(-101%);
+}
+.moon-panel.shrunken .moon-panel-content-wrapper {
+  -webkit-transform: translateZ(0) translateY(101%);
+}
+.moon-panel:not(.shrunken) .moon-panel-breadcrumb-viewport {
+  -webkit-transform: translateZ(0) translateY(101%);
+}
+.moon-panel:not(.shrunken) .moon-panel-mini-header-wrapper {
+  -webkit-transform: translateZ(0) translateY(-101%);
 }
 /* Panels */
 .moon-panels.activity,

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3202,7 +3202,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  height: 200px;
+  height: 100%;
   overflow: hidden;
 }
 .moon-panel-mini-header-wrapper {
@@ -3263,6 +3263,90 @@
 .moon-panels.always-viewing .moon-panel-mini-header,
 .moon-panels.always-viewing .moon-panel-mini-header-title-above {
   color: #ffffff;
+}
+/* Panel animations */
+@-webkit-keyframes panel-outer {
+  0% {
+    -webkit-transform: translateZ(0) translateY(-100%);
+  }
+  100% {
+    -webkit-transform: translateZ(0) translateY(0);
+  }
+}
+@-webkit-keyframes panel-inner {
+  0% {
+    -webkit-transform: translateZ(0) translateY(100%);
+  }
+  100% {
+    -webkit-transform: translateZ(0) translateY(0);
+  }
+}
+@-webkit-keyframes breadcrumb-outer {
+  0% {
+    -webkit-transform: translateZ(0) translateY(0%);
+  }
+  36%,
+  100% {
+    -webkit-transform: translateZ(0) translateY(100%);
+  }
+}
+@-webkit-keyframes breadcrumb-inner {
+  0% {
+    -webkit-transform: translateZ(0) translateY(0%);
+  }
+  36%,
+  100% {
+    -webkit-transform: translateZ(0) translateY(-100%);
+  }
+}
+.moon-panel .moon-panel-viewport,
+.moon-panel .moon-panel-content-wrapper,
+.moon-panel .moon-panel-breadcrumb-viewport,
+.moon-panel .moon-panel-mini-header-wrapper {
+  -webkit-transform: translateZ(0);
+  -webkit-animation-fill-mode: both;
+  -webkit-animation-timing-function: ease-in-out;
+}
+.moon-panel.growing .moon-panel-viewport,
+.moon-panel.shrinking .moon-panel-viewport {
+  -webkit-animation-name: panel-outer;
+}
+.moon-panel.growing .moon-panel-breadcrumb-viewport,
+.moon-panel.shrinking .moon-panel-breadcrumb-viewport {
+  -webkit-animation-name: breadcrumb-outer;
+}
+.moon-panel.growing .moon-panel-content-wrapper,
+.moon-panel.shrinking .moon-panel-content-wrapper {
+  -webkit-animation-name: panel-inner;
+}
+.moon-panel.growing .moon-panel-mini-header-wrapper,
+.moon-panel.shrinking .moon-panel-mini-header-wrapper {
+  -webkit-animation-name: breadcrumb-inner;
+}
+.moon-panel.growing .moon-panel-viewport,
+.moon-panel.growing .moon-panel-content-wrapper,
+.moon-panel.growing .moon-panel-breadcrumb-viewport,
+.moon-panel.growing .moon-panel-mini-header-wrapper {
+  -webkit-animation-duration: 0.4s;
+}
+.moon-panel.shrinking .moon-panel-viewport,
+.moon-panel.shrinking .moon-panel-content-wrapper,
+.moon-panel.shrinking .moon-panel-breadcrumb-viewport,
+.moon-panel.shrinking .moon-panel-mini-header-wrapper {
+  -webkit-animation-duration: 0.5s;
+  -webkit-animation-direction: reverse;
+}
+.moon-panel.shrunken .moon-panel-viewport {
+  -webkit-transform: translateZ(0) translateY(-101%);
+}
+.moon-panel.shrunken .moon-panel-content-wrapper {
+  -webkit-transform: translateZ(0) translateY(101%);
+}
+.moon-panel:not(.shrunken) .moon-panel-breadcrumb-viewport {
+  -webkit-transform: translateZ(0) translateY(101%);
+}
+.moon-panel:not(.shrunken) .moon-panel-mini-header-wrapper {
+  -webkit-transform: translateZ(0) translateY(-101%);
 }
 /* Panels */
 .moon-panels.activity,

--- a/source/Panel.js
+++ b/source/Panel.js
@@ -65,7 +65,7 @@ enyo.kind({
 				]}
 			]}
 		]},
-		{name: "viewport", classes: "moon-panel-viewport", components: [
+		{name: "viewport", classes: "moon-panel-viewport", onwebkitAnimationEnd: "animationComplete", components: [
 			{name: "contentWrapper", kind:"FittableRows", classes: "moon-panel-content-wrapper", components: [
 				/* header will be created here programmatically in createTools after mixing-in headerOptions */
 				{name: "panelBody", kind: "FittableRows", fit: true, classes: "moon-panel-body"}
@@ -126,8 +126,6 @@ enyo.kind({
 		this.inherited(arguments);
 		this.getInitAnimationValues();
 		this.updateViewportSize();
-		this.createShrinkAnimation();
-		this.createGrowAnimation();
 		this.shrinkAsNeeded();
 	},
 	//* Updates _this.$.contentWrapper_ to have the height/width of _this_.
@@ -315,20 +313,20 @@ enyo.kind({
 	shrinkAnimation: function() {
 		this.growing = false;
 		this.shrinking = true;
-		this.haltAnimations();
-		this.$.animator.play("shrink");
+		this.addClass("shrunken");
+		this.addClass("shrinking");
 	},
 	shrink: function() {
-		this.$.animator.jumpToEnd("shrink");
+		this.addClass("shrunken");
 	},
 	growAnimation: function() {
 		this.growing = true;
 		this.shrinking = false;
-		this.haltAnimations();
-		this.$.animator.play("grow");			
+		this.addClass("growing");	
+		this.removeClass("shrunken");
 	},
 	grow: function() {
-		this.$.animator.jumpToEnd("grow");
+		this.removeClass("shrunken");
 	},
 	//* @protected
 	getInitAnimationValues: function() {
@@ -341,9 +339,8 @@ enyo.kind({
 		this.initialWidth = node.offsetWidth   - paddingR - paddingL;
 	},
 	haltAnimations: function() {
-		this.$.animator.stop();
-		this.$.animator.pause("grow");
-		this.$.animator.pause("shrink");
+		this.removeClass("growing");
+		this.removeClass("shrinking");
 	},
 	preTransitionComplete: function() {
 		this.shrinking = false;
@@ -352,14 +349,15 @@ enyo.kind({
 	postTransitionComplete: function() {
 		this.growing = false;
 		this.doPostTransitionComplete();
-		this.reflow();
 	},
 	animationComplete: function(inSender, inEvent) {
-		switch (inEvent.animation.name) {
-		case "shrink":
+		if (this.shrinking) {
+			this.removeClass("shrinking");
 			this.preTransitionComplete();
 			return true;
-		case "grow":
+		}
+		if (this.growing) {
+			this.removeClass("growing");
 			this.postTransitionComplete();
 			return true;
 		}
@@ -373,43 +371,5 @@ enyo.kind({
 			this.resized();
 			break;
 		}
-	},
-	createGrowAnimation: function() {
-		this.$.animator.newAnimation({
-			name: "grow",
-			duration: 400,
-			timingFunction: "cubic-bezier(.25,.1,.25,1)",
-			keyframes: {
-				0: [
-					{control: this.$.viewport, properties: {"height"  : "0px"}},
-					{control: this.$.breadcrumbViewport, properties: { "height": "current" }}
-				],
-				50: [
-					{control: this.$.breadcrumbViewport, properties: { "height": "0px" }}
-				],
-				100: [
-					{control: this.$.viewport, properties: {"height" : this.initialHeight + "px"}}
-				]
-			}
-		});
-	},
-	createShrinkAnimation: function() {
-		this.$.animator.newAnimation({
-			name: "shrink",
-			duration: 500,
-			timingFunction: "cubic-bezier(.25,.1,.25,1)",
-			keyframes: {
-				0: [
-					{control: this.$.viewport, properties: { "height"  : "current" }}
-				],
-				50: [
-					{control: this.$.breadcrumbViewport, properties: { "height": "current" }}
-				],
-				100: [
-					{control: this.$.viewport, properties: { "height"  : "0px" }},
-					{control: this.$.breadcrumbViewport, properties: { "height": "370px" }}
-				]
-			}
-		});
 	}
 });


### PR DESCRIPTION
... instead of javascript measurements and style animator.

New technique uses no DOM measurements, no dynamically generated CSS, no repaints, and no re-layouts.

A double-inverse-transform is preformed on the breadcrumb frame and the panel-body frame to simulate the height+clipping effect.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
