### PR TITLE
BHV-8206: Restore moon.ToggleText for backwards-compatibility.

### DIFF
--- a/css/ToggleText.less
+++ b/css/ToggleText.less
@@ -1,0 +1,38 @@
+/* ToggleText.css */
+
+.moon-checkbox.moon-toggle-text {
+	text-align: left;
+	text-transform: uppercase;
+	background: inherit;
+	opacity: 1;
+	background: transparent none no-repeat 0 0;
+}
+.moon-checkbox.moon-toggle-text[disabled] {
+	opacity: @moon-disabled-opacity;
+}
+.moon-checkbox.moon-toggle-text[checked] {
+	background: transparent none no-repeat 0px 0px;
+}
+
+.moon-checkbox-item.spotlight .moon-checkbox.moon-toggle-text[checked] {
+	background: transparent none no-repeat 0px 0px;
+}
+
+.moon-toggle-text-text {
+	position: absolute;
+	right: 0px;
+	top: 2px;
+	text-align: right;
+	color: @moon-toggle-text-color;
+}
+
+.enyo-locale-right-to-left {
+	.moon-toggle-text-text {
+		right: auto;
+		left: 0px;
+	}
+}
+
+.moon-checkbox-item.spotlight .moon-toggle-text-text {
+	color: @moon-spotlight-text-color;
+}

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1206,6 +1206,37 @@
   margin-right: 32px;
   margin-left: 0px;
 }
+/* ToggleText.css */
+.moon-checkbox.moon-toggle-text {
+  text-align: left;
+  text-transform: uppercase;
+  background: inherit;
+  opacity: 1;
+  background: transparent none no-repeat 0 0;
+}
+.moon-checkbox.moon-toggle-text[disabled] {
+  opacity: 0.6;
+}
+.moon-checkbox.moon-toggle-text[checked] {
+  background: transparent none no-repeat 0px 0px;
+}
+.moon-checkbox-item.spotlight .moon-checkbox.moon-toggle-text[checked] {
+  background: transparent none no-repeat 0px 0px;
+}
+.moon-toggle-text-text {
+  position: absolute;
+  right: 0px;
+  top: 2px;
+  text-align: right;
+  color: #a6a6a6;
+}
+.enyo-locale-right-to-left .moon-toggle-text-text {
+  right: auto;
+  left: 0px;
+}
+.moon-checkbox-item.spotlight .moon-toggle-text-text {
+  color: #ffffff;
+}
 /* ToggleSwitch.css */
 .moon-checkbox.moon-toggle-switch {
   border-radius: 16.5px;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1206,6 +1206,37 @@
   margin-right: 32px;
   margin-left: 0px;
 }
+/* ToggleText.css */
+.moon-checkbox.moon-toggle-text {
+  text-align: left;
+  text-transform: uppercase;
+  background: inherit;
+  opacity: 1;
+  background: transparent none no-repeat 0 0;
+}
+.moon-checkbox.moon-toggle-text[disabled] {
+  opacity: 0.35;
+}
+.moon-checkbox.moon-toggle-text[checked] {
+  background: transparent none no-repeat 0px 0px;
+}
+.moon-checkbox-item.spotlight .moon-checkbox.moon-toggle-text[checked] {
+  background: transparent none no-repeat 0px 0px;
+}
+.moon-toggle-text-text {
+  position: absolute;
+  right: 0px;
+  top: 2px;
+  text-align: right;
+  color: #4b4b4b;
+}
+.enyo-locale-right-to-left .moon-toggle-text-text {
+  right: auto;
+  left: 0px;
+}
+.moon-checkbox-item.spotlight .moon-toggle-text-text {
+  color: #ffffff;
+}
 /* ToggleSwitch.css */
 .moon-checkbox.moon-toggle-switch {
   border-radius: 16.5px;

--- a/css/moonstone-rules.less
+++ b/css/moonstone-rules.less
@@ -50,6 +50,7 @@
 @import "Checkbox.less";
 @import "Divider.less";
 @import "CheckboxItem.less";
+@import "ToggleText.less";
 @import "ToggleSwitch.less";
 @import "ToggleItem.less";
 @import "ToggleButton.less";

--- a/source/ToggleText.js
+++ b/source/ToggleText.js
@@ -1,0 +1,31 @@
+/**
+	_moon.ToggleText_, which extends [moon.Checkbox](#moon.Checkbox), is a control
+	that looks like a switch with labels for an "on" state and an "off" state.
+	When the ToggleText is tapped, it switches its state and fires an _onChange_
+	event.
+*/
+
+enyo.kind({
+	name: "moon.ToggleText",
+	kind: "moon.Checkbox",
+	//* @public
+	published: {
+		//* Text label for the "on" state
+		onContent: moon.$L("on"),   // i18n "ON" label in moon.ToggleText widget
+		//* Text label for the "off" state
+		offContent: moon.$L("off")  // i18n "OFF" label in moon.ToggleText widget
+	},
+	//* @protected
+	classes: "moon-toggle-text",
+	components: [
+		{name: "label", classes: "moon-toggle-text-text"}
+	],
+	create: function() {
+		this.inherited(arguments);
+		this.checkedChanged();
+	},
+	checkedChanged: function() {
+		this.inherited(arguments);
+		this.$.label.setContent(this.getChecked() ? this.onContent : this.offContent);
+	}
+});

--- a/source/package.js
+++ b/source/package.js
@@ -15,6 +15,7 @@ enyo.depends(
 	"MoonGridFlyweightRepeater.js",
 	"Checkbox.js",
 	"CheckboxItem.js",
+	"ToggleText.js",
 	"ToggleSwitch.js",
 	"ToggleItem.js",
 	"ToggleButton.js",


### PR DESCRIPTION
## Issue

The `moon.ToggleText` was removed during a clean-up, as the implementation of `moon.ToggleItem` had changed. Unfortunately, certain apps are still using the `moon.ToggleText` kind directly.
## Fix

Fully restore `moon.ToggleText`. We will make a note to developers that this kind is deprecated and to upgrade their apps for the eventual removal of this kind.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
