### PR TITLE
BHV-10842: ExpandableIntegerPicker-NonLatin: Arrows do not display in No...

### DIFF
--- a/css/SimpleIntegerPicker.less
+++ b/css/SimpleIntegerPicker.less
@@ -26,7 +26,7 @@
 .moon-simple-integer-picker.spotlight .moon-simple-integer-picker-button {
 	color: @moon-spotlight-text-color;
 }
-.moon-simple-integer-picker-button {  
+.moon-simple-integer-picker-button {
   border-radius: @moon-picker-button-width/2;  border: 0;
   background: inherit;
   padding: 0;
@@ -42,6 +42,10 @@
     height: 100%;
   }
 }
+.enyo-locale-non-latin .moon button.moon-simple-integer-picker-button {
+  font-family: "Moonstone Icons";
+}
+
 .spotlight .moon-simple-integer-picker-button {
 	&.moon-icon {
 		color: @moon-spotlight-text-color;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -985,6 +985,9 @@
   width: 60px;
   height: 100%;
 }
+.enyo-locale-non-latin .moon button.moon-simple-integer-picker-button {
+  font-family: "Moonstone Icons";
+}
 .spotlight .moon-simple-integer-picker-button {
   /* Hover while not Pressed state */
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -985,6 +985,9 @@
   width: 60px;
   height: 100%;
 }
+.enyo-locale-non-latin .moon button.moon-simple-integer-picker-button {
+  font-family: "Moonstone Icons";
+}
 .spotlight .moon-simple-integer-picker-button {
   /* Hover while not Pressed state */
 }


### PR DESCRIPTION
...n-Latin Font Enyo-DCO-1.1-Signed-off-by: Brooke Peterson brooke.peterson@lge.com
### Objective/Issues

in non-latin SimpleIntergerPicker icon do not render
### Cause

There is a generic rule .enyo-locale-non-latin .moon button font-family: "Moonstone LG Display"; override the moon icon font family
### Fix:

Write a more specificity class to correct this problem:
.enyo-locale-non-latin .moon button.moon-simple-integer-picker-button {
  font-family: "Moonstone Icons";
}
### Note:

This is just a quick fix,  SimpleIntegerPicker.less is very verbose and the code could be greatly simplified. Also we probably should not use moon-icon, can just use pseudo elector like I did with date/time picker. Will do a follow up PR.
