### PR TITLE
BHV-13418: Moon checkbox not propagating rendered event

### DIFF
--- a/source/Checkbox.js
+++ b/source/Checkbox.js
@@ -93,11 +93,13 @@
 		/**
 		* @private
 		*/
-		rendered: function () {
-			this.iconChanged();
-			this.srcChanged();
-		},
-
+		rendered: enyo.inherit(function (sup) {
+			return function() {
+				sup.apply(this, arguments);
+				this.srcChanged();
+				this.iconChanged();
+			};
+		}),
 		/**
 		* @fires enyo.Checkbox#onChange
 		* @private


### PR DESCRIPTION
Issue:

While rendering, enyo.checkbox dom node is not updated based on the
current checked value of moon.checkbox.

Fix:

Propagated rendered event to enyo.checkbox.

Enyo-DCO-1.1-Signed-off-by: Anish Ramesan anish.ramesan@lge.com
