### PR TITLE
BHV-12091: regression in moon.ToggleItem due to changes in BHV-5139

### DIFF
--- a/css/ToggleItem.less
+++ b/css/ToggleItem.less
@@ -4,6 +4,7 @@
 
 	.moon-checkbox.moon-toggle-switch {
 		top: @moon-spotlight-outset + 1px; /* To override top:10px set by .moon-checkbox-item .moon-checkbox so the indicator vertically middle align */
+		right: @moon-spotlight-outset;
 	}
 }
 
@@ -11,7 +12,13 @@
 	margin-right: @moon-toggleswitch-margin;
 }
 
-.enyo-locale-right-to-left .moon-toggle-item .moon-toggle-item-label-wrapper {
-	margin-left: @moon-toggleswitch-margin;
-	margin-right: 0px;
+.enyo-locale-right-to-left .moon-toggle-item {
+	.moon-checkbox.moon-toggle-switch {
+		left: @moon-spotlight-outset;
+		right: auto;
+	}
+	.moon-toggle-item-label-wrapper {
+		margin-left: @moon-toggleswitch-margin;
+		margin-right: 0px;
+	}
 }

--- a/css/ToggleSwitch.less
+++ b/css/ToggleSwitch.less
@@ -9,29 +9,35 @@
 	font-size: @moon-toggleswitch-image-width;
 	overflow: hidden;
 	text-align: left;
-	
-	&:after {
+
+	.moon-icon {
+		visibility: visible;
+		cursor: default;
+		background-color: transparent;
+		left: 0px;
+	}
+	.moon-icon:after {
 		color: @moon-checkbox-toggle-switch-color;
-		content: @moon-icon-circle;
-		margin-left: 5px;
 	}
 	&[checked] {
 		background-color: @moon-checkbox-toggle-switch-checked-bg-color;
-		&:after {
+		.moon-icon {
+			left:  @moon-toggleswitch-image-width / 2;
+		}
+		.moon-icon:after {
 			color: @moon-checkbox-toggle-switch-checked-color;
-			margin-left: (@moon-toggleswitch-image-width - @moon-toggleswitch-image-height + 5px);
 		}
 	}
 	&[disabled] {
 		background-color: @moon-checkbox-toggle-switch-bg-color;
-		&:after {
+		.moon-icon:after {
 			color: @moon-checkbox-toggle-switch-color;
 		}
 	}
-	&.animated {
-		-webkit-transition: background-color 0.2s;
+	&.animated .moon-icon {
+		-webkit-transition: background-color 0.2s, left 0.2s;
 		&:after {
-			-webkit-transition: color 0.2s, margin-left 0.2s;
+			-webkit-transition: color 0.2s;
 		}
 	}
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1170,29 +1170,35 @@
   overflow: hidden;
   text-align: left;
 }
-.moon-checkbox.moon-toggle-switch:after {
+.moon-checkbox.moon-toggle-switch .moon-icon {
+  visibility: visible;
+  cursor: default;
+  background-color: transparent;
+  left: 0px;
+}
+.moon-checkbox.moon-toggle-switch .moon-icon:after {
   color: #a6a6a6;
-  content: "\0F0013";
-  margin-left: 5px;
 }
 .moon-checkbox.moon-toggle-switch[checked] {
   background-color: #ffffff;
 }
-.moon-checkbox.moon-toggle-switch[checked]:after {
+.moon-checkbox.moon-toggle-switch[checked] .moon-icon {
+  left: 32.5px;
+}
+.moon-checkbox.moon-toggle-switch[checked] .moon-icon:after {
   color: #cf0652;
-  margin-left: 37px;
 }
 .moon-checkbox.moon-toggle-switch[disabled] {
   background-color: #404040;
 }
-.moon-checkbox.moon-toggle-switch[disabled]:after {
+.moon-checkbox.moon-toggle-switch[disabled] .moon-icon:after {
   color: #a6a6a6;
 }
-.moon-checkbox.moon-toggle-switch.animated {
-  -webkit-transition: background-color 0.2s;
+.moon-checkbox.moon-toggle-switch.animated .moon-icon {
+  -webkit-transition: background-color 0.2s, left 0.2s;
 }
-.moon-checkbox.moon-toggle-switch.animated:after {
-  -webkit-transition: color 0.2s, margin-left 0.2s;
+.moon-checkbox.moon-toggle-switch.animated .moon-icon:after {
+  -webkit-transition: color 0.2s;
 }
 .moon-toggle-item {
   display: block;
@@ -1201,9 +1207,14 @@
 .moon-toggle-item .moon-checkbox.moon-toggle-switch {
   top: 11px;
   /* To override top:10px set by .moon-checkbox-item .moon-checkbox so the indicator vertically middle align */
+  right: 10px;
 }
 .moon-toggle-item .moon-toggle-item-label-wrapper {
   margin-right: 75px;
+}
+.enyo-locale-right-to-left .moon-toggle-item .moon-checkbox.moon-toggle-switch {
+  left: 10px;
+  right: auto;
 }
 .enyo-locale-right-to-left .moon-toggle-item .moon-toggle-item-label-wrapper {
   margin-left: 75px;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1170,29 +1170,35 @@
   overflow: hidden;
   text-align: left;
 }
-.moon-checkbox.moon-toggle-switch:after {
+.moon-checkbox.moon-toggle-switch .moon-icon {
+  visibility: visible;
+  cursor: default;
+  background-color: transparent;
+  left: 0px;
+}
+.moon-checkbox.moon-toggle-switch .moon-icon:after {
   color: #4b4b4b;
-  content: "\0F0013";
-  margin-left: 5px;
 }
 .moon-checkbox.moon-toggle-switch[checked] {
   background-color: #ffffff;
 }
-.moon-checkbox.moon-toggle-switch[checked]:after {
+.moon-checkbox.moon-toggle-switch[checked] .moon-icon {
+  left: 32.5px;
+}
+.moon-checkbox.moon-toggle-switch[checked] .moon-icon:after {
   color: #cf0652;
-  margin-left: 37px;
 }
 .moon-checkbox.moon-toggle-switch[disabled] {
   background-color: #ffffff;
 }
-.moon-checkbox.moon-toggle-switch[disabled]:after {
+.moon-checkbox.moon-toggle-switch[disabled] .moon-icon:after {
   color: #4b4b4b;
 }
-.moon-checkbox.moon-toggle-switch.animated {
-  -webkit-transition: background-color 0.2s;
+.moon-checkbox.moon-toggle-switch.animated .moon-icon {
+  -webkit-transition: background-color 0.2s, left 0.2s;
 }
-.moon-checkbox.moon-toggle-switch.animated:after {
-  -webkit-transition: color 0.2s, margin-left 0.2s;
+.moon-checkbox.moon-toggle-switch.animated .moon-icon:after {
+  -webkit-transition: color 0.2s;
 }
 .moon-toggle-item {
   display: block;
@@ -1201,9 +1207,14 @@
 .moon-toggle-item .moon-checkbox.moon-toggle-switch {
   top: 11px;
   /* To override top:10px set by .moon-checkbox-item .moon-checkbox so the indicator vertically middle align */
+  right: 10px;
 }
 .moon-toggle-item .moon-toggle-item-label-wrapper {
   margin-right: 75px;
+}
+.enyo-locale-right-to-left .moon-toggle-item .moon-checkbox.moon-toggle-switch {
+  left: 10px;
+  right: auto;
 }
 .enyo-locale-right-to-left .moon-toggle-item .moon-toggle-item-label-wrapper {
   margin-left: 75px;

--- a/source/ToggleItem.js
+++ b/source/ToggleItem.js
@@ -23,6 +23,11 @@
 		/**
 		 * @private
 		 */
+		icon: 'circle',
+
+		/**
+		 * @private
+		 */
 		classes: 'moon-toggle-item',
 
 		/**

--- a/source/ToggleSwitch.js
+++ b/source/ToggleSwitch.js
@@ -26,6 +26,11 @@
 		/**
 		 * @private
 		 */
+		icon: 'circle',
+
+		/**
+		 * @private
+		 */
 		classes: 'moon-toggle-switch',
 
 		/**


### PR DESCRIPTION
### Issue:

moon.ToggleItem subclasses from moon.CheckboxItem. Due to changes in moon.Checkbox and moon.CheckboxItem in BHV-5139 (specifically, using a moon.Icon instead of styling the checkbox directly), toggleItem now shows a checkmark when it shouldn't, and requires other css adjustments
### Fix:

Add an "icon: 'circle'" property to ToggleItem/Switch.js, and modify css to ensure proper color, background-color and position.

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
