### PR TITLE
BHV-11989 remove unnecessary freeze/unfreeze routine in ExapandableInput

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -168,7 +168,6 @@
 			} else {
 				this.setActive(true);
 				enyo.Spotlight.unspot();
-				enyo.Spotlight.freeze();
 			}
 		},
 
@@ -259,7 +258,6 @@
 		*/
 		drawerAnimationEnd: function () {
 			if (this.getOpen()) {
-				enyo.Spotlight.unfreeze();
 				this.focusInput();
 			}
 			this.inherited(arguments);


### PR DESCRIPTION
## Issue

Spotlight throws exception when using ExpandableInput
## Cause

After the change that '_oCurrent' shoud be null when current spotted control is unspotted (before that change, _oCurrent didn't update properly until new control is spotted), enyo.Spotlight.freeze() function can throws exception easily according to how developer call that function.
Currently, code that cause an error related to GF-58781 and that code is not working anymore(because the change that explained above).
## Fix

Remove freeze/unfreeze routine for GF-58781 (I verified GF-58781 issue is not reproduced anymore even though I removed freeze/unfreeze routine. I think it is changed by wekit side also)

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
