### PR TITLE
Fixes BHV-14524 and ENYO-247

### DIFF
--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -1,4 +1,39 @@
 (function (enyo, scope) {
+	// To prevent lingering tooltips, we're monitoring spotlight changes and tooltip display
+	// to ensure that only 1 tooltip is active.
+	// see BHV-14524, ENYO-247
+	var observer = new enyo.Component({
+
+		/**
+		* Last active tooltip
+		* @private
+		*/
+		active: null,
+
+		/**
+		* @private
+		*/
+		components: [
+			{kind: 'enyo.Signals', onSpotlightCurrentChanged: 'spotChanged'}
+		],
+
+		/**
+		* @private
+		*/
+		activeChanged: function (was) {
+			if(was) {
+				was.waterfall('onRequestHideTooltip');
+			}
+		},
+
+		/**
+		* @private
+		*/
+		spotChanged: function (sender, event) {
+			this.set('active', null);
+		}
+	});
+
 	/**
 	* {@link moon.Tooltip} is a popup that works in conjunction with
 	* {@link moon.TooltipDecorator}. The tooltip is automatically displayed when the
@@ -159,6 +194,7 @@
 		* @private
 		*/
 		requestShow: function (inSender, inEvent) {
+			observer.set('active', this);
 			this.activator = inSender;
 			this.startJob('showJob', 'show', this.showDelay);
 			return true;

--- a/source/TooltipDecorator.js
+++ b/source/TooltipDecorator.js
@@ -119,14 +119,6 @@
 		/**
 		* @private
 		*/
-		create: function () {
-			this.inherited(arguments);
-			this.createComponent({kind: 'enyo.Signals', onSpotlightCurrentChanged: 'spotChanged'});
-		},
-
-		/**
-		* @private
-		*/
 		autoShowChanged: function () {
 			if (!this.autoShow) {
 				this.requestHideTooltip();
@@ -158,13 +150,6 @@
 		* @private
 		*/
 		spotBlur: function () {
-			this.requestHideTooltip();
-		},
-
-		/**
-		* @private
-		*/
-		spotChanged: function (sender, event) {
 			this.requestHideTooltip();
 		},
 


### PR DESCRIPTION
## Issue

Tooltips can linger if the focus is programmatically changed or via 5-way from disabled activators
## Fix

Adds a singleton tooltip observer that is notified when a tooltip is display or spotlight focus changes and requests the currently displayed tooltip (if any) be hidden
## Notes

This reverts #1609 with an alternate solution

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
