### PR TITLE
BHV-14089: DatePicker: Incrementing year picker above 2037 results in an error

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -291,6 +291,11 @@
 		setChildPickers: function (inOld) {
 			if (this.value) {
 				var value = this.value;
+				if (typeof ilib !== 'undefined') {
+					this.localeValue = ilib.Date.newInstance({unixtime: this.value.getTime(), timezone: "local"});
+					var l = this.localeValue;
+					value = new Date(l.year, l.month-1, l.day, l.hour, l.minute, l.second, l.millisecond);
+				}
 				this.$.year.setValue(value.getFullYear());
 				this.$.month.setValue(value.getMonth() + 1);
 				this.$.day.setValue(value.getDate());


### PR DESCRIPTION
### Issue:

"this.setValue(new Date(this.localeValue.getTime()));" was not setting this.value correctly, when the year incremented past 2038. Also, setChildPickers() was modifying this.value and this.localeValue, when they had already been set in updateValue().
### Fix:

replace 
"this.setValue(new Date(this.localeValue.getTime()));"
with
"var l = this.localeValue;
this.setValue(new Date(l.year, l.month-1, l.day, l.hour, l.minute, l.second, l.millisecond));"
and delete code in setChildPickers()

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
