### PR TITLE
BHV-4645: Move onSpotlightSelect call from onKeyDown to onKeyUp timing.

### DIFF
--- a/source/Button.js
+++ b/source/Button.js
@@ -37,7 +37,7 @@ enyo.kind({
 	spotlight: true,
 	handlers: {
 		//* _onSpotlightSelect_ simulates _mousedown_.
-		onSpotlightSelect	: 'depress',
+		onSpotlightKeyDown	: 'depress',
 		//* _onSpotlightKeyUp_ simulates _mouseup_.
 		onSpotlightKeyUp	: 'undepress',
 		//* Also make sure we remove the pressed class if focus is removed from
@@ -56,8 +56,10 @@ enyo.kind({
 		this.inherited(arguments);
 	},
 	//* Adds _pressed_ CSS class.
-	depress: function() {
-		this.addClass('pressed');
+	depress: function(inSender, inEvent) {
+		if (inEvent.keyCode === 13) {
+			this.addClass('pressed');
+		}
 	},
 	//* Bubble _requestScrollIntoView_ event
 	spotFocused: function(inSender, inEvent) {

--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -39,7 +39,7 @@ enyo.kind({
 		]},
 		{name: "drawer", kind: "enyo.Drawer", resizeContainer:false, classes:"moon-expandable-list-item-client indented", components: [
 			{name: "inputDecorator", kind: "moon.InputDecorator", onSpotlightBlur: "inputBlur", onSpotlightFocus: "inputFocus", onSpotlightDown: "inputDown", components: [
-				{name: "clientInput", kind: "moon.Input", onchange: "doChange", onkeydown: "inputKeyDown"}
+				{name: "clientInput", kind: "moon.Input", onchange: "doChange", onkeyup: "inputKeyUp"}
 			]}
 		]}
 	],
@@ -95,7 +95,7 @@ enyo.kind({
 			this.toggleActive();
 		}
 	},
-	inputKeyDown: function(inSender, inEvent) {
+	inputKeyUp: function(inSender, inEvent) {
 		if (inEvent.keyCode === 13) {
 			this.closeDrawerAndHighlightHeader();
 		}

--- a/source/IconButton.js
+++ b/source/IconButton.js
@@ -47,7 +47,7 @@ enyo.kind({
 	spotlight: true,
 	handlers: {
 		//* onSpotlightSelect simulates mousedown
-		onSpotlightSelect: "depress",
+		onSpotlightKeyDown: "depress",
 		//* onSpotlightKeyUp simulates mouseup
 		onSpotlightKeyUp: "undepress",
 		//* used to request it is in view in scrollers
@@ -75,8 +75,10 @@ enyo.kind({
 		this.bubble("onActivate");
 	},
 	//* Adds _pressed_ CSS class.
-	depress: function() {
-		this.addClass("pressed");
+	depress: function(inSender, inEvent) {
+		if (inEvent.keyCode === 13) {
+			this.addClass("pressed");
+		}
 	},
 	//* Removes _pressed_ CSS class.
 	undepress: function() {

--- a/source/PagingControl.js
+++ b/source/PagingControl.js
@@ -17,7 +17,7 @@ enyo.kind({
 	noBackground: true,
 	handlers: {
 		onSpotlightFocused: "noop",
-		onSpotlightSelect: "depress",
+		onSpotlightKeyDown: "depress",
 		onSpotlightKeyUp: "undepress",
 		ondown: "down",
 		onup: "endHold",
@@ -96,14 +96,16 @@ enyo.kind({
 		this.inherited(arguments);
 		// keydown events repeat (while mousedown/hold does not); simulate
 		// hold behavior with mouse by catching the second keydown event
-		if (!this.downCount) {
-			this.down();
-			this.downCount = 1;
-		} else {
-			this.downCount++;
-		}
-		if (this.downCount == 2) {
-			this.hold();
+		if (inEvent.keyCode === 13) {
+			if (!this.downCount) {
+				this.down();
+				this.downCount = 1;
+			} else {
+				this.downCount++;
+			}
+			if (this.downCount == 2) {
+				this.hold();
+			}
 		}
 	},
 	undepress: function(inSender, inEvent) {

--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -72,11 +72,11 @@ enyo.kind({
 		onSpotlightFocused: "scrollIntoView"
 	},
 	components: [
-		{name: "buttonLeft",  kind: "moon.IconButton", noBackground:true, classes: "moon-simple-picker-button left", icon:"arrowlargeleft", onSpotlightSelect: "left", ondown: "downLeft", onholdpulse:"left", defaultSpotlightDisappear: "buttonRight"},
+		{name: "buttonLeft",  kind: "moon.IconButton", noBackground:true, classes: "moon-simple-picker-button left", icon:"arrowlargeleft", onSpotlightKeyDown:"configureSpotlightHoldPulse", onSpotlightSelect: "left", ondown: "downLeft", onholdpulse:"left", defaultSpotlightDisappear: "buttonRight"},
 		{kind: "enyo.Control", name: "clientWrapper", classes:"moon-simple-picker-client-wrapper", components: [
 			{kind: "enyo.Control", name: "client", classes: "moon-simple-picker-client"}
 		]},
-		{name: "buttonRight", kind: "moon.IconButton", noBackground:true, classes: "moon-simple-picker-button right", icon:"arrowlargeright", onSpotlightSelect: "right", ondown: "downRight", onholdpulse:"right", defaultSpotlightDisappear: "buttonLeft"}
+		{name: "buttonRight", kind: "moon.IconButton", noBackground:true, classes: "moon-simple-picker-button right", icon:"arrowlargeright", onSpotlightKeyDown:"configureSpotlightHoldPulse", onSpotlightSelect: "right", ondown: "downRight", onholdpulse:"right", defaultSpotlightDisappear: "buttonLeft"}
 	],
 	create: function() {
 		this.inherited(arguments);
@@ -236,46 +236,60 @@ enyo.kind({
 			}
 		}
 	},
-	left: function() {
+	left: function(inSender, inEvent) {
+		if (inEvent && inEvent.sentHold) { return; }
 		if (this.rtl) {
-			this.next();
+			this.next(inSender, inEvent);
 		} else {
-			this.previous();
+			this.previous(inSender, inEvent);
 		}
 	},
-	right: function() {
+	right: function(inSender, inEvent) {
+		if (inEvent && inEvent.sentHold) { return; }
 		if (this.rtl) {
-			this.previous();
+			this.previous(inSender, inEvent);
 		} else {
-			this.next();
+			this.next(inSender, inEvent);
 		}
 	},
 	downLeft: function(inSender, inEvent) {
 		inEvent.configureHoldPulse({endHold: "onLeave", delay: 300});
-		this.left();
+		this.left(inSender, inEvent);
 	},
 	downRight: function(inSender, inEvent) {
 		inEvent.configureHoldPulse({endHold: "onLeave", delay: 300});
-		this.right();
+		this.right(inSender, inEvent);
+	},
+	configureSpotlightHoldPulse: function(inSender, inEvent) {
+		if (inEvent.keyCode === 13) {
+			inEvent.configureHoldPulse({endHold: "onLeave", delay: 300});
+		}
 	},
 	//* @public
 	//* Cycles the selected item to the one before the currently selected item.
-	previous: function() {
+	previous: function(inSender, inEvent) {
 		if (!this.disabled) {
 			var idx = this.selectedIndex - 1;
 			if (idx < 0) {
 				idx = this.wrap ? this.getClientControls().length - 1 : 0;
+			}
+			if (!this.wrap && idx === 0 && inEvent && inEvent.cancelHoldPulse) {
+				inEvent.cancelHoldPulse();
 			}
 			this.setSelectedIndex(idx);
 		}
 	},
 	//* @public
 	//* Cycles the selected item to the one after the currently selected item.
-	next: function() {
+	next: function(inSender, inEvent) {
 		if (!this.disabled) {
 			var idx = this.selectedIndex + 1;
 			if (idx > this.getClientControls().length - 1) {
 				idx = this.wrap ? 0 : this.getClientControls().length - 1;
+			}
+			if (!this.wrap && idx === this.getClientControls().length - 1 
+				&& inEvent && inEvent.cancelHoldPulse) {
+				inEvent.cancelHoldPulse();
 			}
 			this.setSelectedIndex(idx);
 		}


### PR DESCRIPTION
- Button, IconButton, PagingControl: Change onSpotlightSelect handler to onSotlightKeyDown with keyCode check.
- ExpandableInput: Change onkeyup handler to onkeydown with keyCode check.
- SimplePicker: Apply repeated key handling
  Set configureHoldPulse on onSpotlightKeyDown handler to set pulse delay
  Cancel holdPulse when index reaches to the boundary.

Fixing: http://jira2.lgsvl.com/browse/BHV-4645

Depends on : https://github.com/enyojs/spotlight/pull/132

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
