### PR TITLE
BHV-10371: DataList: 5way Down does not Spot Drawer

### DIFF
--- a/source/Drawers.js
+++ b/source/Drawers.js
@@ -47,7 +47,8 @@ enyo.kind({
 		onActivate: "drawerActivated",
 		onDeactivate: "drawerDeactivated",
 		onSpotlightDown:"spotDown",
-		onSpotlightUp:"spotUp"
+		onSpotlightUp:"spotUp",
+		onSpotlightFocus: "initialSpotlightFocus"
 	},
 	components: [
 		{name:"activatorWrapper", classes:"moon-drawers-activator-wrapper", spotlight:true, ontap:"activatorHandler", components: [
@@ -158,6 +159,14 @@ enyo.kind({
 			}
 		}
 		this.updateActivator(false);
+	},
+	// initialSpotlightFocus() ensures the first spot in response 
+	// to a 5-way event goes to the topmost element, activatorWrapper
+	initialSpotlightFocus: function(inSender, inEvent) {
+		if (!enyo.Spotlight.getCurrent() && !enyo.Spotlight.getPointerMode() && (inEvent.dispatchTarget != this.$.activatorWrapper) && inEvent.dispatchTarget.isDescendantOf(this)) {
+			enyo.Spotlight.spot(this.$.activatorWrapper);
+			return true;
+		}
 	},
 	captureSpotFocus: function(inSender, inEvent) {
 		// Only close drawers on 5-way focus in the client (not pointer focus)


### PR DESCRIPTION
Issue

When pressing 5-way down after loading, the spotlight does not go the activator, the topmost element of the drawer

Fix

Add a check to ensure that when no element is currently spotlighted, and the drawer receives a spotlightFocus event as a result of a 5-way input, the activator element is the one spotlighted

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
