### PR TITLE
Quick fix on tooltip to address overlay problem between marquee text and tooltip

### DIFF
--- a/css/Tooltip.less
+++ b/css/Tooltip.less
@@ -1,6 +1,7 @@
 .moon-tooltip {
 	z-index: 20;
 	height: @moon-tooltip-height;
+	transform: translatez(0);
 }
 .moon-tooltip-label {
 	.moon-small-button-text;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3775,6 +3775,7 @@
 .moon-tooltip {
   z-index: 20;
   height: 68px;
+  transform: translatez(0);
 }
 .moon-tooltip-label {
   font-family: "Moonstone Miso Bold";

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3772,6 +3772,7 @@
 .moon-tooltip {
   z-index: 20;
   height: 68px;
+  transform: translatez(0);
 }
 .moon-tooltip-label {
   font-family: "Moonstone Miso Bold";


### PR DESCRIPTION
### Issue

This is a regression of previous fix for 1px garbage when marquee flows.
Marquee text is on top of tooltip.
### Fix

Add translateZ(0) to set acceleration

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
