### PR TITLE
BHV-11091: Fixing ExpandableInput so that it can be closed when tap on header.

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -149,9 +149,11 @@ enyo.kind({
 		subsequently 5-way move.
 	*/
 	closeDrawerAndHighlightHeader: function() {
+		var mode = enyo.Spotlight.getPointerMode();
 		enyo.Spotlight.setPointerMode(false);
 		enyo.Spotlight.unfreeze();
 		enyo.Spotlight.spot(this.$.headerWrapper);
+		enyo.Spotlight.setPointerMode(mode);
 		this.toggleActive();
 	}
 });


### PR DESCRIPTION
Problem:
ExpandableInput is not closed by tap on header when it is opened.

Analysis:
This is regression which is introduced after changing spotlight select timing from onKeyDown to onKeyUp.
Both of Gesture and Spotlight are generating tap event but Spotlight is filter events by pointer mode on onMouseDown and onMouseUp handler.
The closeDrawerAndHighlightHeader is called by tap handler in ExpandableInput, pointer mode is set as false to give focus to header even in pointer mode.
This forced pointer mode setting make duplicated tap event because onMouseUp handler is not filter out the event.

Solution:
Recover previous spotlight pointer mode to prevent unwanted onMouseUp event on ExpandableInput.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
