### PR TITLE
BHV-14856: Guard against uncreated DOM node. Also, optimization to prevent repeated calculation of popup bounds

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -256,86 +256,88 @@
 		* @private
 		*/
 		alterDirection: function () {
-			var clientRect = this.getBoundingRect(this.node);
-			var viewPortHeight = enyo.dom.getWindowHeight();
-			var viewPortWidth = enyo.dom.getWindowWidth();
-			var offsetHeight = (clientRect.height - this.activatorOffset.height) / 2;
-			var offsetWidth = (clientRect.width - this.activatorOffset.width) / 2;
-			var popupMargin = 20;
+			if (this.showing) {
+				var clientRect = this.getBoundingRect(this.node);
+				var viewPortHeight = enyo.dom.getWindowHeight();
+				var viewPortWidth = enyo.dom.getWindowWidth();
+				var offsetHeight = (clientRect.height - this.activatorOffset.height) / 2;
+				var offsetWidth = (clientRect.width - this.activatorOffset.width) / 2;
+				var popupMargin = 20;
 
-			var bounds = {top: null, left: null};
+				var bounds = {top: null, left: null};
 
-			if(this.direction === 'left') {
-				if(clientRect.width + popupMargin < this.activatorOffset.left) { 
-					this.resetDirection();
-					this.addClass('right');
-
-					if(this.activatorOffset.top < offsetHeight) {
-						this.addClass('high');
-						bounds.top = this.activatorOffset.top;
-					} else if(viewPortHeight - this.activatorOffset.bottom < offsetHeight) {
-						this.addClass('low');
-						bounds.top = this.activatorOffset.bottom - clientRect.height;
-					} else {
-						bounds.top = this.activatorOffset.top - offsetHeight;
-					}
-
-					bounds.left = this.activatorOffset.left - clientRect.width;
-				}
-			} else if(this.direction === 'right') {
-				if(viewPortWidth > this.activatorOffset.right + clientRect.width + popupMargin) {
-					this.resetDirection();
-					this.addClass('left');
-
-					if(this.activatorOffset.top < offsetHeight) {
-						this.addClass('high');
-						bounds.top = this.activatorOffset.top;
-					} else if(viewPortHeight - this.activatorOffset.bottom < offsetHeight) {
-						this.addClass('low');
-						bounds.top = this.activatorOffset.bottom - clientRect.height;
-					} else {
-						bounds.top = this.activatorOffset.top - offsetHeight;
-					}
-
-					bounds.left = this.activatorOffset.right;
-				}
-			} else if(this.direction === 'top') {
-				if(clientRect.height + popupMargin < this.activatorOffset.top) {
-					this.resetDirection();
-					this.addClass('above');
-
-					if(this.activatorOffset.left < offsetWidth) {
+				if(this.direction === 'left') {
+					if(clientRect.width + popupMargin < this.activatorOffset.left) { 
+						this.resetDirection();
 						this.addClass('right');
-						bounds.left = this.activatorOffset.left;
-					} else if(viewPortWidth - this.activatorOffset.right < offsetWidth) {
-						this.addClass('left');
-						bounds.left = this.activatorOffset.right - clientRect.width;
-					} else {
-						bounds.left = this.activatorOffset.left - offsetWidth;
+
+						if(this.activatorOffset.top < offsetHeight) {
+							this.addClass('high');
+							bounds.top = this.activatorOffset.top;
+						} else if(viewPortHeight - this.activatorOffset.bottom < offsetHeight) {
+							this.addClass('low');
+							bounds.top = this.activatorOffset.bottom - clientRect.height;
+						} else {
+							bounds.top = this.activatorOffset.top - offsetHeight;
+						}
+
+						bounds.left = this.activatorOffset.left - clientRect.width;
 					}
-
-					bounds.top = this.activatorOffset.top - clientRect.height;
-				}
-			} else if(this.direction === 'bottom') {
-				if(viewPortHeight > this.activatorOffset.bottom + clientRect.height + popupMargin) {
-					this.resetDirection();
-					this.addClass('below');
-
-					if(this.activatorOffset.left < offsetWidth) {
-						this.addClass('right');
-						bounds.left = this.activatorOffset.left;
-					} else if(viewPortWidth - this.activatorOffset.right < offsetWidth) {
+				} else if(this.direction === 'right') {
+					if(viewPortWidth > this.activatorOffset.right + clientRect.width + popupMargin) {
+						this.resetDirection();
 						this.addClass('left');
-						bounds.left = this.activatorOffset.right - clientRect.width;
-					} else {
-						bounds.left = this.activatorOffset.left - offsetWidth;
-					}
 
-					bounds.top = this.activatorOffset.bottom;
+						if(this.activatorOffset.top < offsetHeight) {
+							this.addClass('high');
+							bounds.top = this.activatorOffset.top;
+						} else if(viewPortHeight - this.activatorOffset.bottom < offsetHeight) {
+							this.addClass('low');
+							bounds.top = this.activatorOffset.bottom - clientRect.height;
+						} else {
+							bounds.top = this.activatorOffset.top - offsetHeight;
+						}
+
+						bounds.left = this.activatorOffset.right;
+					}
+				} else if(this.direction === 'top') {
+					if(clientRect.height + popupMargin < this.activatorOffset.top) {
+						this.resetDirection();
+						this.addClass('above');
+
+						if(this.activatorOffset.left < offsetWidth) {
+							this.addClass('right');
+							bounds.left = this.activatorOffset.left;
+						} else if(viewPortWidth - this.activatorOffset.right < offsetWidth) {
+							this.addClass('left');
+							bounds.left = this.activatorOffset.right - clientRect.width;
+						} else {
+							bounds.left = this.activatorOffset.left - offsetWidth;
+						}
+
+						bounds.top = this.activatorOffset.top - clientRect.height;
+					}
+				} else if(this.direction === 'bottom') {
+					if(viewPortHeight > this.activatorOffset.bottom + clientRect.height + popupMargin) {
+						this.resetDirection();
+						this.addClass('below');
+
+						if(this.activatorOffset.left < offsetWidth) {
+							this.addClass('right');
+							bounds.left = this.activatorOffset.left;
+						} else if(viewPortWidth - this.activatorOffset.right < offsetWidth) {
+							this.addClass('left');
+							bounds.left = this.activatorOffset.right - clientRect.width;
+						} else {
+							bounds.left = this.activatorOffset.left - offsetWidth;
+						}
+
+						bounds.top = this.activatorOffset.bottom;
+					}
 				}
+
+				this.setBounds(bounds);
 			}
-
-			this.setBounds(bounds);
 		},
 
 		/**


### PR DESCRIPTION
### Issue

An error was thrown when the direction of a `moon.ContextualPopup` was set before the popup had been shown for the first time.
### Fix

We guard against accessing an undefined node by adding a conditional check in `alterDirection` that examines the `showing` property. This also adds an optimization to prevent unnecessary calculation of bounds when the popup is not showing and/or when the popup is being hidden.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
