### PR TITLE
BHV-10909: Fixing DismissOnEnter on moon.Input

### DIFF
--- a/source/Input.js
+++ b/source/Input.js
@@ -24,7 +24,7 @@ enyo.kind({
 	},
 	//* @protected
 	handlers: {
-		onkeypress : 'onKeyUp',
+		onkeyup    : 'onKeyUp',
 		onblur     : 'onBlur',
 		onfocus    : 'onFocus'
 	},


### PR DESCRIPTION
### Problem:

DismissnEnter is not working.
### Analysis:

This is regression which is introduced after changing spotlight select timing from onKeyDown to onKeyUp.
Original sequence when onSpotlightSelect is fired on onKeyDown
1) Spotlight: onKeyDown -> return false (onSpotlightSelect is not comes)
2) Input: onkeypress -> blur (This makes focus goes to decorator)
3) Spotlight: onkeyUp -> not able to return true (because event target is not input after blur)
Current sequence when onSpotlightSelect is fired on onKeyUp
1) Spotlight: onKeyDown -> return false
2) Input: onkeypress -> blur (This makes focus goes to decorator)
3) Spotlight: onKeyUp -> not able to return true (because event target is not input after blur)
4) Spotlight: onSpotlightKeyUp -> onSpotlightSelect -> ontap (This makes focus goes to input again)
### Solution:

Change onkeypress handler as onkeyup, so that event target is not changed until 3).
Change return true as false, so that onSpotlightKeyUp is not bubbled up.

When user type enter on input, spotlight onKeyUp handler is called and checking spotlightIgnoredKeys then returning true.
This makes onkeyup event is not comes to input.

This fix is dependent to spotlight PR below.
https://github.com/enyojs/spotlight/pull/138

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
