### PR TITLE
BHV-754 Close panels if sequential left input is occurred on index 1.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -367,7 +367,12 @@ enyo.kind({
 		}
 	},
 	setIndex: function(inIndex) {
-		inIndex = this.clamp(inIndex);
+		// Normally this.index cannot be smaller than 0 and larger than panels.length
+		// However, if panels uses handle and there is sequential key input during transition
+		// then inIndex could have -1. It means that panels will be hided.
+		if (this.toIndex === null || this.useHandle === false) {
+			inIndex = this.clamp(inIndex);
+		}
 
 		if (inIndex === this.index) {
 			return;
@@ -584,9 +589,13 @@ enyo.kind({
 
 		this.transitionInProgress = false;
 
-		if (this.queuedIndex !== null) {
-			this.setIndex(this.queuedIndex);
-		}
+		// queuedIndex becomes -1 when left key input is occurred 
+ 		// during transition from index 1 to 0.
+ 		if (this.queuedIndex === -1) {
+ 			this.hide();
+		} else if (this.queuedIndex !== null) {
+  			this.setIndex(this.queuedIndex);
+  		}
 
 		enyo.Spotlight.unmute(this);
 		// Spot the active panel


### PR DESCRIPTION
Currently, sequential key inputs during panels transition are queuing.
And last key input will be conducted after transition is finished.

But specific case, last key input is ignored.

To reproduce this case, plz open AlwaysViewingPanelsWithVideoSample.html
If we give 2 times LEFT key input from index 2, 
it will call two times setIndex() and queueIndex is set properly.
However if we starting from index 1, second LEFT key calls setIndex() but it stayed 0 panel.
Because clamp() does not allow that panels.index become smaller than 0.

To resolve this matter, I enforced condition statement in setIndex()

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
