### PR TITLE
Fixes BHV-11417

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -305,6 +305,12 @@
 			this.updateOverlays();
 		},
 
+		stepChanged: function (old) {
+			var step = parseInt(this.step, 10);
+			this.step = isNaN(step)? 1 : step;
+			this.valueChanged(this.value);
+		},
+
 		/**
 		* @private
 		*/


### PR DESCRIPTION
## Issue

Providing invalid `step` values for IntegerPicker breaks the control
## Fix

Add stepChanged to perform basic validation

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
