### PR TITLE
BHV-11123: modify ExpandableInput.js to be able to open only one ExpandableInput

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -189,8 +189,8 @@
 		},
 
 		/**
-		* value should submit if user clicks outside control. We check for 'onSpotlightFocus' and 'mouseover' to 
-		* make sure not to contract on the event which is fired from itself.
+		* value should submit if user clicks outside control. We check for 'onSpotlightFocus' and  
+		* 'mouseover' to make sure not to contract on the event which is fired from itself.
 		*
 		* @private
 		*/


### PR DESCRIPTION
### Issue & problem

ExpandableInput should open only one at one time but it isn't now.
### Fix

Currently, ExpandableInput has a complex freeze/unfreeze and spot/unspot logic. I changed inputBlur logic to open only one ExpandableInput with minimum change. But I think refactoring is needed some day.
(changes in closeDrawerAndHighlightHeader are code in https://github.com/enyojs/moonstone/pull/1428)

Enyo-DCO-Signed-off-by: Sungbae Cho sb.cho@lge.com
