### PR TITLE
BHV-14652: ContextualPopupSample with a non-latin locale now fits the direction buttons.

### DIFF
--- a/samples/ContextualPopupSample.js
+++ b/samples/ContextualPopupSample.js
@@ -181,7 +181,7 @@ enyo.kind({
 			{
 				kind: 'moon.ContextualPopup',
 				name: 'directionContext',
-				classes: 'moon-6h moon-4v',
+				classes: 'moon-7h moon-4v',
 				components: [
 					{kind: moon.Scroller, horizontal: 'auto', classes: 'enyo-fill', components: [
 						{kind: moon.Button, content: 'Button 1'},


### PR DESCRIPTION
Buttons in the `DIRECTION` popup would be out of place when a non-latin locale was loaded. This widens the space they have to work with, so they don't wrap.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
