### PR TITLE
BHV-12792 : add checking routine for value on refresh function

### DIFF
--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -358,7 +358,9 @@
 			if (this._tf) {
 				delete this._tf;
 			}
-			this.localeValue = ilib.Date.newInstance({unixtime: this.value.getTime(), timezone: "local"});
+			if (this.value){
+				this.localeValue = ilib.Date.newInstance({unixtime: this.value.getTime(), timezone: "local"});
+			}
 			this.initDefaults();
 			this.render();
 		}


### PR DESCRIPTION
## Issue

TimePicker: Picker Disappears when Defaulted Locale is Reselected
## Cause

After Edwin added fix( 0338c37f ), there was no checking statement about value's status
Currently, locale can be changed when 'value' is null, 'this.value.getTime' makes error msg at that time.
## Fix

Add checking routine for value on refresh function
