### PR TITLE
BHV-2169: Disable SimplePicker Arrows when it has less than 2 items.

### DIFF
--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -115,14 +115,14 @@ enyo.kind({
 		if (this.disabled) {
 			this.hideNavButton(prevButton);
 			this.hideNavButton(nextButton);
-		// Always show buttons if _this.wrap_ is _true_
-		} else if (this.wrap) {
-			this.showNavButton(prevButton);
-			this.showNavButton(nextButton);
 		// If we have one or less options, always show no buttons
 		} else if (maxIndex <= 0) {
 			this.hideNavButton(prevButton);
 			this.hideNavButton(nextButton);
+		// Always show buttons if _this.wrap_ is _true_
+		} else if (this.wrap) {
+			this.showNavButton(prevButton);
+			this.showNavButton(nextButton);
 		// If we are on the first option, hide the left button
 		} else if (index <= 0) {
 			this.showNavButton(nextButton);


### PR DESCRIPTION
SimplePicker check wrap first then check maxIndex to enable/disable arrows.
But, arrows should be disabled when it has less than 2 items even if it is wrapping.

So, changing the order of condition check to check maxIndex before wrap.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
