### PR TITLE
BHV-13120: make disabled buttons receive mouse events, ...

### DIFF
--- a/css/Button.less
+++ b/css/Button.less
@@ -1,6 +1,8 @@
 /* Button */
 
 .moon-button {
+   position: relative;
+   overflow: visible;
 	height:@moon-button-height;
 	line-height:(@moon-button-height)-(2*@moon-button-border-width);
 	border-radius: @moon-button-border-radius;
@@ -8,7 +10,6 @@
 	border: @moon-button-border-width solid transparent;
 	cursor: pointer;
 	white-space: nowrap;
-	overflow: hidden;
 	display: inline-block;
 	width: auto;
 	min-width: @moon-button-height;
@@ -39,8 +40,6 @@
   min-width: @moon-button-small-height;
   line-height:(@moon-button-small-height)-(2*@moon-button-border-width);
   padding:0 @moon-button-small-h-padding;
-  position: relative;
-  overflow: visible;
 }
 .moon-button.min-width {
   min-width: @moon-button-large-min-width;
@@ -49,7 +48,15 @@
   min-width: @moon-button-small-min-width;
 }
 
-.moon-button.small > .small-button-tap-area {
+.moon-button > .button-tap-area {
+	position: absolute;
+	top: -(@moon-button-border-width);
+	bottom: -(@moon-button-border-width);
+	left: -(@moon-button-border-width);
+	right: -(@moon-button-border-width);
+}
+
+.moon-button.small > .button-tap-area {
 	position: absolute;
 	top: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);
 	bottom: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1200,6 +1200,8 @@
 }
 /* Button */
 .moon-button {
+  position: relative;
+  overflow: visible;
   height: 85px;
   line-height: 75px;
   border-radius: 9999px;
@@ -1207,7 +1209,6 @@
   border: 5px solid transparent;
   cursor: pointer;
   white-space: nowrap;
-  overflow: hidden;
   display: inline-block;
   width: auto;
   min-width: 85px;
@@ -1237,8 +1238,6 @@
   min-width: 60px;
   line-height: 50px;
   padding: 0 20px;
-  position: relative;
-  overflow: visible;
 }
 .moon-button.min-width {
   min-width: 180px;
@@ -1246,7 +1245,14 @@
 .moon-button.small.min-width {
   min-width: 130px;
 }
-.moon-button.small > .small-button-tap-area {
+.moon-button > .button-tap-area {
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+}
+.moon-button.small > .button-tap-area {
   position: absolute;
   top: -14px;
   bottom: -14px;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1200,6 +1200,8 @@
 }
 /* Button */
 .moon-button {
+  position: relative;
+  overflow: visible;
   height: 85px;
   line-height: 75px;
   border-radius: 9999px;
@@ -1207,7 +1209,6 @@
   border: 5px solid transparent;
   cursor: pointer;
   white-space: nowrap;
-  overflow: hidden;
   display: inline-block;
   width: auto;
   min-width: 85px;
@@ -1237,8 +1238,6 @@
   min-width: 60px;
   line-height: 50px;
   padding: 0 20px;
-  position: relative;
-  overflow: visible;
 }
 .moon-button.min-width {
   min-width: 180px;
@@ -1246,7 +1245,14 @@
 .moon-button.small.min-width {
   min-width: 130px;
 }
-.moon-button.small > .small-button-tap-area {
+.moon-button > .button-tap-area {
+  position: absolute;
+  top: -5px;
+  bottom: -5px;
+  left: -5px;
+  right: -5px;
+}
+.moon-button.small > .button-tap-area {
   position: absolute;
   top: -14px;
   bottom: -14px;

--- a/source/Button.js
+++ b/source/Button.js
@@ -121,6 +121,7 @@
 		initComponents: function () {
 			if (!(this.components && this.components.length > 0)) {
 				this.createComponent({name: 'client', kind:'moon.MarqueeText', isChrome: true});
+				this.createComponent({name: 'tapArea', classes: 'button-tap-area', isChrome: true});
 			}
 			this.smallChanged();
 			this.minWidthChanged();
@@ -158,21 +159,13 @@
 		},
 
 		/**
-		* If `this.small` is `true`, adds a child that increases the tap area.
+		* If `this.small` is `true`, `taparea` dimensions are increased
 		* @private
 		*/
 		smallChanged: function () {
-			if (this.$.tapArea) {
-				this.$.tapArea.destroy();
-			}
-
 			if (this.small) {
 				this.addClass('small');
 				this.addClass('moon-small-button-text');
-				var ta = this.createComponent({name: 'tapArea', classes: 'small-button-tap-area', isChrome: true});
-				if (this.generated) {
-					ta.render();
-				}
 			} else {
 				this.removeClass('small');
 				this.removeClass('moon-small-button-text');

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -295,7 +295,7 @@
 		_marquee_enter: function (inSender, inEvent) {
 			this._marquee_isHovered = true;
 			if ((this.marqueeOnHover && !this.marqueeOnSpotlight) || 
-			(this.disabled && this.marqueeOnSpotlight && !this.hasNode().getAttribute('disabled'))) {
+			(this.disabled && this.marqueeOnSpotlight)) {
 				this.startMarquee();
 			}
 		},


### PR DESCRIPTION
...in order to display tooltips and marquee on hover
### Issue:

disabled buttons do not receive mouse events, so do not display tooltips or marquee on hover
### Fix:

On investigation, found that small, disabled buttons do receive mouse events, because they have a taparea child. So created the taparea child for large buttons as well as small, with different less styling.

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
