### PR TITLE
(For Beehive) Ang 10315 Moving 5-way key does not work after records added

### DIFF
--- a/source/DataList.js
+++ b/source/DataList.js
@@ -30,10 +30,10 @@
 		* @private
 		*/
 		handlers: {
-			onSpotlightUp    : 'selectPrev',
-			onSpotlightLeft  : 'selectPrev',
-			onSpotlightDown  : 'selectNext',
-			onSpotlightRight : 'selectNext'
+			onSpotlightUp    : '_spotlightPrev',
+			onSpotlightLeft  : '_spotlightPrev',
+			onSpotlightDown  : '_spotlightNext',
+			onSpotlightRight : '_spotlightNext'
 		},
 
 		/**
@@ -128,15 +128,15 @@
 		/**
 		* @private
 		*/
-		selectNext: function (inSender, inEvent) {
-			return this.selectItem(inEvent, 1);
+		_spotlightNext: function (inSender, inEvent) {
+			return this._spotlightSelect(inEvent, 1);
 		},
 
 		/**
 		* @private
 		*/
-		selectPrev: function (inSender, inEvent) {
-			return this.selectItem(inEvent, -1);
+		_spotlightPrev: function (inSender, inEvent) {
+			return this._spotlightSelect(inEvent, -1);
 		},
 
 		/**
@@ -145,7 +145,7 @@
 		*
 		* @private
 		*/
-		selectItem: function (inEvent, inDirection) {
+		_spotlightSelect: function (inEvent, inDirection) {
 			var pages = this.delegate.pagesByPosition(this),
 				spottableControl;
 


### PR DESCRIPTION
## Issue

If your focus places on controls in last row of lastPage and you added some recoreds,
then you can not go down with 5-way key even though there are spottable items.
## Cause

Currently adjusting page is not occurred with down key in lastPage because it is useless.
And we can consider whether we should adjust page or not only after scrolling.
So in last row of lastPage, down key input cannot make "onScroll" event.
There is a trap.
## Fix

We can use "onScroll" event. So, I use spotlight event.
When we select "next" item, I added conditional branch to make thing right.
