### PR TITLE
BHV-14852: Fix initial position to match default position.

### DIFF
--- a/samples/ContextualPopupSample.js
+++ b/samples/ContextualPopupSample.js
@@ -176,7 +176,7 @@ enyo.kind({
 				{content: 'bottom', classes: 'radioItemFont'}
 			]}
 		]},
-		{kind: 'moon.ContextualPopupDecorator', name: 'directionButton', style: 'position: absolute; left: 40%; top: 75%;', components: [
+		{kind: 'moon.ContextualPopupDecorator', name: 'directionButton', style: 'position: absolute; left: 40%; top: 70%;', components: [
 			{content: 'Direction'},
 			{
 				kind: 'moon.ContextualPopup',


### PR DESCRIPTION
### Issue

The "Direction" button is shifted when the top position value is omitted when setting the position. This is caused by a mismatch between the initial top position of the "Direction" button, and the default value that is set when the top position value is not specified.
### Fix

The initial and default value for the top position is now the same.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
