### PR TITLE
Switch this fix to use the icon font variable.

### DIFF
--- a/css/SimpleIntegerPicker.less
+++ b/css/SimpleIntegerPicker.less
@@ -43,7 +43,7 @@
   }
 }
 .enyo-locale-non-latin .moon button.moon-simple-integer-picker-button {
-  font-family: "Moonstone Icons";
+  font-family: @moon-icon-font-family;
 }
 
 .spotlight .moon-simple-integer-picker-button {


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
