### PR TITLE
BHV-13959: Drawer: Now Icons gets Display in Handle

### DIFF
--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3542,6 +3542,97 @@
 .moon-drawers-client > * {
   pointer-events: all;
 }
+/* moonstone-icons.css */
+.moon-icon-arrowlargeup:after {
+  content: "\0F0002";
+}
+.moon-icon-arrowlargedown:after {
+  content: "\0F0001";
+}
+.moon-icon-arrowlargeleft:after {
+  content: "\0F0003";
+}
+.moon-icon-arrowlargeright:after {
+  content: "\0F0004";
+}
+.moon-icon-arrowsmallup:after {
+  content: "\0F0005";
+}
+.moon-icon-arrowsmalldown:after {
+  content: "\0F0006";
+}
+.moon-icon-arrowsmallleft:after {
+  content: "\0F0007";
+}
+.moon-icon-arrowsmallright:after {
+  content: "\0F0008";
+}
+.moon-icon-closex:after {
+  content: "\0F0009";
+}
+.moon-icon-check:after {
+  content: "\0F000A";
+}
+.moon-icon-search:after {
+  content: "\0F000B";
+}
+.moon-icon-drawer:after {
+  content: "\0F0000";
+}
+.moon-icon-fullscreen:after {
+  content: "\0F0012";
+}
+.moon-icon-circle:after {
+  content: "\0F0013";
+}
+.moon-icon-stop:after {
+  content: "\0F0014";
+}
+.moon-icon-play:after {
+  content: "\0F0015";
+}
+.moon-icon-pause:after {
+  content: "\0F0016";
+}
+.moon-icon-forward:after {
+  content: "\0F0017";
+}
+.moon-icon-backward:after {
+  content: "\0F0018";
+}
+.moon-icon-skipforward:after {
+  content: "\0F0019";
+}
+.moon-icon-skipbackward:after {
+  content: "\0F001A";
+}
+.moon-icon-pauseforward:after {
+  content: "\0F001B";
+}
+.moon-icon-pausebackward:after {
+  content: "\0F001C";
+}
+.moon-icon-pausejumpforward:after {
+  content: "\0F001D";
+}
+.moon-icon-pausejumpbackward:after {
+  content: "\0F001E";
+}
+.moon-icon-jumpforward:after {
+  content: "\0F001F";
+}
+.moon-icon-jumpbackward:after {
+  content: "\0F0020";
+}
+.moon-icon-arrowextend:after {
+  content: "\0F0021";
+}
+.moon-icon-arrowshrink:after {
+  content: "\0F0022";
+}
+.moon-icon-exitfullscreen:after {
+  content: "\0F0011";
+}
 /* Scrim.css */
 .moon-scrim {
   z-index: 1;

--- a/css/moonstone-icons.less
+++ b/css/moonstone-icons.less
@@ -1,0 +1,32 @@
+/* moonstone-icons.css */
+
+.moon-icon-arrowlargeup:after      { content: @moon-icon-arrowlargeup; }
+.moon-icon-arrowlargedown:after    { content: @moon-icon-arrowlargedown }
+.moon-icon-arrowlargeleft:after    { content: @moon-icon-arrowlargeleft; }
+.moon-icon-arrowlargeright:after   { content: @moon-icon-arrowlargeright; }
+.moon-icon-arrowsmallup:after      { content: @moon-icon-arrowsmallup; }
+.moon-icon-arrowsmalldown:after    { content: @moon-icon-arrowsmalldown; }
+.moon-icon-arrowsmallleft:after    { content: @moon-icon-arrowsmallleft; }
+.moon-icon-arrowsmallright:after   { content: @moon-icon-arrowsmallright; }
+.moon-icon-closex:after            { content: @moon-icon-closex; }
+.moon-icon-check:after             { content: @moon-icon-check; }
+.moon-icon-search:after            { content: @moon-icon-search; }
+.moon-icon-drawer:after            { content: @moon-icon-drawer; }
+.moon-icon-fullscreen:after        { content: @moon-icon-fullscreen; }
+.moon-icon-circle:after            { content: @moon-icon-circle; }
+.moon-icon-stop:after              { content: @moon-icon-stop; }
+.moon-icon-play:after              { content: @moon-icon-play; }
+.moon-icon-pause:after             { content: @moon-icon-pause; }
+.moon-icon-forward:after           { content: @moon-icon-forward; }
+.moon-icon-backward:after          { content: @moon-icon-backward; }
+.moon-icon-skipforward:after       { content: @moon-icon-skipforward; }
+.moon-icon-skipbackward:after      { content: @moon-icon-skipbackward; }
+.moon-icon-pauseforward:after      { content: @moon-icon-pauseforward; }
+.moon-icon-pausebackward:after     { content: @moon-icon-pausebackward; }
+.moon-icon-pausejumpforward:after  { content: @moon-icon-pausejumpforward; }
+.moon-icon-pausejumpbackward:after { content: @moon-icon-pausejumpbackward; }
+.moon-icon-jumpforward:after       { content: @moon-icon-jumpforward; }
+.moon-icon-jumpbackward:after      { content: @moon-icon-jumpbackward; }
+.moon-icon-arrowextend:after       { content: @moon-icon-arrowextend; }
+.moon-icon-arrowshrink:after       { content: @moon-icon-arrowshrink; }
+.moon-icon-exitfullscreen:after    { content: @moon-icon-exitfullscreen; }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3539,6 +3539,97 @@
 .moon-drawers-client > * {
   pointer-events: all;
 }
+/* moonstone-icons.css */
+.moon-icon-arrowlargeup:after {
+  content: "\0F0002";
+}
+.moon-icon-arrowlargedown:after {
+  content: "\0F0001";
+}
+.moon-icon-arrowlargeleft:after {
+  content: "\0F0003";
+}
+.moon-icon-arrowlargeright:after {
+  content: "\0F0004";
+}
+.moon-icon-arrowsmallup:after {
+  content: "\0F0005";
+}
+.moon-icon-arrowsmalldown:after {
+  content: "\0F0006";
+}
+.moon-icon-arrowsmallleft:after {
+  content: "\0F0007";
+}
+.moon-icon-arrowsmallright:after {
+  content: "\0F0008";
+}
+.moon-icon-closex:after {
+  content: "\0F0009";
+}
+.moon-icon-check:after {
+  content: "\0F000A";
+}
+.moon-icon-search:after {
+  content: "\0F000B";
+}
+.moon-icon-drawer:after {
+  content: "\0F0000";
+}
+.moon-icon-fullscreen:after {
+  content: "\0F0012";
+}
+.moon-icon-circle:after {
+  content: "\0F0013";
+}
+.moon-icon-stop:after {
+  content: "\0F0014";
+}
+.moon-icon-play:after {
+  content: "\0F0015";
+}
+.moon-icon-pause:after {
+  content: "\0F0016";
+}
+.moon-icon-forward:after {
+  content: "\0F0017";
+}
+.moon-icon-backward:after {
+  content: "\0F0018";
+}
+.moon-icon-skipforward:after {
+  content: "\0F0019";
+}
+.moon-icon-skipbackward:after {
+  content: "\0F001A";
+}
+.moon-icon-pauseforward:after {
+  content: "\0F001B";
+}
+.moon-icon-pausebackward:after {
+  content: "\0F001C";
+}
+.moon-icon-pausejumpforward:after {
+  content: "\0F001D";
+}
+.moon-icon-pausejumpbackward:after {
+  content: "\0F001E";
+}
+.moon-icon-jumpforward:after {
+  content: "\0F001F";
+}
+.moon-icon-jumpbackward:after {
+  content: "\0F0020";
+}
+.moon-icon-arrowextend:after {
+  content: "\0F0021";
+}
+.moon-icon-arrowshrink:after {
+  content: "\0F0022";
+}
+.moon-icon-exitfullscreen:after {
+  content: "\0F0011";
+}
 /* Scrim.css */
 .moon-scrim {
   z-index: 1;

--- a/css/moonstone-rules.less
+++ b/css/moonstone-rules.less
@@ -90,6 +90,7 @@
 @import "InputHeader.less";
 @import "Drawer.less";
 @import "Drawers.less";
+@import "moonstone-icons.less";
 @import "Scrim.less";
 @import "Popup.less";
 @import "Dialog.less";


### PR DESCRIPTION
Issue:
Drawer: Icons Do Not Display in Handle
moonstone-icons.less file has been removed due to which the icons are not getting overridden.
Fix:
moonstone-icons.less file has been again added so that the icons gets overridden in Handle.

Enyo-DCO-1.1-Signed-off-by: Anshu Agrawal anshu.agrawal@lge.com
