### PR TITLE
BHV-8321: Blocking consecutive push/pop/replace panel

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -109,7 +109,7 @@ enyo.kind({
 	//* Flag for panel transition
 	transitionInProgress: false,
 	//* Flag for blocking consecutive push/pop/replace panel to protect create/render/destroy time
-	inPushPopReplacePanel: false,
+	isModifyingPanels: false,
 	//* @public
 
 	//* Returns true if a transition between panels is currently in progress.
@@ -120,22 +120,22 @@ enyo.kind({
 	//* Creates a panel on top of the stack and increments index to select that
 	//* component.
 	pushPanel: function(inInfo, inMoreInfo) { // added
-		if (this.transitionInProgress || this.inPushPopReplacePanel) {return null;}
-		this.inPushPopReplacePanel = true;
+		if (this.transitionInProgress || this.isModifyingPanels) {return null;}
+		this.isModifyingPanels = true;
 		var lastIndex = this.getPanels().length - 1,
 			oPanel = this.createComponent(inInfo, inMoreInfo);
 		oPanel.render();
 		this.reflow();
 		oPanel.resized();
 		this.setIndex(lastIndex+1);
-		this.inPushPopReplacePanel = false;
+		this.isModifyingPanels = false;
 		return oPanel;
 	},
 	//* Creates multiple panels on top of the stack and updates index to select
 	//* the last one created.
 	pushPanels: function(inInfos, inCommonInfo) { // added
-		if (this.transitionInProgress || this.inPushPopReplacePanel) {return null;}
-		this.inPushPopReplacePanel = true;
+		if (this.transitionInProgress || this.isModifyingPanels) {return null;}
+		this.isModifyingPanels = true;
 		var lastIndex = this.getPanels().length - 1,
 			oPanels = this.createComponents(inInfos, inCommonInfo),
 			nPanel;
@@ -148,25 +148,25 @@ enyo.kind({
 			oPanels[nPanel].resized();
 		}
 		this.setIndex(lastIndex+1);
-		this.inPushPopReplacePanel = false;
+		this.isModifyingPanels = false;
 		return oPanels;
 	},
 	//* Destroys panels whose index is greater than or equal to _inIndex_.
 	popPanels: function(inIndex) {
-		if (this.transitionInProgress || this.inPushPopReplacePanel) {return;}
-		this.inPushPopReplacePanel = true;
+		if (this.transitionInProgress || this.isModifyingPanels) {return;}
+		this.isModifyingPanels = true;
 		var panels = this.getPanels();
 		inIndex = inIndex || panels.length - 1;
 
 		while (panels.length > inIndex && inIndex >= 0) {
 			panels[panels.length - 1].destroy();
 		}
-		this.inPushPopReplacePanel = false;
+		this.isModifyingPanels = false;
 	},
 	//* Destroys right panel and creates new panel without transition effect.
 	replacePanel: function(index, inInfo, inMoreInfo) {
-		if (this.transitionInProgress || this.inPushPopReplacePanel) {return;}
-		this.inPushPopReplacePanel = true;
+		if (this.transitionInProgress || this.isModifyingPanels) {return;}
+		this.isModifyingPanels = true;
 		var oPanel = null;
 
 		if (this.getPanels().length > index) {
@@ -178,7 +178,7 @@ enyo.kind({
 		oPanel = this.createComponent(inInfo, inMoreInfo);
 		oPanel.render();
 		this.resized();
-		this.inPushPopReplacePanel = false;
+		this.isModifyingPanels = false;
 	},
 	/**
 		Returns the panel index of the passed-in control, or -1 if the panel is not
@@ -248,7 +248,7 @@ enyo.kind({
 	},
 	onTap: function(oSender, oEvent) {
 		if (oEvent.originator === this.$.showHideHandle || this.pattern === "none" || 
-			this.transitionInProgress === true || this.inPushPopReplacePanel === true) {
+			this.transitionInProgress === true || this.isModifyingPanels === true) {
 			return;
 		}
 


### PR DESCRIPTION
We blocking consecutive index change by looking at transitionInProgress flag.

But, we can not guard consecutive function call on push/pop/replace panels
because it has create/render/destroy call which is not protected by transitionInProgress flag.

This is simple straight forward fix for this reentrance problem.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
