### PR TITLE
BHV-10443: Add proper support for disabled item.

### DIFF
--- a/samples/ExpandableListItemSample.js
+++ b/samples/ExpandableListItemSample.js
@@ -13,6 +13,11 @@ enyo.kind({
 					{content: "Item 2"},
 					{content: "Item 3"}
 				]},
+				{kind: "moon.ExpandableListItem", disabled:true, content:"Disabled ListItem", components: [
+					{content: "Item 1"},
+					{content: "Item 2"},
+					{content: "Item 3"}
+				]},
 				{kind: "moon.ExpandableListItem", content: "Pre-expanded ListItem", open: true, components: [
 					{content: "Item 1"},
 					{content: "Item 2"},

--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -92,7 +92,8 @@ enyo.kind({
 	],
 	bindings: [
 		{from: ".allowHtml", to: ".$.header.allowHtml"},
-		{from: ".disabled", to: ".$.header.disabled"}
+		{from: ".disabled", to: ".$.header.disabled"},
+		{from: ".disabled", to: ".$.headerContainer.disabled"}
 	],
 	//* @protected
 	create: function() {


### PR DESCRIPTION
## Issue

The header for a disabled `moon.ExpandableListItem` was not reflecting the disabled state.
## Fix

Bind the value of `disabled` to `headerContainer`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
