### PR TITLE
Bhv 11099 Has improper position for disabled control.

### DIFF
--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -99,24 +99,28 @@ enyo.kind({
 				pBounds = this.parent.getAbsoluteBounds(),
 				acBounds =null;
 			
-			//* If target control is disabled, Spotlight focus cannot be captured.
-			//* In that case, we consider that tooltip decorator covers target bounds.
+			var paTopDiff, 
+				paLeftDiff,
+				paRightDiff;
+
+			//* If activator is disabled, Spotlight focus cannot be captured.
+			//* In that case, we consider that tooltip decorator covers activator's bounds.
 			this.activator = enyo.Spotlight.getCurrent();
 			if (!!this.activator) {
 				acBounds = this.activator.getAbsoluteBounds();	
+
+				//* Calculate the difference between decorator and activating
+				//* control's top, left, right differences, position tooltip against
+				//* the activating control instead of the decorator accordingly.
+				paTopDiff = pBounds.top - acBounds.top;
+				paLeftDiff =  acBounds.left - pBounds.left;
+				paRightDiff = pBounds.left + pBounds.width - acBounds.left - acBounds.width;
 			} else {
 				acBounds = pBounds;
+
+				paTopDiff = paLeftDiff = paRightDiff = 0;
 			}
 			
-
-			//* Calculate the difference between decorator and activating
-			//* control's top, left, right differences, position tooltip against
-			//* the activating control instead of the decorator accordingly.
-			var paTopDiff = pBounds.top - acBounds.top,
-				paLeftDiff =  acBounds.left - pBounds.left,
-				paRightDiff = pBounds.left + pBounds.width - acBounds.left - acBounds.width,
-				acRight = window.innerWidth - moonDefaultPadding - acBounds.left - acBounds.width;
-
 			//* When there is not enough room in the bottom, move it above the
 			//* decorator; when the tooltip bottom is within window height but
 			//* set programmatically above, move it above
@@ -150,6 +154,7 @@ enyo.kind({
 				this.addClass("right-arrow");
 				this.applyPosition({"margin-left": - b.width + "px", "left": "auto"});
 				if (this.floating) {
+					var acRight = window.innerWidth - moonDefaultPadding - acBounds.left - acBounds.width;
 					this.applyStyle("right", acBounds.width / 2 + acRight + moonDefaultPadding + "px");
 				} else {
 					this.applyStyle("right", acBounds.width / 2 + paRightDiff + "px");


### PR DESCRIPTION
## Issue

If tooltip is showing on disabled control, it could not calculate its position
## Cause

Current position calculation of tooltip is based on enyo.Spotlight.getCurrent()
However disabled control could not have spotlight focus. It makes problem.
## Fix

If activator is disabled, we will use decorator's bounds as activator's
because decorator could cover activator's space. 
