### PR TITLE
[BHV-14914] Tooltip position is wrong when spotlight focus shifts in som...

### DIFF
--- a/source/TooltipDecorator.js
+++ b/source/TooltipDecorator.js
@@ -130,7 +130,7 @@
 		*/
 		enter: function (inSender, inEvent) {
 			if(!enyo.Spotlight.hasCurrent())
-			this.requestShowTooltip(inSender, inEvent);
+				this.requestShowTooltip(inSender, inEvent);
 		},
 
 		/**


### PR DESCRIPTION
...e cases

Issue: "onenter" event is handled  without checking for the present
spotted control.
Fix:
As the "onenter" event can be triggered without mousemove, before
showing the tooltip it checks if any current spotted control is there or
not.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P rajyavardhan.p@lge.com
