### PR TITLE
ENYO-266 Delay unchecking item until checking is done.

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -267,7 +267,7 @@
 			i; //declaring i here to fix travis error
 
 			if (this.multipleSelection) {
-				this.rebuildSelected(selected, controls);
+				this.rebuildSelectedIndices(selected, controls);
 				if(this.hasNode()) {
 					this.fireChangeEvent();
 				}
@@ -389,14 +389,10 @@
 		* @method
 		* @private
 		*/
-		rebuildSelected: function(selected, controls) {
+		rebuildSelectedIndices: function(selected, controls) {
 			this.selectedIndex = [];
-			if (!selected) {
-				selected = this.getSelected();
-			}
-			if (!controls) {
-				controls = this.getCheckboxControls();
-			}
+			selected = selected || this.getSelected();
+			controls = controls || this.getCheckboxControls();
 
 			for (var i = 0; i < controls.length; i++) {
 				if (selected.indexOf(controls[i]) >= 0) {
@@ -429,7 +425,7 @@
 						}
 						// in case of multipleSection, removing control could change
 						// selected array.
-						this.rebuildSelected();
+						this.rebuildSelectedIndices();
 					} else {
 						if (this.selected === inControl) {
 							this.setSelected(null);


### PR DESCRIPTION
## Issue

Calling setSelectedIndex() directly and tapping checkboxItem have difference behavior.
## Cause

Tapping checkboxItem will select item first and then de-select previous item.
However calling setSelectedIndex() will de-select first in some specific case.
## Fix

To guarantee same behavior between tapping checkboxItem and direct calling of setSelectedIndex(),
we should prevent unchecking work before checking is finished due to Group.active updating.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
