### PR TITLE
BHV-12260: Item border show and hide when marquee flow

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -230,8 +230,11 @@
 				// FIXME: not sure why events can arrive without event objects, but we guard here for safety
 				if (oEvent && !oEvent.delegate) {
 					var handler = this._marquee_Handlers[sEventName];
-					if (handler && this[handler](oSender, oEvent)) {
-						return true;
+					if (handler){
+						this.cachePoint = true;
+						if(this[handler](oSender, oEvent)) {
+							return true;
+						}
 					}
 				}
 				return sup.apply(this, arguments);


### PR DESCRIPTION
Issue:
TranslateZ is creating H/W accelerated layer and make small blurred gap between normal and accelerated layer. 

Fix:
Change translateZ value from -0.01 to "-0.1px".
This fix can reduce the gap between H/W accelerated layer and normal layer.
So that remove random blurred line show and hide.

Previous PR is reverted because it was not reset translateZ to null. So, fixed it.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
