### PR TITLE
BHV-10114 Updata metrics after collection changed.

### DIFF
--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -50,14 +50,14 @@ enyo.kind({
 			};
 		}),
 		modelsAdded: enyo.inherit(function (sup) {
-			return function (c, e, props) {
-				this.updateMetrics(this.list);
+			return function (list, props) {
+				this.updateIndexBound(list);
 				sup.apply(this, arguments);
 			};
 		}),
 		modelsRemoved: enyo.inherit(function (sup) {
-			return function (c, e, props) {
-				this.updateMetrics(this.list);
+			return function (list, props) {
+				this.updateIndexBound(list);
 				sup.apply(this, arguments);
 			};
 		}),


### PR DESCRIPTION
Especially in dataGridList, after model added or removed then HandleSpotlightFocus() is not working well.
When you press down from bottom item, it should scroll a single row.
However after some models are added, it scrolls two rows and you can see spotlight focus.
(It is out of view port)

When collection is changed, list.indexBoundFirstRow and list.indexBoundLastRow should be updated too.
To resolve this, I calls updateMetrics when model is added or removed

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
