### PR TITLE
BHV-13526: Drawer: Now Proper Icon displays in Handle

### DIFF
--- a/css/Drawers.less
+++ b/css/Drawers.less
@@ -2,7 +2,7 @@
 .moon-drawers-activator {
 	z-index: 100;
 	font-family: @moon-icon-font-family;
-	font-size: 43px;
+	font-size: 60px;
 	// adjust the caret to line-up with the bottom edge of the activator bar
 	line-height: @moon-icon-font-size / 2 - 4;
 	// Height must be less than or equal to the distance from the edge of the screen to the content

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3481,7 +3481,7 @@
 .moon-drawers-activator {
   z-index: 100;
   font-family: "Moonstone Icons";
-  font-size: 43px;
+  font-size: 60px;
   line-height: 32px;
   height: 0px;
   position: absolute;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3478,7 +3478,7 @@
 .moon-drawers-activator {
   z-index: 100;
   font-family: "Moonstone Icons";
-  font-size: 43px;
+  font-size: 60px;
   line-height: 32px;
   height: 0px;
   position: absolute;


### PR DESCRIPTION
Issue:
Drawer: Previously Corrupted Icon displays in Handle
Fix:
Changed the font-size of the icon from 43px to 60px.
Now proper icon gets displays in Drawer Handle.

Enyo-DCO-1.1-Signed-off-by: Anshu Agrawal anshu.agrawal@lge.com
