### PR TITLE
BHV-12132: DatePicker: 'Day' suddenly Loops then Hangs when 'Month' Wraps Around

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -293,7 +293,7 @@
 				if (typeof ilib !== 'undefined') {
 					this.localeValue = ilib.Date.newInstance({unixtime: this.value.getTime(), timezone: "local"});
 					
-					updateDays = false;
+					updateDays = true;
 					if (inOld) {
 						var old = ilib.Date.newInstance({date: inOld});
 						updateDays = (old.getYears() != this.localeValue.getYears() ||
@@ -310,9 +310,9 @@
 						this.$.day.updateOverlays();
 					}
 				} else {
-					updateDays = inOld &&
+					updateDays = (inOld &&
 					(inOld.getFullYear() != this.value.getFullYear() ||
-					inOld.getMonth() != this.value.getMonth());
+					inOld.getMonth() != this.value.getMonth())) || !inOld;
 					this.$.year.setValue(this.value.getFullYear());
 					this.$.month.setValue(this.value.getMonth() + 1);
 					if (updateDays) {


### PR DESCRIPTION
### Issue:

The original bug fixed itself, possibly due to changes in scroller. This commit fixes a related issue (the max value of the day picker is wrongly initialized) discovered when investigating the original bug.
### Fix:

update max when month and/or year change, and when the old date value is null

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
