### PR TITLE
BHV-13458: DatePicker: Mismatch between year picker value and current value for th-Th locale

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -113,6 +113,7 @@
 		initILib: function () {
 			this.inherited(arguments);
 			if (typeof ilib !== 'undefined' && this.value) {
+				ilib.setLocale(this.locale);
 				this.localeValue = ilib.Date.newInstance({unixtime: this.value.getTime(), timezone: "local"});
 			}
 		},
@@ -186,6 +187,7 @@
 			var valueFullYear = 0, valueMonth = 0, valueDate = 0, maxMonths = 12;
 
 			if (typeof ilib !== 'undefined') {
+				ilib.setLocale(this.locale);
 				if (this.localeValue) {
 					valueFullYear = this.localeValue.getYears();
 					valueMonth = this.localeValue.getMonths();
@@ -300,10 +302,7 @@
 					this.$.day.setValue(this.localeValue.getDays());
 					this.$.day.setMax(this.monthLength(this.localeValue.getYears(), this.localeValue.getMonths()));
 				} else {
-					this.$.year.setValue(value.getFullYear());
-					this.$.month.setValue(value.getMonth() + 1);
-					this.$.day.setValue(value.getDate());
-					this.$.day.setMax(this.monthLength(value.getFullYear(), value.getMonth() + 1));
+					return;
 				}
 			}
 			this.$.currentValue.setContent(this.formatValue());

--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -330,7 +330,6 @@
 		*/
 		localeChanged: function () {
 			// Our own locale property has changed, so we need to rebuild our child pickers
-			this.value = this.value || new Date();
 			this.refresh();
 		},
 
@@ -360,8 +359,7 @@
 			if (this._tf) {
 				delete this._tf;
 			}
-			if (this.value){
-				ilib.setLocale(this.locale);
+			if(this.value){
 				this.localeValue = ilib.Date.newInstance({unixtime: this.value.getTime(), timezone: "local"});
 			}
 			this.initDefaults();


### PR DESCRIPTION
Issue:
There was a mismatch between year picker value and current value for th-TH locale
Fix:
Mismatch removed between year picker value and current value for th-TH locale

Enyo-DCO-1.1-Signed-off-by: Anshu Agrawal anshu.agrawal@lge.com
