### PR TITLE
BHV-11655: Replace for in to for on DataList.js

### DIFF
--- a/source/DataList.js
+++ b/source/DataList.js
@@ -233,7 +233,7 @@
 			var pages = (this.$.page1.index < this.$.page2.index) ?
 				[this.$.page1, this.$.page2] :
 				[this.$.page2, this.$.page1];
-			for (var p in pages) {
+			for (var p=0; p< pages.length; p++) {
 				var page = pages[p];
 				var pb = page.getBounds();
 				// Loop through children in each page top-down


### PR DESCRIPTION
### Issue:

"For in" only can be used properly on hash but in this case it is used with Array which is having prototype functions.
### Fix:

Replace "for in" to "for"

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
