### PR TITLE
BHV-12785 : propagate a parameter to doAnimateFinish()

### DIFF
--- a/source/Slider.js
+++ b/source/Slider.js
@@ -758,7 +758,7 @@
 		animatorComplete: function(sender) {
 			this._setValue(sender.value);
 			this.animatingTo = null;
-			this.doAnimateFinish();
+			this.doAnimateFinish(sender);
 			return true;
 		},
 


### PR DESCRIPTION
## Issue

Slider: Undefined (NAN) Value displays via 5way
## Cause

Currently, SliderSample are using onAnimateFinish event for updating their status
But, after the change (ENYO-11 Updating documentation, df1fa354), onAnimationFinish doesn't include 'value' on it.
## Fix

Propagate a parameter to doAnimateFinish

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
