### PR TITLE
BHV-8467: moon.ScrollStrategy update and clean-up.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -231,8 +231,8 @@ enyo.kind({
 	enter: function(inSender, inEvent) {
 		this.hovering = true;
 		this.setupBounds();
-		this.enableDisablePageControls();
 		this.showHideScrollColumns(true);
+		this.updateHoverOnPagingControls(true);
 	},
 	//* On _leave_, sets _this.hovering_ to false and hides pagination controls.
 	leave: function(inSender, inEvent) {
@@ -327,17 +327,6 @@ enyo.kind({
 		}
 
 		return true;
-	},
-	scrollMathScroll: function() {
-		this.inherited(arguments);
-
-		if (this.hovering) {
-			this.enableDisablePageControls();
-		} else {
-			this.hidePageControls();
-		}
-
-		this.showHideScrollColumns(true);
 	},
 	//* Scrolls to specific x/y positions within the scroll area.
 	_scrollTo: function(inX, inY) {
@@ -447,18 +436,9 @@ enyo.kind({
 		return true;
 	},
 	spotlightModeChanged: function(inSender, inEvent) {
-		this.enableDisablePageControls();
-		this.updateHoverOnPagingControls(this.shouldShowPageControls() || enyo.Spotlight.getPointerMode());
-	},
-	//* Shows or hides pagination controls, as appropriate.
-	enableDisablePageControls: function(inSender, inEvent) {
-		/*
-			If we're not in pointer mode, and set to hide paging on key, hide pagination controls.
-			If not hovering and set to hide on leave, hide pagination controls.
-		*/
-		if (!this.shouldShowPageControls()) {
-			this.hidePageControls();
-		}
+		var activatePageControls = this.shouldShowPageControls();
+		this.showHideScrollColumns(activatePageControls);
+		this.updateHoverOnPagingControls(activatePageControls);
 	},
 	//* Enables or disables scroll columns.
 	enableDisableScrollColumns: function() {
@@ -512,15 +492,6 @@ enyo.kind({
 		return (this.getHorizontal() == "scroll" ||
 				(this.getHorizontal() !== "hidden" &&
 				((-1 * this.$.scrollMath.rightBoundary > 0) || this.spotlightPagingControls)));
-	},
-	//* Hides pagination controls.
-	hidePageControls: function() {
-		if (!this.spotlightPagingControls) {
-			this.$.pageLeftControl.setDisabled(true);
-			this.$.pageRightControl.setDisabled(true);
-			this.$.pageUpControl.setDisabled(true);
-			this.$.pageDownControl.setDisabled(true);
-		}
 	},
 	_getScrollBounds: function() {
 		if (this.scrollBounds) {


### PR DESCRIPTION
## Issue

When moving in 5-way mode in a `moon.Scroller` that has `spotlightPagingControls:false` and then changing to pointer mode, the paging controls are no longer spottable.
## Fix

Reworked the logic for `moon.ScrollStrategy`, getting rid of some cruft.

The logic I tried to enforce (as a sanity check for the reviewer):
- The paging controls should always be enabled (as necessary) when scrolling the list in both 5-way and pointer mode. This involved removing a call to `enableDisablePagingControls` from the `enter` handler (as this method would only ever potentially disable the paging controls), and removing the `scrollMathScroll` handler as it doesn't seem like a use case that the scroller would be scrolled without the pointer hovered over the scroller.
- The paging controls should not be visible when the scroller and/or its contents are not spotted. This involved adding a call to `showHideScrollColumns` in the `spotlightModeChanged` handler and removing the call to `enableDisablePagingControls`. This effectively removed the need for the `enableDisablePagingControls` and `hidePagingControls` methods, which were removed entirely as a result. There is an issue where this logic is not enforced when leaving the scroller via 5-way and will be addressed by BHV-9960.
- The paging controls should be hoverable whenever we are focused on the scroller in pointer mode, so a call to `updateHoverOnPagingControls` in the `enter` handler has been added to guarantee this.

Also fixed a prior typo.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
