### PR TITLE
BHV-5144: moon.Panels - change onTransitionStart to fires before pre-transition

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -426,6 +426,7 @@ enyo.kind({
 			if (this.animate) {
 				this.transitionInProgress = true;
 				enyo.Spotlight.mute(this);
+				this.fireTransitionStart();
 				this.triggerPreTransitions();
 			}
 			else {
@@ -498,6 +499,12 @@ enyo.kind({
 		info.index = inPanelIndex;
 		info.animate = this.animate;
 		return info;
+	},
+	startTransition: function(sendEvents) {
+		if (this.transitionInProgress) {
+			sendEvents = !this.transitionInProgress;
+		}
+		this.inherited(arguments);
 	},
 	/**
 		If any panel has a pre-transition, pushes the panel's index to


### PR DESCRIPTION
BHV-5144: moon.Panels - change onTransitionStart to fires before pre-transition

Now, onTransitionStart fires after pre-transition work done when moving forward

So change transitionStart event firing time so that the event can fire before pre-transition.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
