### PR TITLE
BHV-14088: Add fa-IR locale to sample.

### DIFF
--- a/samples/CalendarSample.js
+++ b/samples/CalendarSample.js
@@ -30,6 +30,7 @@ enyo.kind({
 					{kind: "moon.ExpandablePicker", name:"localePicker", noneText: "No Language Selected", content: "Choose Locale", onChange: "setLocale", components: [
 						{content: "en-US", active:true}, //United States, firstDayOfWeek: 0
 						{content: "th-TH"}, //Thailand
+						{content: "fa-IR"}, // Iran, persian calendar
 						{content: "en-CA"}, //Canada, firstDayOfWeek: 0
 						{content: "ko-KO"}, //Korea, firstDayOfWeek: 1
 						{content: "und-AE"}, //United Arab Emirates, firstDayOfWeek: 6


### PR DESCRIPTION
## Issue

The `fa-IR` locale has disappeared from `moon.CalendarSample`.
## Fix

The `fa-IR` locale has been re-added.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
