### PR TITLE
BHV-13593: Undefined Error in moon.Checkbox.

### DIFF
--- a/source/CheckboxItem.js
+++ b/source/CheckboxItem.js
@@ -236,7 +236,8 @@
 		*/
 		decorateActivateEvent: function (inSender, inEvent) {
 			inEvent.toggledControl = this;
-			this.setChecked(this.$.input.getChecked());
+			if(this.$.input)
+				this.setChecked(this.$.input.getChecked());
 			inEvent.checked = this.checked;
 		},
 


### PR DESCRIPTION
Issue:
If we create ''moon.FormCheckBox" in the group control. the dynamic
operations like create and destroy is causing exception.
Fix:
performing a check in 'decorateActivateEvent' for the current
'moon.Checkbox' component.

Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com