### PR TITLE
ENYO-261 Remove silence() to cover direct calling of setSelectedIndex()

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -281,7 +281,6 @@
 							index.splice(selIndex,1);
 						}
 					}
-					controls[i].unsilence();
 				}
 				this.$.currentValue.setContent(this.multiSelectCurrentValue());
 				if(this.hasNode()) {
@@ -289,7 +288,6 @@
 				}
 			} else {
 				for (i=0;i<controls.length;i++) {
-					controls[i].silence();
 					if(controls[i] === selected) {
 						controls[i].setChecked(true);
 						index = i;


### PR DESCRIPTION
When we call setSelectedIndex() directly, it block event bubbling before `active` object of ExpandablePicker is updated.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
