### PR TITLE
Fixes CMB-1323

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -273,7 +273,7 @@
 		*/
 		labelForValue: function(value) {
 			if (this.digits) {
-				value = ('00000000000000000000' + value).slice(-this.digits);
+				value = (value < 0? '-' : '') + ('00000000000000000000' + Math.abs(value)).slice(-this.digits);
 			}
 
 			return value;


### PR DESCRIPTION
## Issue

IntegerPicker formats padded negative numbers with the negative sign in the middle and includes the negative sign in the count of number of digits. (e.g. 00-1 instead of -0001)
## Fix

Prepend digits based on absolute value and prepend negative sign

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
