### PR TITLE
BHV-11798: PopupSample: Error: Out of memory!

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -609,7 +609,7 @@
 		*/
 		requestSetupBounds: function(sender, event) {
 			this.scrollBounds = this._getScrollBounds();
-			if (this.scrollBounds.clientHeight && this.scrollBounds.clientWidth) {
+			if (this.validBound(this.scrollBounds.clientHeight) && this.validBound(this.scrollBounds.clientWidth)) {
 				this.setupBounds();
 				this.scrollBounds = null;
 				if ((this.showVertical() && this.$.scrollMath.bottomBoundary) || (this.showHorizontal() && this.$.scrollMath.rightBoundary)) {
@@ -617,6 +617,13 @@
 				}
 				return true;
 			}
+		},
+
+		/*
+		* @private
+		*/
+		validBound: function(value) {
+			return (!isNaN(value) && value != null);
 		},
 
 		/**


### PR DESCRIPTION
### Issue:

Load the http://nebula.palm.com/enyojs/lib/moonstone/samples/PopupSample.html on the TV. After about 3-5 minutes there will be thousands of Error: Out of memory errors.
### Investigation:

when moon.Popup was created but not showing, moon.BodyText was bubbling an `onRequestSetupBounds` event to moon.Scroller, which was calling MoonScrollStrategy:requestSetupBounds(). This method made a call to _getScrollBounds() and assumed it was valid, even though it was not.
### Fix:

add a check to MoonScrollStrategy:requestSetupBounds() to perform scrolling logic only when _getScrollBounds() returns valid values

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
