### PR TITLE
BHV-10720 : change input to don't have a focus css when press 'enter'

### DIFF
--- a/source/Input.js
+++ b/source/Input.js
@@ -105,6 +105,7 @@
 				if (oEvent.keyCode == 13) {
 					if (this._bFocused) {
 						this.blur();
+						enyo.Spotlight.unspot();
 					}
 				}
 			}


### PR DESCRIPTION
## Issue

Header: 'Enter' prompts temporary Focus on Input
## Problem

Original ux design is that input has a spoltight css style when input is blured
But, in the http://jira2.lgsvl.com/browse/BHV-10720, new requirement is requested.
## Cause & Fix

Currently, input has their own CSS class "moon-focused". It override spoltlight css as gray color when input is focused.
If input is blurred with enter key, 'moon-focused' is removed thus only spotlight css is remained.
So, after blur, I unspot the input which is spotted so that looks not-red. 

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
