### PR TITLE
BHV-14241: Adjusted marquee to apply the full animation definition as style

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -794,7 +794,7 @@
 			this.$.marqueeText.applyStyle('transition', 'transform ' + duration + 's linear');
 			this.$.marqueeText.applyStyle('-webkit-transition', '-webkit-transform ' + duration + 's linear');
 
-			enyo.dom.transform(this, {translateZ: -0.01});
+			enyo.dom.transform(this, {translateZ: '-0.1px'});
 
 			// Need this timeout for FF!
 			setTimeout(this.bindSafely(function () {


### PR DESCRIPTION
### Issue

Marquee was being applied, but only partially. When the duration was being set, it was being set as `transform: <duration>`. This means that the other two properties on this are automatically set to their default values, which includes the timing function `ease`.
### Fix

Setting all 3 of the value on the master property ensures that the browser knows what to do, by not inheriting or assuming anything.

There is also much variable name and improper quotation cleanup that is not directly relevant to this PR, but needed to be done anyway.
