### PR TITLE
updated tool tip parent check, for moving tool tip position

### DIFF
--- a/samples/TooltipSample.html
+++ b/samples/TooltipSample.html
@@ -9,7 +9,7 @@
 	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
 	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script> -->
 	<!-- -->
-	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
+	<script src="../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
 	<script src="../../moonstone/package.js" type="text/javascript"></script>

--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -254,7 +254,7 @@
                 //tooltip do not change position
                 if(this.parent != this.activator.parent) {
                     return;
-                };
+                }
 
 				//* Calculate the difference between decorator and activating
 				//* control's top, left, right differences, position tooltip against


### PR DESCRIPTION
Added a check for the tool tip, to verify that the current Spotlight is within the same Parent as the tooltip, if it is not then the tooltip will not move. Addressing BHV-14914.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
