### PR TITLE
BHV-14452: CheckboxItem doens't call srcChanged/iconChanged on initial. . .

### DIFF
--- a/source/CheckboxItem.js
+++ b/source/CheckboxItem.js
@@ -201,7 +201,7 @@
 		*/
 		rendered: function () {
 			this.inherited(arguments);
-			if (this.src || this.icon) {
+			if (this.hasOwnProperty('src') || this.hasOwnProperty('icon')) {
 				this.srcChanged();
 				this.iconChanged();
 			}


### PR DESCRIPTION
. . .render when it is set to empty string
### Issue:

When user wants to set icon and src to "" to clear icon, icon changed is not called on render.
### Fix:

use this.hasOwnProperty('icon') instead of this.icon

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
