### PR TITLE
ENYO-246: IntegerPickers now maintain their correct height and position.

### DIFF
--- a/css/IntegerPicker.less
+++ b/css/IntegerPicker.less
@@ -3,6 +3,7 @@
 	display: inline-block;
 	position: relative;
 	text-align: center;
+	vertical-align: top;
 }
 
 /*disabled*/
@@ -77,7 +78,7 @@
 	height: @moon-integer-picker-overlay-height + 5px;
 	width: 100%;
 	background-color: @moon-accent;
-	
+
 	&.next {
 	 	top: 0;
 		border-style: solid;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1726,6 +1726,7 @@
   display: inline-block;
   position: relative;
   text-align: center;
+  vertical-align: top;
 }
 /*disabled*/
 .moon-scroll-picker-container.disabled {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1726,6 +1726,7 @@
   display: inline-block;
   position: relative;
   text-align: center;
+  vertical-align: top;
 }
 /*disabled*/
 .moon-scroll-picker-container.disabled {


### PR DESCRIPTION
### Cause

The IntegerPickers were becoming misaligned because of an incorrect height calculation done by older webkit.
### Fix

IntegerPickers, being inline elements, must have a `vertical-align` property set to remain vertically aligned with each other.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
