### PR TITLE
BHV-12188: Re-adding fix for BHV-11579.

### DIFF
--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -167,7 +167,7 @@
 		* @private
 		*/
 		drawerComponents: [
-			{name: 'drawer', kind: 'moon.ListActionsDrawer', classes: 'list-actions-drawer', onComplete: 'drawerAnimationEnd', open: false, spotlight: 'container', spotlightModal:true, components: [
+			{name: 'drawer', spotlightDisabled: true, kind: 'moon.ListActionsDrawer', classes: 'list-actions-drawer', onComplete: 'drawerAnimationEnd', open: false, spotlight: 'container', spotlightModal:true, components: [
 				{name: 'closeButton', kind: 'moon.IconButton', icon: 'closex', classes: 'moon-popup-close moon-list-actions-close moon-neutral', ontap: 'expandContract', defaultSpotlightDown:'listActions'},
 				{name: 'listActionsClientContainer', classes: 'enyo-fit moon-list-actions-client-container moon-neutral', components: [
 					{name: 'listActions', kind: 'moon.Scroller', classes: 'enyo-fit moon-list-actions-scroller', horizontal:'hidden', vertical:'hidden', onActivate: 'optionSelected', defaultSpotlightUp:'closeButton'}
@@ -327,6 +327,7 @@
 		* @private
 		*/
 		openChanged: function(){
+			this.$.drawer.set('spotlightDisabled', !this.getOpen());
 			this.setActive(this.getOpen());
 			this.doListActionOpenChanged({open: this.open});
 			// If opened, show drawer and resize it if needed


### PR DESCRIPTION
## Issue

`Spotlight` focus can be lost when 5-way navigating, as `Spotlight` focus can shift to the `moon.ListActions` drawer when it is closed.
## Fix

Re-add the fix for BHV-11579 (https://github.com/enyojs/moonstone/pull/1443), which sets `spotlightDisabled:true` when the `moon.ListActions` drawer is closed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
