### PR TITLE
CMB-1022: Ensure that the negative sign remains on the left side of numeric values  in RTL.

### DIFF
--- a/css/IntegerPicker.less
+++ b/css/IntegerPicker.less
@@ -12,6 +12,7 @@
 }
 
 .moon-scroll-picker {
+	direction: ltr;
 	height: @moon-integer-picker-height;
 	border-top: solid 30px transparent;
 	border-bottom: solid 30px transparent;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1896,6 +1896,7 @@
   opacity: 0.6;
 }
 .moon-scroll-picker {
+  direction: ltr;
   height: 94px;
   border-top: solid 30px transparent;
   border-bottom: solid 30px transparent;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1896,6 +1896,7 @@
   opacity: 0.35;
 }
 .moon-scroll-picker {
+  direction: ltr;
   height: 94px;
   border-top: solid 30px transparent;
   border-bottom: solid 30px transparent;


### PR DESCRIPTION
## Issue

The negative sign is displayed on the right side of numeric values in RTL.
## Fix

We specify `direction:ltr` for `moon.IntegerPicker` to ensure the negative sign remains on the left side of numeric values.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
