### PR TITLE
BHV-12790: Dynamic content change on HighlightText is not work when used with marquee

### DIFF
--- a/samples/HighlightTextSample.js
+++ b/samples/HighlightTextSample.js
@@ -28,7 +28,12 @@ enyo.kind({
 					]},
 					{kind: "moon.Item", components: [
 						{kind: "moon.HighlightText", content:"Text to highlight", highlight:"highlight", highlightClasses:"highlight-text-sample-fancy"}
-					]}
+					]},
+					{kind: "moon.Divider", content:"Custom control with marquee"},
+					{tag:"div", style: "border: 2px dotted grey; margin: 5px 10px;", marqueeOnSpotlight: false, marqueeOnRender: true, mixins: ["moon.MarqueeSupport"], components: [
+						{name: "dynamic", kind: "moon.HighlightText", highlight:"text", mixins: ["moon.MarqueeItem"], content:$L("Very long text to see highlight with marquee but not using item")}
+					]},
+					{kind: "moon.Button", content: "Dynamic Content Change", ontap: "changeContent"}
 				]}
 			]},
 			{name: "inputPanel", kind: "moon.Panel", headerOptions: {kind: "moon.InputHeader"}, classes:"moon-6h", joinToPrev: true, oninput: "search", components: [
@@ -53,6 +58,9 @@ enyo.kind({
 	},
 	search: function(inSender, inEvent) {
 		inSender.waterfall("onHighlight", {highlight: inEvent.originator.getValue()});
+	},
+	changeContent: function() {
+		this.$.dynamic.setContent("Dynamic content change test, this text should be highlighted.");
 	},
 	data: [
 		{ text: "proident irure nostrud", isFolder: false },

--- a/source/HighlightText.js
+++ b/source/HighlightText.js
@@ -21,12 +21,20 @@
 		HighlightTextDelegate = Object.create(HTMLStringDelegate);
 
 	HighlightTextDelegate.generateInnerHtml = function (control) {
+		var i = 0, child;
 		// flow can alter the way that html content is rendered inside
 		// the container regardless of whether there are children.
 		control.flow();
-		if (control.children.length) { return this.generateChildHtml(control); }
+		if (control.children.length) {
+			// If marqueeText is created inside of highlightText then it needs to pass search keyword to children
+			for (; (child = control.children[i]); ++i) {
+				child.search = control.search;
+				child.highlightClasses = control.highlightClasses; // this is not included in search, so passing it
+			}
+			return this.generateChildHtml(control);
+		}
 		else {
-			if (control.search) {
+			if (control.search && control.content) {
 				return control.content.replace(control.search, control.bindSafely(function (s) {
 					return '<span style=\'pointer-events:none;\' class=\'' + this.highlightClasses + '\'>' + enyo.dom.escape(s) + '</span>';
 				}));


### PR DESCRIPTION
### Issue

If marquee is used with highlight text, highlight text can have marqueeText as a child.
In generateInnerHtml, marqueeText doesn't have search and highlightClasses property on it.
So, it goes to usual content change routine.
### Fix

Pass search and highlightClasses properties to child controls(marqueeText).
Adding empty content check for safety.
Adding test case on sample.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
