### PR TITLE
Fix for: BHV-13452

### DIFF
--- a/source/SelectableItem.js
+++ b/source/SelectableItem.js
@@ -81,7 +81,18 @@
 			* @default false
 			* @public
 			*/
-			active: false
+			active: false,
+			
+			/**
+			* If used as the base control within a {@link moon.DataList} or {@glossary subkind},
+			* this should be set to `false` so that selection support can be synchronized to the
+			* checked state of this control.
+			*
+			* @type {Boolean}
+			* @default true
+			* @public
+			*/
+			handleTapEvent: true
 		},
 		
 		/**
@@ -132,9 +143,10 @@
 			if (this.disabled) {
 				return true;
 			}
-
-			this.setActive(!this.getActive());
-			this.bubble('onchange');
+			if (this.handleTapEvent) {
+				this.setActive(!this.getActive());
+				this.bubble('onchange');
+			}
 		},
 
 		/**


### PR DESCRIPTION
### Problem

Currently, having moon.SelectableItem's in a moon.DataRepeater and attempting to use selection support is not possible.
### Reason

There is mutually-exclusive code executing for the `ontap` event - with moon.SelectableItem's handler going second and inverting the selection case already handled by the repeater.
### Solution

Add an optional API flag for use within the repeater that, when set to `false`, will allow the repeater exclusive access for handling the `ontap` event and selection.
