### PR TITLE
BHV-14435: Updating drawer activator during create

### DIFF
--- a/source/Drawers.js
+++ b/source/Drawers.js
@@ -174,6 +174,7 @@
 			this.inherited(arguments);
 			this.$.drawers.createComponents(this.drawers, {kind: 'moon.Drawer', owner:this.owner});
 			this.setupHandles();
+			this.updateActivator();
 		},
 
 		/**


### PR DESCRIPTION
ISSUE: "icon" and "src" are not updated for activator when "drawers" component
block is not present.

Cause:
When drawer components are not present, the "onDrawersRendered" event
which is waterfall'd during "moon.Drawers" render, is not received by
defaulted "moon.Drawer" component. Thus not leading to trigger
"updateActivator" function required to set the "icon" and "src".

Implemented:
Adding "this.updateActivator();" in moon.Drawers create routine could take care of scenarios when drawer component block is not provided
