### PR TITLE
BHV-14650: Convert back to JS date when child picker value changes.

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -257,8 +257,7 @@
 					second: valueSeconds,
 					millisecond: valueMilliseconds
 				});
-				var l = this.localeValue;
-				this.setValue(new Date(l.year, l.month-1, l.day, l.hour, l.minute, l.second, l.millisecond));
+				this.setValue(this.localeValue.getJSDate());
 			} else {
 				maxDays = this.monthLength(year, month);
 				this.setValue(new Date(year, month-1, (day <= maxDays) ? day : maxDays,


### PR DESCRIPTION
### Issue

When specifying a locale with a non-Gregorian calendar, incrementing/decrementing the year picker can cause an incorrect year value to appear. This is due to the fact that, when the year picker's value changes, the value of the `moon.DatePicker` is set to a Gregorian date via the JavaScript `Date` object. This results in the locale date being calculated using the locale-specific year as a Gregorian year, which causes an incorrect year shift.
### Fix

We retrieve the Gregorian value of the locale date and set this as the current value.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
