### PR TITLE
Fix for: BHV-10816

### DIFF
--- a/samples/DataGridListSample.js
+++ b/samples/DataGridListSample.js
@@ -46,7 +46,7 @@ enyo.kind({
 	},
 	generateRecords: function () {
 		var records = [],
-			idx     = this.index || 0;
+			idx     = this.modelIndex || 0;
 		for (; records.length < 500; ++idx) {
 			var title = (idx % 8 === 0) ? " with long title" : "";
 			var subTitle = (idx % 8 === 0) ? "Lorem ipsum dolor sit amet" : "Subtitle";
@@ -58,7 +58,7 @@ enyo.kind({
 			});
 		}
 		// update our internal index so it will always generate unique values
-		this.index = idx;
+		this.modelIndex = idx;
 		return records;
 	},
 	refreshItems: function () {


### PR DESCRIPTION
The sample was using the enyo.Panels property `index` and was experiencing collision. The fact it was working before was a fluke. A recent change updates the `index` to the correct panel index and was overwriting the sample's intended variable. Simply avoiding this collision fixes the problem.

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)
