### PR TITLE
BHV-9859: Handle value validation in generic setter instead of change handler.

### DIFF
--- a/samples/CalendarSample.js
+++ b/samples/CalendarSample.js
@@ -91,6 +91,6 @@ enyo.kind({
 		this.$.calendar.setValue(new Date(this.$.input.getValue()));
 	},
 	resetDate: function() {
-		this.$.calendar.setValue(new Date());
+		this.$.calendar.setValue(null);
 	}
 });

--- a/source/Calendar.js
+++ b/source/Calendar.js
@@ -201,11 +201,28 @@ enyo.kind({
 		this.updateDays();
 		this.updateDates();
 	},
+	/**
+		We were previously relying on a non-guaranteed ordering of calls (change handlers
+		on bindings, transformation of binding values) to perform validation on the 
+		Date value before updating a control with this value. Though this ordering was 
+		non-guaranteed, it has since changed and can possibly affect any code that is 
+		improperly relying on the specific ordering of these calls. We instead handle the 
+		validation in the generic setter and facade this via the _setValue_ method.
+	*/
+	setValue: function(inValue) {
+		this.set("value", inValue);
+	},
+	set: enyo.inherit(function (sup) {
+		return function(path, value) {
+			if (path == "value") {
+				if(isNaN(value) || value === null) {
+					value = new Date();
+				}
+			}
+			sup.apply(this, arguments);
+		};
+	}),
 	valueChanged: function(inOld) {
-		if(isNaN(this.value) || this.value === null) {
-			this.setValue(new Date());
-			return;
-		}
 		if (!this.generated || this.$.monthPicker.getSelectedIndex() != this.value.getMonth()) {
 			this.$.monthPicker.setSelectedIndex(this.value.getMonth());
 		}


### PR DESCRIPTION
## Issue

The reset button in the Calendar sample no longer functions.
## Fix

It appears there has been a change in the order of evaluation of bindings and change handlers, which the Calendar sample is dependent upon (it attempts to transform the value during binding, assuming that the change handler has already run). We can instead pass the current date (via `new Date()`) instead of `null` as the value of `moon.Calendar` when resetting.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
