### PR TITLE
Fixes ENYO-247

### DIFF
--- a/source/TooltipDecorator.js
+++ b/source/TooltipDecorator.js
@@ -119,6 +119,14 @@
 		/**
 		* @private
 		*/
+		create: function () {
+			this.inherited(arguments);
+			this.createComponent({kind: 'enyo.Signals', onSpotlightCurrentChanged: 'spotChanged'});
+		},
+
+		/**
+		* @private
+		*/
 		autoShowChanged: function () {
 			if (!this.autoShow) {
 				this.requestHideTooltip();
@@ -150,6 +158,13 @@
 		* @private
 		*/
 		spotBlur: function () {
+			this.requestHideTooltip();
+		},
+
+		/**
+		* @private
+		*/
+		spotChanged: function (sender, event) {
 			this.requestHideTooltip();
 		},
 


### PR DESCRIPTION
## Issue

Tooltips for disabled controls are not hidden when 5-way to a spottable control. The current code handles `onleave` and `onSpotlightBlur` but neither are fired as the cursor hasn't moved and the activating control did not have spotlight focus because it is disabled.
## Fix

Add a listener for the global onSpotlightCurrentChanged. This is fired before onSpotlightFocus so the tooltip will still be appropriately displayed when an enabled activator is spotted. 

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
