### PR TITLE
BHV-11367: Support marquee function with HighlightText

### DIFF
--- a/samples/HighlightTextSample.js
+++ b/samples/HighlightTextSample.js
@@ -11,7 +11,7 @@ enyo.kind({
 				{kind: "moon.Scroller", fit: true, components: [
 					{kind: "moon.Divider", content:"Standard highlight"},
 					{kind: "moon.Item", components: [
-						{kind: "moon.HighlightText", content:"Text to highlight", highlight:"text"}
+						{kind: "moon.HighlightText", content:"Very long text to see highlight with marquee", highlight:"text", mixins: ["moon.MarqueeItem"]}
 					]},
 					{kind: "moon.Item", components: [
 						{kind: "moon.HighlightText", content:"Text to highlight", highlight:"to"}

--- a/source/HighlightText.js
+++ b/source/HighlightText.js
@@ -21,12 +21,18 @@
 		HighlightTextDelegate = Object.create(HTMLStringDelegate);
 
 	HighlightTextDelegate.generateInnerHtml = function (control) {
-		if (control.search) {
-			return control.content.replace(control.search, control.bindSafely(function (s) {
-				return '<span style=\'pointer-events:none;\' class=\'' + this.highlightClasses + '\'>' + enyo.dom.escape(s) + '</span>';
-			}));
-		} else {
-			return enyo.dom.escape(control.get('content'));
+		// flow can alter the way that html content is rendered inside
+		// the container regardless of whether there are children.
+		control.flow();
+		if (control.children.length) { return this.generateChildHtml(control); }
+		else {
+			if (control.search) {
+				return control.content.replace(control.search, control.bindSafely(function (s) {
+					return '<span style=\'pointer-events:none;\' class=\'' + this.highlightClasses + '\'>' + enyo.dom.escape(s) + '</span>';
+				}));
+			} else {
+				return enyo.dom.escape(control.get('content'));
+			}
 		}
 	};
 

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -752,7 +752,15 @@
 		* @private
 		*/
 		_marquee_createMarquee: function () {
-			this.createComponent({name:'marqueeTextWrapper', classes: 'moon-marquee-text-wrapper', components: [{name: 'marqueeText', classes: 'moon-marquee-text', allowHtml: this.allowHtml, content: this.content}]});
+			var marqueeText = {name: "marqueeText", classes: "moon-marquee-text", allowHtml: this.allowHtml, content: this.content},
+				highlightText = null;
+
+			if (this instanceof moon.HighlightText) {
+				enyo.dom.setInnerHtml(this.hasNode(), "");
+				highlightText = {renderDelegate: this.renderDelegate, highlightClasses: this.highlightClasses, search: this.search};
+				marqueeText = enyo.mixin(marqueeText, highlightText);
+			}
+			this.createComponent({name:"marqueeTextWrapper", classes: "moon-marquee-text-wrapper", components: [marqueeText]});
 			this.render();
 			return true;
 		},


### PR DESCRIPTION
## Problem

When using HighlightText with marqueeItem, marquee text is not created within marqueeItem.
- The renderDelegate (HighlightTextDelegate) is not checking the children and this makes this.render() in _marquee_createMarquee not actually create marqueeText.
- The marqueeItem is rendering marqueeText content with default renderDelegate. But highlighed text should be rendered with renderDelegate.
## Fix
- Adding highlight text with marquee case in Sample
- Let marqueeText know the highlightText renderDelegate so it can render highlighted text inside of marquee.
- Adding highlightText renderDelegate function to consider multiple children case.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
