### PR TITLE
BHV-14129: VideoTransportSlider: Does not unfreeze Spotlight upon dragfinish

### DIFF
--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -670,6 +670,7 @@
 					// TODO : action in dummy area
 					this.dummyAction = true;
 				} else {
+					// the call to the super class freezes spotlight, so it needs to be unfrozen in dragfinish
 					var dragstart = this.inherited(arguments);
 					if (dragstart) {
 						this.doSeekStart();
@@ -744,6 +745,7 @@
 				e.preventTap();
 				// this.hideKnobStatus();
 				this.doSeekFinish({value: v});
+				enyo.Spotlight.unfreeze();
 			}
 			this.$.knob.removeClass('active');
 			this.dummyAction = false;


### PR DESCRIPTION
### Issue:

VideoTransportSlider dragstart was freezing spotlight (indirectly via call to super class) but dragfinish was not unfreezing
### Fix:

add the unfreeze call to dragfinish

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
