### PR TITLE
BHV-4060: Only reflow when necessary (initial expansion, picker property change).

### DIFF
--- a/source/ExpandableIntegerPicker.js
+++ b/source/ExpandableIntegerPicker.js
@@ -45,7 +45,8 @@ enyo.kind({
 	autoCollapse: true,
 
 	handlers: {
-		requestScrollIntoView: "requestScrollIntoView"
+		requestScrollIntoView: "requestScrollIntoView",
+		onRebuilt: "requestPickerReflow"
 	},
 	components: [
 		{name: "headerWrapper", kind: "moon.Item", classes: "moon-expandable-picker-header-wrapper", onSpotlightFocus: "headerFocus", ontap: "expandContract", components: [
@@ -76,14 +77,11 @@ enyo.kind({
 
 	create: function() {
 		this.inherited(arguments);
-		for (var i = 0, observedProps = this.$.picker.observers["triggerRebuild"]; i < observedProps.length; i++) {
-			this.addObserver(observedProps[i], this.triggerReflow);
-		}
-		this.triggerReflow();
+		this.requestPickerReflow();
 	},
 
-	triggerReflow: function() {
-		this.shouldReflow = true;
+	requestPickerReflow: function() {
+		this._needsPickerReflow = true;
 	},
 
 	// Change handlers
@@ -96,9 +94,9 @@ enyo.kind({
 	openChanged: function() {
 		this.inherited(arguments);
 		this.setActive(this.getOpen());
-		if (this.open && this.shouldReflow) {
+		if (this.open && this._needsPickerReflow) {
 			this.$.picker.reflow();
-			this.shouldReflow = false;
+			this._needsPickerReflow = false;
 		}
 	},
 

--- a/source/SimpleIntegerPicker.js
+++ b/source/SimpleIntegerPicker.js
@@ -30,7 +30,13 @@ enyo.kind({
 
 			_inEvent.content_ contains the content of the currently selected item.
 		*/
-		onSelect: ""
+		onSelect: "",
+		/**
+			Fires when the picker is rebuilt, allowing other controls the opportunity to reflow the 
+			picker as necessary, i.e. as a child of _moon.ExpandableIntegerPicker_ needing to be 
+			reflowed when opened as it may currently not be visible.
+		*/
+		onRebuilt: ""
 	},
 	//* @protected
 	handlers: {
@@ -171,6 +177,7 @@ enyo.kind({
 		this.$.client.render();
 		this.reflow();
 		this.validate();
+		this.doRebuilt();
 	},
 	triggerRebuild: function() {
 		// We use a job here to avoid rebuilding the picker multiple


### PR DESCRIPTION
## Issue

A reflow is run everytime the picker is opened.
## Fix

Instead of defining the observer declaratively in `moon.ExpandableIntegerPicker`, I defined it programmatically to keep it in sync with the `triggerRebuild` observable of `moon.SimpleIntegerPicker`. Would like some extra review on this in case this is not kosher or has some subtle side effects. Now we only reflow the picker upon initial opening, or when one of the properties that triggers a rebuild has changed.

There would be an issue if the property names did not match between `moon.ExpandableIntegerPicker` and `moon.SimpleIntegerPicker`, so maybe the programmatic instantiation of the observer is not really necessary...

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
