### PR TITLE
BHV-12260: Item border show and hide when marquee flow

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -775,7 +775,7 @@
 			this.$.marqueeText.applyStyle('transition-duration', duration + 's');
 			this.$.marqueeText.applyStyle('-webkit-transition-duration', duration + 's');
 
-			enyo.dom.transform(this, {translateZ: -0.01});
+			enyo.dom.transform(this, {translateZ: '-0.1px'});
 
 			// Need this timeout for FF!
 			setTimeout(this.bindSafely(function () {


### PR DESCRIPTION
### Issue:

TranslateZ is creating H/W accelerated layer and make small blurred gap between normal and accelerated layer.
### Fix:

Change translateZ value from -0.01 to "-0.1px".
This fix can reduce the gap between H/W accelerated layer and normal layer.
So that remove random blurred line show and hide.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
