### PR TITLE
BHV-4060: Trigger reflow when picker is opened.

### DIFF
--- a/source/ExpandableIntegerPicker.js
+++ b/source/ExpandableIntegerPicker.js
@@ -84,6 +84,9 @@ enyo.kind({
 	openChanged: function() {
 		this.inherited(arguments);
 		this.setActive(this.getOpen());
+		if (this.open) {
+			this.$.picker.reflow();
+		}
 	},
 
 	// Computed props


### PR DESCRIPTION
## Issue

The content of the picker when a `moon.ExpandableIntegerPicker` is expanded is empty. This is caused by a regression from a fix for BHV-737 that prevented `resized`, and effectively `reflow`, from being called when the picker is expanded.
## Fix

We trigger a reflow of the picker whenever it is opened.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
