### PR TITLE
Fixes BHV-13000

### DIFF
--- a/samples/SliderSample.js
+++ b/samples/SliderSample.js
@@ -98,7 +98,7 @@ enyo.kind({
 		this.changeValue();
 	},
 	changeProgress: function(inSender, inEvent) {
-		var v = parseInt(this.$.progressInput.getValue());
+		var v = parseInt(this.$.progressInput.getValue(), 10);
 
 		for (var i in this.$) {
 			if (this.$[i].kind == "moon.Slider") {


### PR DESCRIPTION
## Issue

Specifying a value for increment in the slider sample breaks spotlighting right because the increment value is set as a string and + performs string concatenation instead of arithmetic.
## Fix

Parse values from inputs to integers

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
