### PR TITLE
Fix for: BHV-14466

### DIFF
--- a/samples/DynamicPanelsSample.js
+++ b/samples/DynamicPanelsSample.js
@@ -16,6 +16,17 @@ enyo.kind({
 						{kind: "moon.Item", content: "Dummy Item", ontap: "next"}
 					]}
 				]}
+			], headerComponents: [
+				{kind:"moon.TooltipDecorator", components: [
+					{kind:"moon.Tooltip", position:"above", content:"Test Dynamic Lists"},
+					{kind: "moon.ListActions", icon:"drawer", listActions: [
+						{action:"category3", components: [
+							{kind: "moon.Divider", content: "Dynamic List Action"},
+							{kind: "moon.Item", content: "Dummy Item 1"},
+							{kind: "moon.Item", content: "Dummy Item 2"}
+						]}
+					]}
+				]}
 			]}
 		], {owner: this});
 	},

--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -205,7 +205,7 @@
 			this.inherited(arguments);
 			if (this.open) {
 				// Perform post-open work
-				this.drawerAnimationEnd();
+				this.drawerOpened(true);
 				// Update stacking
 				this.resizeDrawer();
 			}
@@ -347,26 +347,42 @@
 		* @fires moon.TooltipDecorator#onRequestUnmuteTooltip
 		* @private
 		*/
-		drawerAnimationEnd: function() {
+		drawerAnimationEnd: function(sender, event) {
+			var rendered = event && event.rendered;
+			
 			//on closed, hide drawer and spot _this.$.activator_
 			if (!this.getOpen()) {
-				if (this.generated) {
-					enyo.Spotlight.spot(this.$.activator);
-				}
-				this.bubble('onRequestUnmuteTooltip');
+				this.drawerClosed(rendered);
 			}
 			//on open, move top and spot _this.$.closeButton_
 			else {
-				if (this.resetScroller) {
-					this.$.listActions.scrollTo(0, 0);
-					this.resetScroller = false;
-				}
-				if (this.generated) {
-					enyo.Spotlight.spot(this.$.closeButton);
-				}
-				this.bubble('onRequestMuteTooltip');
+				this.drawerOpened(rendered);
 			}
 			return true;
+		},
+		
+		/**
+		* @private
+		*/
+		drawerClosed: function (rendered) {
+			if (this.generated && !rendered) {
+				enyo.Spotlight.spot(this.$.activator);
+			}
+			this.bubble('onRequestUnmuteTooltip');
+		},
+		
+		/**
+		* @private
+		*/
+		drawerOpened: function (rendered) {
+			if (this.resetScroller) {
+				this.$.listActions.scrollTo(0, 0);
+				this.resetScroller = false;
+			}
+			if (this.generated && !rendered) {
+				enyo.Spotlight.spot(this.$.closeButton);
+			}
+			this.bubble('onRequestMuteTooltip');
 		},
 
 		/**
@@ -576,7 +592,7 @@
 			// Re-enable animation
 			this.applyAnimatedMode(true);
 			// Let any watchers know we've finished our preparation
-			this.doComplete();
+			this.doComplete({rendered: true});
 		},
 
 		/**


### PR DESCRIPTION
# Issue

The _moon.ListActions_ kind handles an event propagated by its internal _moon.ListActionsDrawer_ the same whether it comes from a post-render (`rendered`) routine or an actual animation event (from open/close state change). If it happens because of an open/close state change then we want spotlight to be involved and properly spot the next control but if it is post-render then we need spotlight not to interfere. When pushing a new _moon.Panel_ into _moon.Panels_ where the panel has, in its _moon.Header_ a _moon.ListActions_ the post-render spotlight spotting of the control interferes with initialization measurements made by the arranger and it becomes impossible to navigate between panels.
# Fix

Separate out logic being actioned by the event handler so they can be called directly from the `rendered` routine of _moon.ListActions_; differentiate the post-render case from the actual state-change case.
