### PR TITLE
BHV-11157: Marquee: 'Marquee on Focus' does not consistently Start

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -330,7 +330,9 @@ moon.MarqueeItem = {
 			this._marquee_createMarquee();
 		}
 
-		this._marquee_addAnimationStyles(distance);
+		setTimeout(this.bindSafely(function(){
+			this._marquee_addAnimationStyles(distance);
+		}), 100);
 		return true;
 	},
 	_marquee_enable: function() {


### PR DESCRIPTION
this._marquee_addAnimationStyles(distance); seemed to be called before the deferred creation of the marquee DOM elements could complete. I added a setTimeout to delay adding the styles until after the DOM elements are created.
