### PR TITLE
BHV-12395: Fix issue with video duration not displaying

### DIFF
--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -767,7 +767,7 @@
 		timeUpdate: function(sender, e) {
 			this._currentTime = sender._currentTime;
 			if (!this.dragging && this.isInPreview()) { return; }
-			this._duration = sender._duration;
+			this._duration = sender.duration;
 			this.currentTime = this._currentTime;
 			this.duration = this._duration;
 			this.$.endTickText.setContent(this.formatTime(this.duration));


### PR DESCRIPTION
## Issue

The video duration appears as 00:00 in `moon.VideoPlayer`.
## Fix

This was due to a name-change of the `duration` property in `moon.VideoPlayer` from `_duration`. `moon.VideoTransportSlider` was originally questionably reaching for a private property of `moon.VideoPlayer`, so this has now been updated to utilize the public property. The private `_currentTime` property is still being retrieved, so this is probably future work involving a non-trivial update to `moon.VideoPlayer`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
