### PR TITLE
BHV-14690: MoonScroller: unnecessary focus on paging control

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -351,7 +351,7 @@
 			this.hovering = true;
 			this.setupBounds();
 			this.showHideScrollColumns(true);
-			this.updateHoverOnPagingControls(enyo.Spotlight.getCurrent() ? false : true);
+			this.updateHoverOnPagingControls(!enyo.Spotlight.hasCurrent());
 		},
 
 		/**


### PR DESCRIPTION
Issue: 'onenter' event in scrollStrategy is giving unexpected focus to
the paging controls.

Fix: updating paging controls based on the existence of current spotted
control.

Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com
