### PR TITLE
BHV-699: When the second panel doesn't have any spottable component, the...

### DIFF
--- a/source/Panel.js
+++ b/source/Panel.js
@@ -234,7 +234,7 @@
 			]},
 
 			{name: 'animator', kind: 'enyo.StyleAnimator', onComplete: 'animationComplete'},
-			{name: "spotlightDummy", spotlight: false, style: "width:0;height:0;"}
+			{name: 'spotlightDummy', spotlight: false, style: 'width:0;height:0;'}
 		],
 
 		/**


### PR DESCRIPTION
... left arrow key doesn't move panel index to the previous.
### Issue:

When the second panel doesn't have any spottable component, the left arrow key doesn't move panel index to the previous.
### Fix:

In the updateSpotability method in moon.Panel, when not offscreen or in breadcrumb mode, check that the panel is Spottable. If not, create a dummy element.

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
