### PR TITLE
Fixes BHV-12786

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -614,7 +614,7 @@
 		* @private
 		*/
 		requestSetupBounds: function(sender, event) {
-			if (this.hasNode()) {
+			if (this.generated) {
 				this.scrollBounds = this._getScrollBounds();
 				this.setupBounds();
 				this.scrollBounds = null;


### PR DESCRIPTION
## Issue

Since ScrollStrategy is tagless, `hasNode()` is always false so the code is unreachable.
## Fix

Using `this.generated instead` has the same effect to block against the subsequent calls until the client controls are rendered.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
