### PR TITLE
CheckboxItem: checkbox-trashcan icon Does Not Display in the Sampler (bu...

### DIFF
--- a/samples/CheckboxItemSample.js
+++ b/samples/CheckboxItemSample.js
@@ -11,7 +11,7 @@ enyo.kind({
 					{kind: "moon.CheckboxItem", content: "Option 2", onchange: "itemChanged"},
 					{kind: "moon.CheckboxItem", disabled: true, content: "Disabled", onchange: "itemChanged"},
 					{kind: "moon.CheckboxItem", content: "Option 4", checked: true, onchange: "itemChanged"},
-					{kind: "moon.CheckboxItem", content: "This is a verrry long option 5 with a custom checkmark", icon: "", src: "assets/checkbox-trashcan.png", onchange: "itemChanged"}
+					{kind: "moon.CheckboxItem", content: "This is a verrry long option 5 with a custom checkmark", icon: "", src: "$lib/moonstone/samples/assets/checkbox-trashcan.png", onchange: "itemChanged"}
 				]},
 				{components: [
 					{kind: "moon.Divider", content: "Right-Handed Checkbox Items"},


### PR DESCRIPTION
...t do in the sample). Enyo-DCO-1.1-Signed-off-by: Brooke Peterson brooke.peterson@lge.com
### Issue:

In Sampler - CheckboxItem, customized image src 'checkbox-trashcan' icon did not display.
### Fix:

In moonstone/samples/CheckboxItemSample.js:
Change the src relative path to absolute path.
