### PR TITLE
ANG-11530: Adding direction ltr on IntegerPicker and Revert ilib format ...

### DIFF
--- a/css/IntegerPicker.less
+++ b/css/IntegerPicker.less
@@ -4,6 +4,7 @@
 	position: relative;
 }
 .moon-scroll-picker {
+	direction: ltr;
 	height: @moon-integer-picker-height;
 	min-width: @moon-picker-min-width;
 	border-top-width: 30px;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -228,9 +228,7 @@
   font-family: "Moonstone LG Display";
   src: local("LG Display-Light");
   font-weight: normal;
-  font-style: normal;
-  
-  /* We want "LG Display" to map to the bold variant, since that was originally the only option */
+  font-style: normal;/* We want "LG Display" to map to the bold variant, since that was originally the only option */
 }
 @font-face {
   font-family: "Moonstone LG Display Bold";
@@ -548,8 +546,11 @@
 }
 .enyo-locale-non-latin {
   /* All/Medium weighted classes */
+
   /* Light weighted classes */
+
   /* Bold weighted classes */
+
 }
 .enyo-locale-non-latin .moon,
 .enyo-locale-non-latin .moon input,
@@ -1169,6 +1170,7 @@
 .moon-toggle-item .moon-checkbox.moon-toggle-switch {
   top: 11px;
   /* To override top:10px set by .moon-checkbox-item .moon-checkbox so the indicator vertically middle align */
+
 }
 .moon-toggle-item .moon-toggle-item-label-wrapper {
   margin-right: 75px;
@@ -1864,8 +1866,10 @@
   right: 0;
   text-align: right;
   /* fallback in case text-align:end isn't supported */
+
   text-align: end;
   /* CSS3 for RTL support */
+
 }
 .full-bleed .moon-header-client {
   left: 20px;
@@ -1874,12 +1878,15 @@
 .moon-header-client > * {
   text-align: left;
   /* fallback in case text-align:start isn't supported */
+
   text-align: start;
   /* CSS3 for RTL support */
+
 }
 .moon-header-client > .moon-button {
   text-align: center;
   /* Overrides the text-align property  for button */
+
 }
 /* Small Header */
 .moon-header.moon-small-header {
@@ -2035,6 +2042,7 @@
   position: relative;
 }
 .moon-scroll-picker {
+  direction: ltr;
   height: 94px;
   min-width: 60px;
   border-top-width: 30px;
@@ -2442,7 +2450,9 @@
   box-shadow: none;
   text-transform: none;
   /* FIXME: hack for styling reset on Android */
+
   /* -webkit-appearance: caret;*/
+
 }
 .moon-textarea-decorator.moon-focused .moon-richtext {
   cursor: text;
@@ -2689,10 +2699,13 @@
 }
 .moon-textarea-decorator > .moon-textarea {
   /* Remove scrollbars and resize handle */
+
   resize: none;
   overflow: auto;
   /* FIXME: hack for styling reset on Android */
+
   /* -webkit-appearance: caret;*/
+
 }
 .moon-textarea-decorator.moon-focused .moon-textarea {
   cursor: text;
@@ -2761,9 +2774,9 @@
   display: inline-block;
   vertical-align: top;
   width: 300px;
-  /* Do not change - used in JS */
   min-width: 300px;
   /* Do not change - used in JS */
+
   float: right;
   box-sizing: border-box;
 }
@@ -3422,6 +3435,7 @@
 		while it is fading out; however, this requires any showing classes
 		to set pointer events to auto or scrim will not function as expected.
 	*/
+
   pointer-events: none;
 }
 .moon-scrim.moon-scrim-translucent {
@@ -4111,6 +4125,7 @@
 .enyo-locale-non-latin .moon-video-player-info-title {
   line-height: 1.5em;
   /* Clip the title box by just a bit to help it fit better */
+
   height: 1.4em;
 }
 .moon-video-player-info-subtitle {
@@ -4244,6 +4259,7 @@
 .enyo-locale-non-latin .moon-video-player-channel-info-no {
   line-height: 1.5em;
   /* Clip the title box by just a bit to help it fit better */
+
   height: 1.4em;
 }
 .moon-video-player-channel-info-name {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -228,9 +228,7 @@
   font-family: "Moonstone LG Display";
   src: local("LG Display-Light");
   font-weight: normal;
-  font-style: normal;
-  
-  /* We want "LG Display" to map to the bold variant, since that was originally the only option */
+  font-style: normal;/* We want "LG Display" to map to the bold variant, since that was originally the only option */
 }
 @font-face {
   font-family: "Moonstone LG Display Bold";
@@ -548,8 +546,11 @@
 }
 .enyo-locale-non-latin {
   /* All/Medium weighted classes */
+
   /* Light weighted classes */
+
   /* Bold weighted classes */
+
 }
 .enyo-locale-non-latin .moon,
 .enyo-locale-non-latin .moon input,
@@ -1169,6 +1170,7 @@
 .moon-toggle-item .moon-checkbox.moon-toggle-switch {
   top: 11px;
   /* To override top:10px set by .moon-checkbox-item .moon-checkbox so the indicator vertically middle align */
+
 }
 .moon-toggle-item .moon-toggle-item-label-wrapper {
   margin-right: 75px;
@@ -1864,8 +1866,10 @@
   right: 0;
   text-align: right;
   /* fallback in case text-align:end isn't supported */
+
   text-align: end;
   /* CSS3 for RTL support */
+
 }
 .full-bleed .moon-header-client {
   left: 20px;
@@ -1874,12 +1878,15 @@
 .moon-header-client > * {
   text-align: left;
   /* fallback in case text-align:start isn't supported */
+
   text-align: start;
   /* CSS3 for RTL support */
+
 }
 .moon-header-client > .moon-button {
   text-align: center;
   /* Overrides the text-align property  for button */
+
 }
 /* Small Header */
 .moon-header.moon-small-header {
@@ -2035,6 +2042,7 @@
   position: relative;
 }
 .moon-scroll-picker {
+  direction: ltr;
   height: 94px;
   min-width: 60px;
   border-top-width: 30px;
@@ -2440,7 +2448,9 @@
   box-shadow: none;
   text-transform: none;
   /* FIXME: hack for styling reset on Android */
+
   /* -webkit-appearance: caret;*/
+
 }
 .moon-textarea-decorator.moon-focused .moon-richtext {
   cursor: text;
@@ -2686,10 +2696,13 @@
 }
 .moon-textarea-decorator > .moon-textarea {
   /* Remove scrollbars and resize handle */
+
   resize: none;
   overflow: auto;
   /* FIXME: hack for styling reset on Android */
+
   /* -webkit-appearance: caret;*/
+
 }
 .moon-textarea-decorator.moon-focused .moon-textarea {
   cursor: text;
@@ -2758,9 +2771,9 @@
   display: inline-block;
   vertical-align: top;
   width: 300px;
-  /* Do not change - used in JS */
   min-width: 300px;
   /* Do not change - used in JS */
+
   float: right;
   box-sizing: border-box;
 }
@@ -3418,6 +3431,7 @@
 		while it is fading out; however, this requires any showing classes
 		to set pointer events to auto or scrim will not function as expected.
 	*/
+
   pointer-events: none;
 }
 .moon-scrim.moon-scrim-translucent {
@@ -4107,6 +4121,7 @@
 .enyo-locale-non-latin .moon-video-player-info-title {
   line-height: 1.5em;
   /* Clip the title box by just a bit to help it fit better */
+
   height: 1.4em;
 }
 .moon-video-player-info-subtitle {
@@ -4240,6 +4255,7 @@
 .enyo-locale-non-latin .moon-video-player-channel-info-no {
   line-height: 1.5em;
   /* Clip the title box by just a bit to help it fit better */
+
   height: 1.4em;
 }
 .moon-video-player-channel-info-name {

--- a/source/SimpleIntegerPicker.js
+++ b/source/SimpleIntegerPicker.js
@@ -139,13 +139,10 @@ enyo.kind({
 	},
 	build: function() {
 		var indices = this.indices = {},
-			values = this.values = [],
-			ilibNumFmt = (typeof ilib !== "undefined") ? new ilib.NumFmt({locale: new ilib.LocaleInfo().locale, useNative: false}) : null,
-			fmtValue;
+			values = this.values = [];
 
 		for (var i = 0, v = this.min; v <= this.max; i++, v += this.step) {
-			fmtValue = ilibNumFmt ? ilibNumFmt.format(v) : v;
-			this.createComponent({content: fmtValue + " " + this.unit, value: v});
+			this.createComponent({content: v + " " + this.unit, value: v});
 			values[i] = v;
 			indices[v] = i;
 			if (this.step <= 0) {


### PR DESCRIPTION
...from SimpleIntegerPicker

This is a requirement from corporate lab for Farsi/Arabic.
### Issue:

Moonstone controls should not change format on negative numeric values.
### Fix:

Adding direction ltr on IntegerPicker and SimpleIntegerPicker so that it is not affected by enyo-locale-right-to-left.
Revert ilib format fix from SimpleIntergerPicker so that is is never change format.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
