### PR TITLE
moon.Panels: Moving transitionInProgress before inherited call in finishTransition.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -608,9 +608,10 @@ enyo.kind({
 				popFrom++;
 			}
 		}
-		this.inherited(arguments);
 
 		this.transitionInProgress = false;
+		
+		this.inherited(arguments);
 
 		// "sendEvents" means we actually transitioned (not a reflow), so
 		// check popOnBack logic


### PR DESCRIPTION
### Issue:

The transitionInProgress is still true on onTransitionFinish event.
### Fix

Moving transitionInProgress false to before inherited call.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
