### PR TITLE
BHV-14412: MoonTimePicker-hour picker issue

### DIFF
--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -148,8 +148,7 @@
 		* @private
 		*/
 		setupItem: function (inSender, inEvent) {
-			var hour = this.format(inEvent.index);
-			hour = hour % this.range === 0 ? this.format(0) : hour;
+			var hour = this.format(inEvent.index % this.range);
 			this.$.item.setContent(hour);
 		},
 


### PR DESCRIPTION
Issue: when we use 24-hrs format locale, hours content is not handled
properly, because of it causes unnecessary value rendering in hour
picker.

Fix: handling the hour value based on the range in HourPicker's
setupItem method.

Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com
