### PR TITLE
BHV-12037: Fix wrong initial value of SimpleIntegerPicker

### DIFF
--- a/source/SimpleIntegerPicker.js
+++ b/source/SimpleIntegerPicker.js
@@ -220,7 +220,7 @@
 		*/
 		sync: function(val, origin, binding) {
 			if (this.values) {
-				return (origin === 'source') ? this.indices[val] : this.values[val];
+				return (origin === enyo.Binding.DIRTY_FROM) ? this.indices[val] : this.values[val];
 			}
 		},
 


### PR DESCRIPTION
Data bindings are passing sync direction as a second parameter of transform.

It was string previously but now it is  integer value which can be referenced by enyo.Binding.DIRTY_FROM/DIRTY_TO constants.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
