### PR TITLE
BHV-11438: modify translateZ value to avoid overlapping between components

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -767,7 +767,7 @@
 			this.$.marqueeText.applyStyle('transition-duration', duration + 's');
 			this.$.marqueeText.applyStyle('-webkit-transition-duration', duration + 's');
 
-			enyo.dom.transform(this, {translateZ: -0.1});
+			enyo.dom.transform(this, {translateZ: -0.01});
 
 			// Need this timeout for FF!
 			setTimeout(this.bindSafely(function () {


### PR DESCRIPTION
## Issue

The End Portion of the Marquee's Text Overlaps the Tooltip on header component.
## Cause

Root cause for this issue is from wekit side(manaing problem between acceleration layer and nomar layer)
## Solution

For now, modified marquee code to prevent this issue in framework level(referring to Aaron's old commit)
