### PR TITLE
BHV-14197 : Moon Scroller: Dual focus on paging controls

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -704,7 +704,7 @@
 		* @private
 		*/
 		shouldShowPageControls: function() {
-			return (enyo.Spotlight.getPointerMode() && this.hovering);
+			return (enyo.Spotlight.getPointerMode() && this.hovering && !this.spotlightPagingControls);
 		},
 
 		/**


### PR DESCRIPTION
Issue: when we switch form 5way mode to pointer mode, hover classes are
not removed on paging controls, due to this paginating controls are
getting dual focus.

Fix: checking the spotlightPagingContrls flag while updating the hover
classes of the controls.

Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com
