### PR TITLE
BHV-14477: Add "enyo-unselectable" class to sample.

### DIFF
--- a/samples/DataGridListSample.js
+++ b/samples/DataGridListSample.js
@@ -2,7 +2,7 @@ enyo.kind({
 	name: "moon.sample.DataGridListSample",
 	kind: "moon.Panels",
 	pattern: "activity",
-	classes: "moon enyo-fit",
+	classes: "moon enyo-fit enyo-unselectable",
 	components: [
 		{kind: "moon.Panel", classes:"moon-6h", title:"Menu", components: [
 			{kind:"moon.Item", content:"Scroll"},


### PR DESCRIPTION
### Issue

Text in the `moon.DataGridListSample` can be highlighted/selected, and this is particularly noticeable when tapping the paging controls, as their icons are now implemented via a font.
### Fix

We add the `enyo-unselectable` class to the sample.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
