### PR TITLE
BHV-9960: Hide scroll columns when 5-way leaving scroller.

### DIFF
--- a/source/Scroller.js
+++ b/source/Scroller.js
@@ -15,11 +15,6 @@ enyo.kind({
 	kind:      "enyo.Scroller",
 	//* @public
 	published: {
-		//* If true, paging controls are hidden if a key is pressed (5-way mode)
-		hidePagingOnKey: true,
-		//* If true, paging controls are hidden if the user's pointer leaves this
-		//* control
-		hidePagingOnLeave: true,
 		/**
 			If true, when scrolling to focused child controls, the scroller will
 			scroll as far as possible, until its edge meets the next item's edge


### PR DESCRIPTION
## Issue

This is related to a regression from BHV-736 where leaving a scroller via 5-way no longer hides the scroll columns.
## Fix

Because the viewport of the scroll strategy is now spottable, we do an object comparison on the owner of the event originator (which should be the strategy if it is the viewport) and the scroller's strategy.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
