### PR TITLE
BHV-12085: Altered the CSS for drawer activator to not conflict with spotlight discovery.

### DIFF
--- a/css/Drawers.less
+++ b/css/Drawers.less
@@ -18,7 +18,7 @@
 		background-color: @moon-drawer-bg-color;
 	}
 	&:after {
-		margin: -10px auto 0;
+		margin: -12px auto 0;
 		width: @moon-drawer-nub-width;
 		height: @moon-drawer-nub-height;
 		border-radius: 0 0 @moon-drawer-nub-height @moon-drawer-nub-height;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3625,7 +3625,7 @@
   background-color: #404040;
 }
 .moon-drawers-activator:after {
-  margin: -10px auto 0;
+  margin: -12px auto 0;
   width: 60px;
   height: 36px;
   border-radius: 0 0 36px 36px;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3622,7 +3622,7 @@
   background-color: #4b4b4b;
 }
 .moon-drawers-activator:after {
-  margin: -10px auto 0;
+  margin: -12px auto 0;
   width: 60px;
   height: 36px;
   border-radius: 0 0 36px 36px;


### PR DESCRIPTION
The increased height of the new design of the activator pushed the activator into un-findable territory for spotlight, requiring this change. The activator is now a zero-height div container with the bar and the nub being pseudo-elements which change based on the classes of their owner.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
