### PR TITLE
BHV-14466: Panels overlapped when push listAction panel with 5 way 'OK' key press

### DIFF
--- a/samples/DynamicPanelsSample.js
+++ b/samples/DynamicPanelsSample.js
@@ -16,6 +16,17 @@ enyo.kind({
 						{kind: "moon.Item", content: "Dummy Item", ontap: "next"}
 					]}
 				]}
+			], headerComponents: [
+				{kind:"moon.TooltipDecorator", components: [
+					{kind:"moon.Tooltip", position:"above", content:"Test Dynamic Lists"},
+					{kind: "moon.ListActions", icon:"drawer", listActions: [
+						{action:"category3", components: [
+							{kind: "moon.Divider", content: "Dynamic List Action"},
+							{kind: "moon.Item", content: "Dummy Item 1"},
+							{kind: "moon.Item", content: "Dummy Item 2"}
+						]}
+					]}
+				]}
 			]}
 		], {owner: this});
 	},

--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -201,11 +201,11 @@
 		/**
 		* @private
 		*/
-		rendered: function() {
+		rendered: function(inSender, inEvent) {
 			this.inherited(arguments);
 			if (this.open) {
 				// Perform post-open work
-				this.drawerAnimationEnd();
+				this.drawerAnimationEnd(inSender, enyo.Mixin(inEvent, {skipSpot: true}));
 				// Update stacking
 				this.resizeDrawer();
 			}
@@ -347,10 +347,10 @@
 		* @fires moon.TooltipDecorator#onRequestUnmuteTooltip
 		* @private
 		*/
-		drawerAnimationEnd: function() {
+		drawerAnimationEnd: function(inSender, inEvent) {
 			//on closed, hide drawer and spot _this.$.activator_
 			if (!this.getOpen()) {
-				if (this.generated) {
+				if (this.generated && (inEvent && inEvent.skipSpot !== true)) {
 					enyo.Spotlight.spot(this.$.activator);
 				}
 				this.bubble('onRequestUnmuteTooltip');
@@ -576,7 +576,7 @@
 			// Re-enable animation
 			this.applyAnimatedMode(true);
 			// Let any watchers know we've finished our preparation
-			this.doComplete();
+			this.doComplete({skipSpot: true});
 		},
 
 		/**


### PR DESCRIPTION
### Issue:

Panel doesn't shrink to breadcrumb while panel arrangement when press 'ok' on panel item to push panel which is having listAction.
ListAction is close itself after completing render, and give focus to activator when it is close itself.
Panel have a code like when item on panel getting focused it is change index.
When panel change index, it is query transition info (getTransitionInfo) which is calling isBreadcrumb.
In this step, arranger is never calculated breadcrumbPositions values for second panel because it is before arrange.
### Fix:

Add option on oncomplete event like "skipSpot: true" to let drawerAnimationEnd handler know it is called on render.
Adding listaction on sample for testing this issue.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
