### PR TITLE
BHV-14524: MoonTooltip-multiple tooltips showing issue

### DIFF
--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -94,6 +94,16 @@
 			*/
 			contentUpperCase: true
 		},
+		statics: {
+			lastTooltip: null,
+			resetPrevious: function() {
+				var t = moon.Tooltip;
+				if (!t.lastTooltip) return;
+				t.lastTooltip.cancelShow(); // clear previous job
+				t.lastTooltip.hide(); // close previous tooltip
+				t.lastTooltip = null;
+			}
+		},
 
 		/**
 		* @private
@@ -159,8 +169,10 @@
 		* @private
 		*/
 		requestShow: function (inSender, inEvent) {
+			moon.Tooltip.resetPrevious(); // close previous tooltip and stop job
 			this.activator = inSender;
 			this.startJob('showJob', 'show', this.showDelay);
+			moon.Tooltip.lastTooltip = this;
 			return true;
 		},
 


### PR DESCRIPTION
Issue: when focus shifts from one tooltip decorator to other, previous
tooltip doesn't hide. this is causing multiple tooltip show.

Fix: Before showing any tooltip, handling the previous tooltips if there
are any.

DCO-1.1-Signed-Off-By: Srinivas V  srinivas.v@lge.com