### PR TITLE
BHV-13458: DatePicker: Mismatch between year picker value and current value for th-TH locale

### DIFF
--- a/samples/DatePickerSample.js
+++ b/samples/DatePickerSample.js
@@ -63,7 +63,11 @@ enyo.kind({
 		var year = isNaN(parseInt(this.$.yearInput.getValue(), 0)) ? this.$.picker.value.getFullYear() : parseInt(this.$.yearInput.getValue(), 0);
 		var month = isNaN(parseInt(this.$.monthInput.getValue(), 0)) ? this.$.picker.value.getMonth() : parseInt(this.$.monthInput.getValue(), 0) - 1;
 		var day = isNaN(parseInt(this.$.dayInput.getValue(), 0)) ? this.$.picker.value.getDate() : parseInt(this.$.dayInput.getValue(), 0);
-		this.$.picker.setValue(new Date(year, month, day));
+		if(this.$.picker.getLocale() == 'th-TH'){
+			this.$.picker.setValue(new Date(year-543, month, day));
+		} else{
+			this.$.picker.setValue(new Date(year, month, day));
+		}
 	},
 	resetDate: function() {
 		this.$.picker.setValue(new Date());

--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -105,6 +105,8 @@
 		*/
 		create: function () {
 			this.inherited(arguments);
+			this.thaiMinYear = this.minYear + this.thaiExtraYear;
+			this.thaiMaxYear = this.maxYear + this.thaiExtraYear;
 		},
 		
 		/**
@@ -232,6 +234,7 @@
 					break;
 				}
 			}
+			this.formatThaiYear();
 			this.inherited(arguments);
 		},
 
@@ -257,6 +260,9 @@
 				month = this.$.month.getValue(),
 				year = this.$.year.getValue(),
 				maxDays;
+			if (this.locale == "th-TH") {
+				year = year - this.thaiExtraYear;
+			}
 			var valueHours = this.value ? this.value.getHours() : 0;
 			var valueMinutes = this.value ? this.value.getMinutes() : 0;
 			var valueSeconds = this.value ? this.value.getSeconds() : 0;
@@ -295,12 +301,36 @@
 					value = this.localeValue.getJSDate();
 				}
 
-				this.$.year.setValue(value.getFullYear());
+				if (this.locale !== "th-TH") {
+					this.$.year.setValue(value.getFullYear());
+				}
 				this.$.month.setValue(value.getMonth() + 1);
 				this.$.day.setValue(value.getDate());
 				this.$.day.setMax(this.monthLength(value.getFullYear(), value.getMonth() + 1));
+				this.formatThaiYear();
 			}
 			this.$.currentValue.setContent(this.formatValue());
+		},
+
+		/**
+		* @private
+		*/
+		formatThaiYear: function () {
+			var valueFullYear;
+			if (this.locale == "th-TH") {
+				this.$.year.setMin(this.thaiMinYear);
+				this.$.year.setMax(this.thaiMaxYear);
+				if (typeof ilib !== 'undefined') {
+					if (this.localeValue) {
+						valueFullYear = this.localeValue.getYears() + this.thaiExtraYear;
+					}
+				} else {
+					if (this.value) {
+						valueFullYear = this.value.getFullYear() + this.thaiExtraYear;
+					}
+				}
+				this.$.year.setValue(valueFullYear);
+			}
 		},
 
 		/**

--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -138,6 +138,11 @@
 		/**
 		* @private
 		*/
+		thaiExtraYear: 543,
+
+		/**
+		* @private
+		*/
 		components: [
 			{name: 'headerWrapper', kind: 'moon.Item', classes: 'moon-date-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 				// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
@@ -244,7 +249,12 @@
 		valueChanged: function (inOld) {
 			this.setChildPickers(inOld);
 			if (this.value) {
-				this.doChange({name:this.name, value:this.value});
+				if(this.locale == 'th-TH'){
+					this.value.setFullYear(this.value.getFullYear() + this.thaiExtraYear);
+					this.doChange({name:this.name, value:this.value});
+				} else {
+					this.doChange({name:this.name, value:this.value});
+				}
 			} else {
 				this.noneTextChanged();
 			}
@@ -358,7 +368,7 @@
 			if (this._tf) {
 				delete this._tf;
 			}
-			this.localeValue = ilib.Date.newInstance({unixtime: this.value.getTime(), timezone: "local"});
+			//this.localeValue = ilib.Date.newInstance({unixtime: this.value.getTime(), timezone: "local"});
 			this.initDefaults();
 			this.render();
 		}


### PR DESCRIPTION
Issue:
There was a mismatch between year picker value and current value for th-TH locale
Fix:
Mismatch removed between year picker value and current value for th-TH locale

Enyo-DCO-1.1-Signed-off-by: Anshu Agrawal anshu.agrawal@lge.com
