### PR TITLE
Move placeholderChanged to create to reduce number of DOM updates.

### DIFF
--- a/source/Header.js
+++ b/source/Header.js
@@ -291,13 +291,11 @@
 			this.backgroundSrcChanged();
 			this.backgroundPositionChanged();
 			this.inputModeChanged();
+			this.placeholderChanged();
 			this.fullBleedBackgroundChanged();
 		},
 
 		rendered: function() {
-			// Evaluate the placeholder (and value) change before the rendered method, but after the create method
-			this.placeholderChanged();
-
 			this.inherited(arguments);
 			this.adjustTitleWidth();
 		},


### PR DESCRIPTION
### Issue

`placeholderChanged` is called in `rendered`, which results in a style update post-render.
### Fix

We move the `placeholderChanged` call to `create`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
