### PR TITLE
BHV-14133: Adding -webkit prefix for Spinner transforms.

### DIFF
--- a/css/Spinner.less
+++ b/css/Spinner.less
@@ -79,12 +79,14 @@
 	&.center {
 		margin: 0;
 		margin-left: 50%;
+		-webkit-transform: translateX(-50%);
 		transform: translateX(-50%);
 
 		// Vertically centered
 		&.middle {
 			position: absolute;
 			top: 50%;
+			-webkit-transform: translateX(-50%) translateY(-50%);
 			transform: translateX(-50%) translateY(-50%);
 		}
 	}

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -2963,11 +2963,13 @@
 .moon-spinner.center {
   margin: 0;
   margin-left: 50%;
+  -webkit-transform: translateX(-50%);
   transform: translateX(-50%);
 }
 .moon-spinner.center.middle {
   position: absolute;
   top: 50%;
+  -webkit-transform: translateX(-50%) translateY(-50%);
   transform: translateX(-50%) translateY(-50%);
 }
 .moon-spinner.moon-spinner-transparent-background {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -2960,11 +2960,13 @@
 .moon-spinner.center {
   margin: 0;
   margin-left: 50%;
+  -webkit-transform: translateX(-50%);
   transform: translateX(-50%);
 }
 .moon-spinner.center.middle {
   position: absolute;
   top: 50%;
+  -webkit-transform: translateX(-50%) translateY(-50%);
   transform: translateX(-50%) translateY(-50%);
 }
 .moon-spinner.moon-spinner-transparent-background {

--- a/samples/SpinnerSample.css
+++ b/samples/SpinnerSample.css
@@ -1,7 +1,7 @@
 .absolute-container {
 	width: 80%;
 	height: 200px;
-	/* Please do not use this red border in your app. This is only to demonstarte centering in a container .*/
+	/* Please do not use this red border in your app. This is only to demonstrate centering in a container .*/
 	border: 2px red dashed;
 	position: relative;
 }


### PR DESCRIPTION
## Issue

The `moon.Spinner` was not properly being centered within its container.
## Fix

This issue did not appear on newer versions of Chrome as the `transform` property became standardized. Adding the `-webkit` prefix corrects the issue.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
