### PR TITLE
BHV-11444 Update out dated comment

### DIFF
--- a/source/Panel.js
+++ b/source/Panel.js
@@ -25,7 +25,7 @@ enyo.kind({
 			with the panel index
 		*/
 		autoNumber: true,
-		//* Facade for the header's _type_ property. You can choose among large, small and mini
+		//* Facade for the header's _type_ property. You can choose among large, medium and small
 		headerType: "large",
 		//* Facade for the header's _small_ property
 		// Note: This property will be deprecated soon. For backward compatiblity, I leave it for a while.


### PR DESCRIPTION
Header type was denoted from Large, Small and Mini to Large, Medium and Small.
However current inline comment of moon.Panel uses old terms.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
