### PR TITLE
BHV-9832 Update scroller sample to correct spacing issue

### DIFF
--- a/samples/ScrollerVerticalSample.js
+++ b/samples/ScrollerVerticalSample.js
@@ -134,6 +134,7 @@ enyo.kind({
 		}
 		var c = this.$.spacingPicker.getSelected().spacingClass;
 		this.$.wrapper.addClass(c);
+		this.$.wrapper.bubble("onRequestSetupBounds");
 		this.lastSpacingClass = c;
 	}
 });


### PR DESCRIPTION
After spacing changed horizontally or vertically
setupBounds still remained as previous value.
This commit will fix it.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
