### PR TITLE
ENYO-251: Add iLib to ExpandablePickerSample

### DIFF
--- a/samples/ExpandablePickerSample.html
+++ b/samples/ExpandablePickerSample.html
@@ -11,6 +11,7 @@
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
+	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../moonstone/package.js" type="text/javascript"></script>
 	<script src="../../spotlight/package.js" type="text/javascript"></script>
 	<!-- -->


### PR DESCRIPTION
iLib was not included in ExpandablePickerSample.html, which
resulted in the sample behaving differently inside the Sampler
from outside. (TimePicker omits the meridiem by default if iLib
is not present.)

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
