### PR TITLE
BHV-4135 Reduce kFrictionEpsilon to allow more generous standard.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -48,7 +48,7 @@ enyo.kind({
 	},
 	//* @protected
 	tools: [
-		{kind: "ScrollMath", onScrollStart: "scrollMathStart", onScroll: "scrollMathScroll", onScrollStop: "scrollMathStop"}
+		{kind: "ScrollMath", kFrictionEpsilon: 1e-1, onScrollStart: "scrollMathStart", onScroll: "scrollMathScroll", onScrollStop: "scrollMathStop"}
 	],
 	components: [
 		{name: "clientContainer", classes: "moon-scroller-client-wrapper", components: [


### PR DESCRIPTION
Currently we can tell this scroll is over when scroll bouncing is under 1e-2.
However considering for TV device, we will reduce it to 1e-1.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
