### PR TITLE
BHV-9375: DatePicker: Choosing a Locale Dismisses the Picker on TV

### DIFF
--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -219,6 +219,11 @@ enyo.kind({
 			delete this._tf;
 		}
 		this.initDefaults();
-		this.render();
+		var pickers = this.pickers;
+		if (pickers) {
+			for (var i = 0; i < pickers.length; i++) {
+				pickers[i].render();
+			}
+		}
 	}
 });


### PR DESCRIPTION
Render children only, not whole control.
