### PR TITLE
BHV-12425: Scroller in ExpandableInputSample can't scroll to first item in certain use case

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -167,6 +167,7 @@
 			} else {
 				this.setActive(true);
 				enyo.Spotlight.unspot();
+				this.focusInput();
 			}
 		},
 
@@ -251,16 +252,6 @@
 				this.closeDrawerAndHighlightHeader();
 			}
 			return true;
-		},
-
-		/**
-		* @private
-		*/
-		drawerAnimationEnd: function () {
-			if (this.getOpen()) {
-				this.focusInput();
-			}
-			this.inherited(arguments);
 		},
 
 		/**


### PR DESCRIPTION
### Issue:

When you call focusinput() at the end of drawerAnimationEnd, the widget jumps up, without changing the scroller values, so that later when the scroller thinks it's scrolling up to 0, there is still content on top.
### Fix:

The call to focusInput() was initially moved to drawerAnimationEnd() from toggleActive() in order to deal with a VKB-issue: https://jira2.lgsvl.com/browse/GF-58781. I've confirmed that that VKB-issue has been resolved, so this fix moves the call to focusInput() back to toggleActive().

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
