### PR TITLE
BHV-12262:update event hooking routine in Marquee.js to cache target pro...

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -230,8 +230,11 @@
 				// FIXME: not sure why events can arrive without event objects, but we guard here for safety
 				if (oEvent && !oEvent.delegate) {
 					var handler = this._marquee_Handlers[sEventName];
-					if (handler && this[handler](oSender, oEvent)) {
-						return true;
+					if (handler){
+						this.cachePoint = true;
+						if(this[handler](oSender, oEvent)) {
+							return true;
+						}
 					}
 				}
 				return sup.apply(this, arguments);


### PR DESCRIPTION
## Issue

SimplePicker: Adding Items Triggers Marquee Jobs to Start Indefinitely
## Cause

Marquee has a ad-hoc event proccessing routine (dispatchEvent function), and event-cache routine didn't capture that handling information.
## Fix

update event hooking routine in Marquee.js to cache target properly

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
