### PR TITLE
ANG-10189 Sequential right key input does not bring the next next panel

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -235,6 +235,9 @@ enyo.kind({
 	spotlightLeft: function(oSender, oEvent) {
 		// Don't allow left-movement from a breadcrumb
 		if (oEvent.originator.name === "breadcrumbBackground") { return true; }
+		if (this.toIndex !== null) {
+			this.queuedIndex = this.toIndex - 1;
+		}
 	},
 	spotlightRight: function(oSender, oEvent) {
 		if (oEvent.originator.name === "breadcrumbBackground") {
@@ -243,6 +246,9 @@ enyo.kind({
 			var idx = this.getPanelIndex(oEvent.originator) + 1;
 			enyo.Spotlight.spot(this.getPanels()[idx]);
 			return true; 
+		}
+		if (this.toIndex !== null) {
+			this.queuedIndex = this.toIndex + 1;
 		}
 	},
 	spotlightDown: function(oSender, oEvent) {
@@ -365,7 +371,6 @@ enyo.kind({
 		}
 
 		if (this.toIndex !== null) {
-			this.queuedIndex = inIndex;
 			return;
 		}
 


### PR DESCRIPTION
## Issue

If you press right key twice, you will expected that there are two panel transition but it does not happen.
Left-right, left-left and right-left are working well but only right-right case is failed.
## Cause

next() is consisted with two behaviors
Shrinking panel and re-arranging panels. We call shrinking is "pre transition"

previous() is also consisted with two behaviors
Re -arranging panels and growing panel. We call growing is "post transition"

Here is the point.
next() has pre transition. So in triggerPretransition(), length of preTransitionWaitlist is not '0'
It makes delay index updating because index updating is conducted when animation finished.
However, sequential right key input is entered before animation playing.
In this reason, last right key input still have initial index value instead of updated one.
## Fix

Move updating queuedIndex into spotlight handlers. 
Spotlight key handler will react every single time.
