### PR TITLE
BHV-10834: Fix margins for VideoFeedback in RTL mode.

### DIFF
--- a/css/VideoFeedback.less
+++ b/css/VideoFeedback.less
@@ -56,3 +56,15 @@
 .enyo-locale-non-latin .moon-video-feedback-icon-right {
 	margin-bottom: 2px;
 }
+
+.enyo-locale-right-to-left {
+	.moon-video-player-feedback {
+		margin: 0 0 0 @moon-video-player-icon-text-gutter-width;
+	}
+	.moon-icon.moon-video-feedback-icon-left {
+		margin: 0 0 0 @moon-video-player-icon-text-gutter-width;
+	}
+	.moon-icon.moon-video-feedback-icon-right {
+		margin: 0 @moon-video-player-icon-text-gutter-width 0 0;
+	}
+}

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4518,6 +4518,15 @@
 .enyo-locale-non-latin .moon-video-feedback-icon-right {
   margin-bottom: 2px;
 }
+.enyo-locale-right-to-left .moon-video-player-feedback {
+  margin: 0 0 0 15px;
+}
+.enyo-locale-right-to-left .moon-icon.moon-video-feedback-icon-left {
+  margin: 0 0 0 15px;
+}
+.enyo-locale-right-to-left .moon-icon.moon-video-feedback-icon-right {
+  margin: 0 15px 0 0;
+}
 .moon-video-info-header {
   display: inline-block;
   vertical-align: top;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4514,6 +4514,15 @@
 .enyo-locale-non-latin .moon-video-feedback-icon-right {
   margin-bottom: 2px;
 }
+.enyo-locale-right-to-left .moon-video-player-feedback {
+  margin: 0 0 0 15px;
+}
+.enyo-locale-right-to-left .moon-icon.moon-video-feedback-icon-left {
+  margin: 0 0 0 15px;
+}
+.enyo-locale-right-to-left .moon-icon.moon-video-feedback-icon-right {
+  margin: 0 15px 0 0;
+}
 .moon-video-info-header {
   display: inline-block;
   vertical-align: top;


### PR DESCRIPTION
## Issue

The `moon.VideoFeedback` icons are displayed improperly in RTL mode.
## Fix

Add some RTL-specific styling for `moon.VideoFeedback` icons and text.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
