### PR TITLE
BHV-12188: Remove unnecessary spotlightDisabled property.

### DIFF
--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -167,7 +167,7 @@
 		* @private
 		*/
 		drawerComponents: [
-			{name: 'drawer', spotlightDisabled: true, kind: 'moon.ListActionsDrawer', classes: 'list-actions-drawer', onComplete: 'drawerAnimationEnd', open: false, spotlight: 'container', spotlightModal:true, components: [
+			{name: 'drawer', kind: 'moon.ListActionsDrawer', classes: 'list-actions-drawer', onComplete: 'drawerAnimationEnd', open: false, spotlight: 'container', spotlightModal:true, components: [
 				{name: 'closeButton', kind: 'moon.IconButton', icon: 'closex', classes: 'moon-popup-close moon-list-actions-close moon-neutral', ontap: 'expandContract', defaultSpotlightDown:'listActions'},
 				{name: 'listActionsClientContainer', classes: 'enyo-fit moon-list-actions-client-container moon-neutral', components: [
 					{name: 'listActions', kind: 'moon.Scroller', classes: 'enyo-fit moon-list-actions-scroller', horizontal:'hidden', vertical:'hidden', onActivate: 'optionSelected', defaultSpotlightUp:'closeButton'}


### PR DESCRIPTION
## Issue

One cannot spot the close button from the `moon.ListActions` drawers and vice versa, via 5-way.
## Fix

Remove the `spotlightDisabled:true` property.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
