### PR TITLE
BHV-10443: Remove unnecessary binding.

### DIFF
--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -92,7 +92,6 @@ enyo.kind({
 	],
 	bindings: [
 		{from: ".allowHtml", to: ".$.header.allowHtml"},
-		{from: ".disabled", to: ".$.header.disabled"},
 		{from: ".disabled", to: ".$.headerContainer.disabled"}
 	],
 	//* @protected


### PR DESCRIPTION
## Issue

Now that we are binding `disabled` to `headerContainer.disabled`, we no longer need the binding to `header.disabled`.
## Fix

We remove the binding to `header.disabled`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
