### PR TITLE
BHV-7944: Marquees now work inside spinners, as well as long text and components.

### DIFF
--- a/css/Spinner.less
+++ b/css/Spinner.less
@@ -62,31 +62,27 @@
 }
 
 .moon-spinner {
-	height: @moon-spinner-size;
+	min-height: @moon-spinner-size;
 	min-width: @moon-spinner-size;
 	line-height: @moon-spinner-size;
 	position: relative;
 	display: inline-block;
 	color: @moon-spinner-text-color;
 	background-color: @moon-spinner-background-color;
-	border-radius: @moon-spinner-size;
+	border-radius: (@moon-button-height / 2);
 	margin: 0 @moon-spotlight-outset;
 
+	> * {
+		display: inline-block;
+	}
 	&.moon-spinner-transparent-background {
 		background-color: transparent;
 	}
 	&.content {
-		position: static;
-
-		height: @moon-button-height;
-		min-width: @moon-button-height;
-		line-height: @moon-button-height;
-		.moon-spinner-ball-decorator {
-			width: @moon-button-height;
-			height: @moon-button-height;
-		}
-		.moon-spinner-text {
-			line-height: @moon-button-height;
+		padding: ((@moon-button-height - @moon-spinner-size) / 2);
+		
+		.moon-spinner-client {
+			max-width: 400px;
 		}
 	}
 	&.running .moon-spinner-ball {
@@ -131,7 +127,7 @@
 		color: @moon-spinner-ball3-color;
 		-webkit-transform: rotateZ(360 - (@moon-spinner-ball-angle * 3));
 	}
-	.moon-spinner-text {
+	.moon-spinner-client {
 		float: left;
 		line-height: @moon-spinner-size;
 		margin: 0 2.6ex 0 0;
@@ -145,7 +141,7 @@
 	.moon-spinner-ball-decorator {
 		float: right;
 	}
-	.moon-spinner-text {
+	.moon-spinner-client {
 		float: right;
 		margin-left: 2.6ex;
 		margin-right: 0;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3134,31 +3134,27 @@
   }
 }
 .moon-spinner {
-  height: 73px;
+  min-height: 73px;
   min-width: 73px;
   line-height: 73px;
   position: relative;
   display: inline-block;
   color: #ffffff;
   background-color: #4d4d4d;
-  border-radius: 73px;
+  border-radius: 42.5px;
   margin: 0 10px;
+}
+.moon-spinner > * {
+  display: inline-block;
 }
 .moon-spinner.moon-spinner-transparent-background {
   background-color: transparent;
 }
 .moon-spinner.content {
-  position: static;
-  height: 85px;
-  min-width: 85px;
-  line-height: 85px;
+  padding: 6px;
 }
-.moon-spinner.content .moon-spinner-ball-decorator {
-  width: 85px;
-  height: 85px;
-}
-.moon-spinner.content .moon-spinner-text {
-  line-height: 85px;
+.moon-spinner.content .moon-spinner-client {
+  max-width: 400px;
 }
 .moon-spinner.running .moon-spinner-ball {
   -webkit-animation-play-state: running;
@@ -3201,7 +3197,7 @@
   color: #ffb80d;
   -webkit-transform: rotateZ(321deg);
 }
-.moon-spinner .moon-spinner-text {
+.moon-spinner .moon-spinner-client {
   float: left;
   line-height: 73px;
   margin: 0 2.6ex 0 0;
@@ -3209,7 +3205,7 @@
 .enyo-locale-right-to-left .moon-spinner .moon-spinner-ball-decorator {
   float: right;
 }
-.enyo-locale-right-to-left .moon-spinner .moon-spinner-text {
+.enyo-locale-right-to-left .moon-spinner .moon-spinner-client {
   float: right;
   margin-left: 2.6ex;
   margin-right: 0;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3131,31 +3131,27 @@
   }
 }
 .moon-spinner {
-  height: 73px;
+  min-height: 73px;
   min-width: 73px;
   line-height: 73px;
   position: relative;
   display: inline-block;
   color: #ffffff;
   background-color: #4d4d4d;
-  border-radius: 73px;
+  border-radius: 42.5px;
   margin: 0 10px;
+}
+.moon-spinner > * {
+  display: inline-block;
 }
 .moon-spinner.moon-spinner-transparent-background {
   background-color: transparent;
 }
 .moon-spinner.content {
-  position: static;
-  height: 85px;
-  min-width: 85px;
-  line-height: 85px;
+  padding: 6px;
 }
-.moon-spinner.content .moon-spinner-ball-decorator {
-  width: 85px;
-  height: 85px;
-}
-.moon-spinner.content .moon-spinner-text {
-  line-height: 85px;
+.moon-spinner.content .moon-spinner-client {
+  max-width: 400px;
 }
 .moon-spinner.running .moon-spinner-ball {
   -webkit-animation-play-state: running;
@@ -3198,7 +3194,7 @@
   color: #ffb80d;
   -webkit-transform: rotateZ(321deg);
 }
-.moon-spinner .moon-spinner-text {
+.moon-spinner .moon-spinner-client {
   float: left;
   line-height: 73px;
   margin: 0 2.6ex 0 0;
@@ -3206,7 +3202,7 @@
 .enyo-locale-right-to-left .moon-spinner .moon-spinner-ball-decorator {
   float: right;
 }
-.enyo-locale-right-to-left .moon-spinner .moon-spinner-text {
+.enyo-locale-right-to-left .moon-spinner .moon-spinner-client {
   float: right;
   margin-left: 2.6ex;
   margin-right: 0;

--- a/samples/SpinnerSample.js
+++ b/samples/SpinnerSample.js
@@ -5,6 +5,18 @@ enyo.kind({
 		{kind: "moon.Divider", content: "Spinner"},
 		{kind: "moon.Spinner"},
 		{kind: "moon.Divider", content: "Spinner with Content"},
-		{kind: "moon.Spinner", content: "Loading..."}
+		{kind: "moon.Spinner", content: "Loading..."},
+		{kind: "moon.Divider", content: "Spinner Centered in its Container"},
+		{style: "text-align: center", components: [
+			{kind: "moon.Spinner", content: "Loading..."}
+		]},
+		{kind: "moon.Divider", content: "Spinner with Looooong Content"},
+		{kind: "moon.Spinner", content: "Loading so much content... This might take some arbitrary amount of time. Could be long, could be short. Who knows?"},
+		{kind: "moon.Divider", content: "Spinner with Components Inside"},
+		{kind: "moon.Spinner", components: [
+			{kind: "moon.Icon", icon: "fullscreen"},
+			{content: "Fullscreen mode is loading"},
+			{kind: "moon.Icon", icon: "exitfullscreen"}
+		]}
 	]
 });

--- a/source/Spinner.js
+++ b/source/Spinner.js
@@ -25,9 +25,32 @@ enyo.kind({
 			{classes: "moon-spinner-ball moon-spinner-ball1"},
 			{classes: "moon-spinner-ball moon-spinner-ball2"},
 			{classes: "moon-spinner-ball moon-spinner-ball3"}
-		]},
-		{name: "client", classes: "moon-spinner-text"}
+		]}
 	],
+	spinnerTools: [
+		{name: "client", classes: "moon-spinner-client"}
+	],
+	initComponents: function() {
+		this.inherited(arguments);
+		this.createTools();
+	},
+	createTools: function() {
+		// This allows for the spinner instances with child components to not have 
+		// MarqueeText kind on the client container.
+		var tools = enyo.clone(this.spinnerTools);
+		if (!(this.components && this.components.length > 0)) {
+			// If there are no components in the spinner, convert its client area to a MarqueeText kind
+			enyo.mixin(tools[0], {
+				kind: "moon.MarqueeText",
+				mixins: ["moon.MarqueeSupport"],
+				marqueeOnSpotlight: false,
+				marqueeOnHover: true,
+				marqueeOnRender: true,
+				marqueeOnRenderDelay: 1000
+			});
+		}
+		this.createChrome(tools);
+	},
 	create: function() {
 		this.inherited(arguments);
 		this.contentChanged();
@@ -48,11 +71,17 @@ enyo.kind({
 		this.set("showing", !this.get("showing"));
 	},
 	//* @protected
-	contentChanged: function() {
+	hasContent: function() {
+		// true if this.content is set to something OR if there are more than zero components 
+		return (!!this.content || (this.components && this.components.length > 0));
+	},
+	contentChanged: function(inOld) {
 		this.inherited(arguments);
-		this.$.client.setContent(this.content);
+		if (this.content || inOld) {
+			this.$.client.set("content", this.content);
+		}
 		this.$.client.set("showing", !!this.content);
-		this.addRemoveClass("content", !!this.content);
+		this.addRemoveClass("content", this.hasContent());
 	},
 	transparentChanged: function() {
 		this.addRemoveClass("moon-spinner-transparent-background", !!this.get("transparent"));


### PR DESCRIPTION
Spinners may now more easily be centered, and do not apply oppressive positioning rules.
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
