### PR TITLE
BHV-11985: Only stop marquee when blurring the control that the marquee was initiated on.

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -104,7 +104,7 @@
 		*/
 		_marquee_Handlers: {
 			onRequestStartMarquee: '_marquee_requestStartMarquee',
-			onSpotlightFocus: '_marquee_spotlightFocus',
+			onSpotlightFocused: '_marquee_spotlightFocused',
 			onSpotlightBlur: '_marquee_spotlightBlur',
 			onenter: '_marquee_enter',
 			onleave: '_marquee_leave',
@@ -270,10 +270,9 @@
 		*
 		* @private
 		*/
-		_marquee_spotlightFocus: function (sender, ev) {
+		_marquee_spotlightFocused: function (sender, ev) {
 			this._marquee_isFocused = true;
 			if (this.marqueeOnSpotlight) {
-				this._marquee_originator = ev.originator;
 				this.startMarquee();
 			}
 		},
@@ -285,8 +284,7 @@
 		*/
 		_marquee_spotlightBlur: function (sender, ev) {
 			this._marquee_isFocused = false;
-			if (this.marqueeOnSpotlight && this._marquee_originator === ev.originator) {
-				this._marquee_originator = null;
+			if (this.marqueeOnSpotlight) {
 				this.stopMarquee();
 			}
 		},


### PR DESCRIPTION
### Issue

Due to a change in the ordering of `Spotlight` focus/blur events, when moving between synchronized marquees (i.e. marquees in the same `moon.MarqueeDecorator` control or a control that has mixed in `MarqueeSupport`), the currently focused marquee will not start. This is caused by the fact that `unspot` is called for the previously focused marquee, which results in an `onSpotlightBlur` event being fired after an `onSpotlightFocus` event is fired (for the currently focused marquee). So effectively the marquee job is cancelled right after it's started.
### Fix

To guarantee that we are stopping the marquee job appropriately, we handle the `onSpotlightFocused` event instead of the `onSpotlightFocus` event, as we know that `onSpotlightBlur` has already been fired at this point.
### Notes

There is another marquee issue that can affect the behavior of this fix (a z-layering issue that has caused a few marquee tickets). To debug this issue independent of the layering issues, I used Canary (39.0.2168.0) as the layering issue is not present there. We may need to wait for a fix to the layering issues and rebase this branch, to fully test/verify.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
