### PR TITLE
BHV-1576: VideoPlayer: Unexpected Overlap between Tooltip and Popup List

### DIFF
--- a/samples/VideoPlayerSample.js
+++ b/samples/VideoPlayerSample.js
@@ -47,22 +47,20 @@ enyo.kind({
 				{kind: "moon.Button", content:"Unload", ontap:"unload"},
 				{kind: "moon.Button", content:"Reload", ontap:"load"},
 				{kind: "moon.ToggleButton", content:"FF/Rewind", name:"ffrewToggleButton"},
-				{name: "popupTooltip", kind: "moon.TooltipDecorator", components: [
-					{kind: "moon.ContextualPopupDecorator", components: [
+				{kind: "moon.ContextualPopupDecorator", components: [
+					{kind: "moon.TooltipDecorator", components: [
 						{kind: "moon.Button", content: "Popup"},
-						{
-							name: "popupVideo",
-							kind: "moon.ContextualPopup",
-							classes: "moon-3h moon-6v",
-							// onShowingChanged: "popupShowingChanged",
-							components: [
-								{kind: "moon.Item", content:"Item 1"},
-								{kind: "moon.Item", content:"Item 2"},
-								{kind: "moon.Item", content:"Item 3"}
-							]
-						}
+						{kind: "moon.Tooltip", floating:true, content: "I'm a tooltip for a button."}
 					]},
-					{kind: "moon.Tooltip", floating:true, content: "I'm a tooltip for a button."}
+					{
+						kind: "moon.ContextualPopup",
+						classes: "moon-3h moon-6v",
+						components: [
+							{kind: "moon.Item", content:"Item 1"},
+							{kind: "moon.Item", content:"Item 2"},
+							{kind: "moon.Item", content:"Item 3"}
+						]
+					}
 				]},
 				{kind: "moon.IconButton", classes:"moon-icon-video-round-controls-style"},
 				{kind: "moon.IconButton", classes:"moon-icon-video-round-controls-style"},
@@ -89,12 +87,5 @@ enyo.kind({
 	load: function() {
 		this.$.player.unload();
 		this.$.player.setSrc("http://media.w3.org/2010/05/bunny/movie.mp4");
-	},
-	popupShowingChanged: function() {
-		if (this.$.popupVideo.getShowing()) {
-			this.$.popupTooltip.mute();
-		} else {
-			this.$.popupTooltip.unmute();
-		}
 	}
 });

--- a/source/TooltipDecorator.js
+++ b/source/TooltipDecorator.js
@@ -74,21 +74,11 @@ enyo.kind({
 		this.requestHideTooltip();
 	},
 	requestShowTooltip: function() {
-		if (this.autoShow && !enyo.Spotlight.isFrozen() && !this.otherPopupsActive()) {
+		if (this.autoShow && !enyo.Spotlight.isFrozen()) {
 			this.waterfallDown("onRequestShowTooltip");
 		}
 	},
 	requestHideTooltip: function() {
 		this.waterfallDown("onRequestHideTooltip");
-	},
-	otherPopupsActive: function() {
-		for (var i=0; i<this.children.length; i++) {
-			var obj = this.children[i];
-			if ((obj.kind == "moon.ContextualPopupDecorator") && obj.popup && obj.popup.showing)
-			{
-				return true;
-			}
-		}
-		return false;
 	}
 });


### PR DESCRIPTION
### Issue:

In the VideoPlayer Sample, there is a contextual popup decorator wrapped inside a tooltip decorator. When they both show, the tooltip unexpectedly overlaps the popup list.
### Fix:

Add an onShowingChanged event handler to the contextual popup, and mute/unmute the tooltip based on whether the popup is showing

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
