### PR TITLE
BHV-10787: Capture Spotlight focus in fullscreen mode.

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -217,6 +217,9 @@ enyo.kind({
 		onSpotlightRight: 'spotlightLeftRightFilter',
 		onresize: 'handleResize'
 	},
+	eventsToCapture: {
+		onSpotlightFocus: "capturedFocus"
+	},
     bindings: [
 		{from: ".sourceComponents",			to:".$.video.sourceComponents"},
 		{from: ".playbackRateHash",			to:".$.video.playbackRateHash"},
@@ -853,7 +856,9 @@ enyo.kind({
 			this.$.fullscreenControl.setShowing(true);
 			this.showFSControls();
 			this.$.controlsContainer.resize();
+			this.capture();
 		} else {
+			this.release();
 			this.stopJob("autoHide");
 			this.addClass("inline");
 			this.$.inlineControl.setShowing(true);
@@ -1235,6 +1240,16 @@ enyo.kind({
 				}
 			}
 		}
+		return true;
+	},
+	capture: function() {
+		enyo.dispatcher.capture(this, this.eventsToCapture);
+	},
+	release: function() {
+		enyo.dispatcher.release(this);
+	},
+	capturedFocus: function(inSender, inEvent) {
+		enyo.Spotlight.spot(this);
 		return true;
 	}
 });


### PR DESCRIPTION
## Issue

Upon initially changing to fullscreen video mode, when the pointer times out and hides, the banner and/or player controls cannot be brought back via the 5-way up/down keys.
## Fix

We capture the `onSpotlightFocus` event via the capture API to constrain Spotlight focus to the `moon.VideoPlayer` in fullscreen mode.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
