### PR TITLE
BHV-5736: ListActions RTL: Unable to 5way right completely in List Action Menu

### DIFF
--- a/samples/ListActionsSample.css
+++ b/samples/ListActionsSample.css
@@ -1,0 +1,3 @@
+.fittable-scroller {
+	position: absolute;
+}

--- a/samples/ListActionsSample.html
+++ b/samples/ListActionsSample.html
@@ -16,6 +16,7 @@
 	<!-- -->
 	<script src="../../layout/list/samples/NameGenerator.js" type="text/javascript"></script>
 	<script src="ListActionsSample.js" type="text/javascript"></script>
+	<link href="ListActionsSample.css" rel="stylesheet">
 	<!-- -->
 </head>
 <body>

--- a/samples/ListActionsSample.js
+++ b/samples/ListActionsSample.js
@@ -27,7 +27,7 @@ enyo.kind({
 					]},
 					{action:"category1", components: [
 						{kind: "moon.Divider", content:"Category 1 (Static)"},
-						{kind: "moon.Scroller", fit: true, components: [
+						{kind: "moon.Scroller", classes: "fittable-scroller", fit: true, components: [
 							{kind: "enyo.Group", name:"group", highlander: true, defaultKind: "moon.SelectableItem", components: [
 								{content:"Just Released"},
 								{content:"Recommended"},


### PR DESCRIPTION
### Issue:

For the scroller inside a list-actions-menu, scrollWidth was 9px greater than the width, despite the scroller having a "fit: true" property. This seems related to combining a "fit:true" property with a css "position: relative;" property. This led to the scrollLeft having a value of 9 in rtl mode, which changed the value of absolute bounds, which led to the nearest neighbor algorithm not considering the rightmost panel in rtl mode.
### Fix:

There are possible ways to fix this that involve changing the nearest neighbor algortithm, or changing the handling of scrollLeft in enyo.dom.getAbsoluteBounds, for webkit browsers, when in rtl mode. Nevertheless, what I've done is change "position: relative" to "position: absolute" for the scroller element which has "fit" set to "true".

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
