### PR TITLE
BHV-14227: Change input to unspot when pointermo...

### DIFF
--- a/source/Input.js
+++ b/source/Input.js
@@ -102,9 +102,9 @@
 		*/
 		onKeyUp: function (oSender, oEvent) {
 			if (this.dismissOnEnter) {
-				if (oEvent.keyCode == 13) {
-					if (this._bFocused) {
-						this.blur();
+				if (oEvent.keyCode == 13 && this._bFocused) {
+					this.blur();
+					if (enyo.Spotlight.getPointerMode()) {
 						enyo.Spotlight.unspot();
 					}
 				}


### PR DESCRIPTION
## Issue

Unspotted after dismiss on enter, there is no spotted control in app.
## History
1. Originally, after dismissOnEnter, framework give a focus to the input.
2. From BHV-10720 issue, we changed input to don't give a focus
3. Now, InputMgr developer request that framework give a focus according to the input key's status(pointer mode)
4. In magic remote control, give no focus in the app
5. In 5-way key control, give a focus to the input.
## Fix

change input to unspot only when dismissOnEnter and pointermode is true

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
