### PR TITLE
DataGridList is fires onActiveChange event for every item render when it...

### DIFF
--- a/source/IconButton.js
+++ b/source/IconButton.js
@@ -58,10 +58,6 @@ enyo.kind({
 		this.inherited(arguments);
 		this.noBackgroundChanged();
 	},
-	rendered: function() {
-		this.inherited(arguments);
-		this.activeChanged();
-	},
 	noBackgroundChanged: function() {
 		this.addRemoveClass("no-background", this.noBackground);
 	},


### PR DESCRIPTION
...em is mixin moon.SelectionOverlaySupport on it.

This is because moon.IconButton is calling activeChanged on rendered always.
And this code is added to support pagingControls auto hide feature which is not a requirement anymore.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
