### PR TITLE
BHV-14937: moon.Dialog should support the 'x' button

### DIFF
--- a/samples/DialogSample.js
+++ b/samples/DialogSample.js
@@ -7,7 +7,7 @@ enyo.kind({
 		{classes: "moon-1v"},
 		{kind: "moon.ToggleButton", content: "Showing", name: "showingToggle"},
 		{kind: "moon.ToggleButton", content: "Animate", name: "animateToggle"},
-		{kind: "moon.ToggleButton", content: "SpotlightModal", name: "spotlightModalToggle"},
+		{kind: "moon.ToggleButton", content: "SpotlightModal", ontap: "buttonToggled"},
 		{
 			name: "dialog", 
 			kind: "moon.Dialog",
@@ -22,9 +22,12 @@ enyo.kind({
 	],
 	bindings: [
 		{from: ".$.showingToggle.value", to: ".$.dialog.showing", oneWay:false},
-		{from: ".$.spotlightModalToggle.value", to: ".$.dialog.spotlightModal", oneWay:false},
 		{from: ".$.dialog.animate", to: ".$.animateToggle.value", oneWay:false}
 	],
+	buttonToggled: function(inSender, inEvent) {
+		this.$.dialog.setSpotlightModal(inSender.getActive());
+		this.$.dialog.setAutoDismiss(!inSender.getActive());
+	},
 	showDialog: function(inSender) {
 		this.$.dialog.show();
 	},


### PR DESCRIPTION
Tweaked the sample so the dialog is not dismissed when there is a click outside the dialog when spotlightModal is true.
