### PR TITLE
BHV-11870: Support moon.Item Icon Overlay

### DIFF
--- a/css/Item.less
+++ b/css/Item.less
@@ -23,3 +23,27 @@
 .enyo-locale-non-latin .moon-item {
 	.enyo-locale-non-latin .moon-sub-header-text;
 }
+
+/* ItemOverlay.css */
+.moon-item .moon-item-overlay {
+	float: left;
+}
+.moon-item:not(.spotlight) .moon-item-overlay.auto-hide {
+	display: none;
+}
+.moon-item.spotlight .moon-item-overlay.auto-hide {
+	display: block;
+}
+.moon-item .moon-item-overlay.right {
+	float: right;
+}
+.moon-item .moon-item-overlay .moon-icon {
+	margin-top: -1px;
+	margin-bottom: -1px;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay {
+	float: right;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay.right {
+	float: left;
+}

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1185,6 +1185,29 @@
   font-family: "Moonstone LG Display Bold";
   font-size: 30px;
 }
+/* ItemOverlay.css */
+.moon-item .moon-item-overlay {
+  float: left;
+}
+.moon-item:not(.spotlight) .moon-item-overlay.auto-hide {
+  display: none;
+}
+.moon-item.spotlight .moon-item-overlay.auto-hide {
+  display: block;
+}
+.moon-item .moon-item-overlay.right {
+  float: right;
+}
+.moon-item .moon-item-overlay .moon-icon {
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay {
+  float: right;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay.right {
+  float: left;
+}
 /* SelectableItem.css */
 .moon-selectable-item.selected {
   padding: 10px 10px 10px 42px;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1185,6 +1185,29 @@
   font-family: "Moonstone LG Display Bold";
   font-size: 30px;
 }
+/* ItemOverlay.css */
+.moon-item .moon-item-overlay {
+  float: left;
+}
+.moon-item:not(.spotlight) .moon-item-overlay.auto-hide {
+  display: none;
+}
+.moon-item.spotlight .moon-item-overlay.auto-hide {
+  display: block;
+}
+.moon-item .moon-item-overlay.right {
+  float: right;
+}
+.moon-item .moon-item-overlay .moon-icon {
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay {
+  float: right;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay.right {
+  float: left;
+}
 /* SelectableItem.css */
 .moon-selectable-item.selected {
   padding: 10px 10px 10px 42px;

--- a/samples/ItemSample.js
+++ b/samples/ItemSample.js
@@ -34,7 +34,49 @@ enyo.kind({
 					{kind: "moon.Image", src: "http://placehold.it/150x150&text=Image+Four", style: "float: right; margin: 10px 0px 10px 10px", alt: "Image Two"},
 					{kind: "moon.BodyText", style: "margin: 10px 0", content: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa."}
 				]}
-			]}
+			]},
+			{classes:"moon-1v"},
+			{kind: "moon.Divider", content: "ItemOverlay Sample"},
+			{
+				components: [
+					{kind: "moon.Item", components: [
+						{kind: "moon.ItemOverlay", autoHide: true, right: true, components:[
+							{kind: "moon.Icon", icon: "arrowlargeup", small: true},
+							{kind: "moon.Icon", icon: "arrowlargedown", small: true},
+							{kind: "moon.Icon", icon: "arrowlargeleft", small: true},
+							{kind: "moon.Icon", icon: "arrowlargeright", small: true}
+						]},
+						{kind: "moon.MarqueeText", content: "Item   with   icons   auto   hides"}
+					]},
+					{kind: "moon.Item", components: [
+						{kind: "moon.ItemOverlay", autoHide: false, right: true, components:[
+							{kind: "moon.Icon", icon: "arrowlargeup", small: true},
+							{kind: "moon.Icon", icon: "arrowlargedown", small: true},
+							{kind: "moon.Icon", icon: "arrowlargeleft", small: true},
+							{kind: "moon.Icon", icon: "arrowlargeright", small: true}
+						]},
+						{kind: "moon.MarqueeText", content: "Item   with   icons   on   right   side"}
+					]},
+					{kind: "moon.Item", components: [
+						{kind: "moon.ItemOverlay", autoHide: false, right: false, components:[
+							{kind: "moon.Icon", icon: "arrowlargeup", small: true},
+							{kind: "moon.Icon", icon: "arrowlargedown", small: true},
+							{kind: "moon.Icon", icon: "arrowlargeleft", small: true},
+							{kind: "moon.Icon", icon: "arrowlargeright", small: true}
+						]},
+						{kind: "moon.MarqueeText", content: "Item   with   icons   on   left   side"}
+					]},
+					{kind: "moon.Item", components: [
+						{kind: "moon.ItemOverlay", autoHide: false, right: false, components:[
+							{kind: "moon.Icon", icon: "arrowlargeup", small: true}
+						]},
+						{kind: "moon.ItemOverlay", autoHide: false, right: true, components:[
+							{kind: "moon.Icon", icon: "arrowlargedown", small: true}
+						]},
+						{kind: "moon.MarqueeText", content: "Item   with   icons   on   both   sides"}
+					]}
+				]
+			}
 		]}
 	]
 });

--- a/source/Item.js
+++ b/source/Item.js
@@ -85,4 +85,88 @@
 		}
 	});
 
+	/**
+	* {@link moon.ItemOverlay} is a supplementary control that helps to manage
+	* layout within a {@link moon.Item}.
+	* 
+	* ```
+	* {kind: "moon.Item", components: [
+	* 	{kind: "moon.ItemOverlay", autoHide: false, right: true, components:[
+	* 		{kind: "moon.Icon", icon: "arrowlargeup", small: true},
+	* 		{kind: "moon.Icon", icon: "arrowlargedown", small: true}
+	* 	]},
+	* 	{kind: "moon.MarqueeText", content: "Item   with   icons   auto   hides"}
+	* ]}
+	* ```
+	* 
+	* @ui
+	* @class moon.ItemOverlay
+	* @extends enyo.Control
+	* @public
+	*/
+	enyo.kind(
+		/** @lends moon.ItemOverlay.prototype */ {
+
+		 /**
+		 * @private
+		 */
+		name: 'moon.ItemOverlay',
+
+		/**
+	 	* @private
+	 	*/
+		classes: 'moon-item-overlay',
+
+		/**
+		* @private
+		*/
+		published: /** @lends moon.ItemOverlay.prototype */ {
+
+			/**
+			* When `true`, the controls in the overlay are only shown on focus; in
+			* other words, if the overlay is not focused, the controls will be hidden.
+			*
+			* @type {Boolean}
+			* @default false
+			* @public
+			*/
+			autoHide: false,
+
+			/**
+			* When `true`, the controls in the overlay are right-aligned.
+			*
+			* @type {Boolean}
+			* @default false
+			* @public
+			*/
+			right: false
+
+		},
+
+		/**
+		* @private
+		*/
+		create: function () {
+			this.inherited(arguments);
+			this.autoHideChanged();
+			this.rightChanged();
+		},
+
+		/**
+		* @private
+		*/
+		autoHideChanged: function() {
+			this.addRemoveClass('auto-hide', this.get('autoHide'));
+		},
+
+
+		/**
+		* @private
+		*/
+		rightChanged: function() {
+			this.addRemoveClass('right', this.get('right'));
+		}
+
+	});
+
 })(enyo, this);


### PR DESCRIPTION
Adding moon.ItemOverlay kind to support common item pattern.

Item is composed of label and icons
Label should have marquee
Icons can be on the left/right side of label
Icons can be shown on focus and auto hide
We can avoid use of fittable inside of item by using this new kind.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com