### PR TITLE
BHV-13960: Use -webkit- prefix for CSS transforms.

### DIFF
--- a/css/ProgressButton.less
+++ b/css/ProgressButton.less
@@ -4,6 +4,7 @@
 	overflow: hidden;
 	border: @moon-progress-button-border-width solid transparent;
 	transform: translateZ(0);
+	-webkit-transform: translateZ(0);
 
 	// Override the moon-button mouse-click state to suppress the border
 	&.in-progress:active:hover:not([disabled]),
@@ -14,13 +15,16 @@
 	}
 	&.completed .moon-progress-button-bar {
 		transform: translateX(103%);
+		-webkit-transform: translateX(103%);
 	}
 	&.animated {
 		.moon-progress-button-bar {
 			transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+			-webkit-transition: -webkit-transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 		}
 		&.completed {
 			transition: transform 0.2s ease-in;
+			-webkit-transition: -webkit-transform 0.2s ease-in;
 		}
 	}
 }
@@ -33,9 +37,11 @@
 	border-radius: @moon-progress-button-bar-border-radius;
 	background-color: @moon-progress-button-bar-color;
 	transform: translateZ(0);
+	-webkit-transform: translateZ(0);
 }
 .moon-progress-button-progresspercent {
 	position: absolute;
 	left: 50%;
 	transform: translateX(-50%);
+	-webkit-transform: translateX(-50%);
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -2104,6 +2104,7 @@
   overflow: hidden;
   border: 5px solid transparent;
   transform: translateZ(0);
+  -webkit-transform: translateZ(0);
 }
 .moon-progress-button.in-progress:active:hover:not([disabled]),
 .moon-progress-button.in-progress {
@@ -2113,12 +2114,15 @@
 }
 .moon-progress-button.completed .moon-progress-button-bar {
   transform: translateX(103%);
+  -webkit-transform: translateX(103%);
 }
 .moon-progress-button.animated .moon-progress-button-bar {
   transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  -webkit-transition: -webkit-transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 .moon-progress-button.animated.completed {
   transition: transform 0.2s ease-in;
+  -webkit-transition: -webkit-transform 0.2s ease-in;
 }
 .moon-progress-button-bar {
   height: 100%;
@@ -2129,11 +2133,13 @@
   border-radius: 9999px;
   background-color: #cf0652;
   transform: translateZ(0);
+  -webkit-transform: translateZ(0);
 }
 .moon-progress-button-progresspercent {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
 }
 .moon-slider-taparea {
   position: absolute;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -2103,6 +2103,7 @@
   overflow: hidden;
   border: 5px solid transparent;
   transform: translateZ(0);
+  -webkit-transform: translateZ(0);
 }
 .moon-progress-button.in-progress:active:hover:not([disabled]),
 .moon-progress-button.in-progress {
@@ -2112,12 +2113,15 @@
 }
 .moon-progress-button.completed .moon-progress-button-bar {
   transform: translateX(103%);
+  -webkit-transform: translateX(103%);
 }
 .moon-progress-button.animated .moon-progress-button-bar {
   transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  -webkit-transition: -webkit-transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 .moon-progress-button.animated.completed {
   transition: transform 0.2s ease-in;
+  -webkit-transition: -webkit-transform 0.2s ease-in;
 }
 .moon-progress-button-bar {
   height: 100%;
@@ -2128,11 +2132,13 @@
   border-radius: 9999px;
   background-color: #cf0652;
   transform: translateZ(0);
+  -webkit-transform: translateZ(0);
 }
 .moon-progress-button-progresspercent {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
+  -webkit-transform: translateX(-50%);
 }
 .moon-slider-taparea {
   position: absolute;

--- a/source/ProgressButton.js
+++ b/source/ProgressButton.js
@@ -197,6 +197,7 @@
 				}
 				// The value is so small that it should not be visible.
 				this.$.bar.applyStyle('transform', 'translateX(-100%)');
+				this.$.bar.applyStyle('-webkit-transform', 'translateX(-100%)');
 				progress = 0;
 			} else if (percent >= 5 && percent < 100) {
 				// Disable spotlight: you can't click a button once it's in progress
@@ -212,10 +213,12 @@
 				// Only change the progress bar if it's different from the last time this was run
 				if (progress != this._visibleProgress) {
 					this.$.bar.applyStyle('transform', 'translateX(-' + (100 + offset - progress) + '%)');
+					this.$.bar.applyStyle('-webkit-transform', 'translateX(-' + (100 + offset - progress) + '%)');
 				}
 			} else if (percent >= 100) {
 				// Make it spottable again, now that it's finished.
 				this.$.bar.applyStyle('transform', null);
+				this.$.bar.applyStyle('-webkit-transform', null);
 				this.setPostContent();
 				progress = 100;
 			}


### PR DESCRIPTION
## Issue

None of the CSS transforms were being applied to older versions of WebKit as this was tested on a recent Chrome build that recognizes the standard `transform` property. This caused the `moon.ProgressButton` control to only function properly in newer builds of Chrome.
## Fix

Add the `-webkit` prefix to CSS transform rules.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
