### PR TITLE
BHV-12514: Ensure valid scroll position when picker is expanded.

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -204,6 +204,7 @@
 		*/
 		refreshScrollState: function () {
 			this.updateScrollBounds();
+			this.stabilize();
 			var node = this.$.repeater.fetchRowNode(this.value - this.min);
 			if (node) {
 				this.$.scroller.scrollToNode(node);


### PR DESCRIPTION
## Issue

The scroll bounds can be invalid for `moon.IntegerPicker` controls expanded within a `moon.TimePicker`, causing unexpected scroll behavior initially. This is a side effect of the fix for BHV-11927 (https://github.com/enyojs/enyo/pull/806) as it assumes a valid value for the scroll bounds upon calling `scrollTo`.
## Fix

We stabilize the scroller when `refreshScrollState` in `moon.IntegerPicker` is called, which occurs when `moon.TimePicker` is expanded.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
