### PR TITLE
BHV-13526: Removed Corrupted Icon displays in Drawer Handle

### DIFF
--- a/css/Drawers.less
+++ b/css/Drawers.less
@@ -2,7 +2,7 @@
 .moon-drawers-activator {
 	z-index: 100;
 	font-family: @moon-icon-font-family;
-	font-size: 50px;
+	font-size: 43px;
 	// adjust the caret to line-up with the bottom edge of the activator bar
 	line-height: @moon-icon-font-size / 2 - 4;
 	// Height must be less than or equal to the distance from the edge of the screen to the content

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3542,7 +3542,7 @@
 .moon-drawers-activator {
   z-index: 100;
   font-family: "Moonstone Icons";
-  font-size: 50px;
+  font-size: 43px;
   line-height: 32px;
   height: 0px;
   position: absolute;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3539,7 +3539,7 @@
 .moon-drawers-activator {
   z-index: 100;
   font-family: "Moonstone Icons";
-  font-size: 50px;
+  font-size: 43px;
   line-height: 32px;
   height: 0px;
   position: absolute;


### PR DESCRIPTION
Issue: Due to the bigger icon size, corrupted icon gets displays in Drawer Handle 
Fix: The size of the icon is reduced from 50px to 43px. 
Now the corrupted image is not coming.
Enyo-DCO-1.1-Signed-off-by:Anshu Agrawal anshu.agrawal@lge.com
