### PR TITLE
Bhv 10793 Resolve timing issue that can be occurred from sequential key input

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -619,7 +619,8 @@ enyo.kind({
 
 		// queuedIndex becomes -1 when left key input is occurred 
 		// during transition from index 1 to 0.
-		if (this.queuedIndex === -1) {
+		// We can hide panels if we use handle.
+		if (this.queuedIndex === -1 && this.useHandle) {
 			this.hide();
 		} else if (this.queuedIndex !== null) {
 			this.setIndex(this.queuedIndex);


### PR DESCRIPTION
## Issue

Sometime last key input is lost and there is not following panel transition after first panel move. 
Just in some specific cases.

To reproduce it, press right first then press left with having a little gap.
More precisely when panel is moving to right, press left. 
What is your expected? Yes. It should move to left.
However there is no more transition.
## Cause

Currently queuedIndex is only get a value when setIndex() is executed.
If next key input is occurred after setIndex() is executed, this key input will be lost.
## Fix

Move updating queuedIndex into spotlight handlers. 
