### PR TITLE
BHV-5143: modify setActive parameter in ListActions.js

### DIFF
--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -185,7 +185,7 @@ enyo.kind({
 		}
 	},
 	openChanged: function(){
-		this.setActive(!this.getOpen());
+		this.setActive(this.getOpen());
 		this.doListActionOpenChanged({open: this.open});
 		// If opened, show drawer and resize it if needed
 		if(this.open){


### PR DESCRIPTION
BHV-5143: ListActionsSample: open/close message is not fired consistently
### Analsys and Solution

After moved 'setActive' line into openChanged function, parameter should be changed. Because, after setOpen call, 'open' property is already changed. So I modify setActive parameter in openChanged function.

DCO-1.1-Signed-Off-By: Sungbae Cho sb.cho@lge.com
