### PR TITLE
BHV-14743: Remove asyncMethod call and added comment.

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -612,9 +612,12 @@
 		rendered: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
-				enyo.asyncMethod(this, function () {
-					this._marquee_detectAlignment();
-				});
+				// There is a known issue where a parent control that modifies the layout will 
+				// invalidate the measurements used to detect the proper alignment, which can
+				// result in the appropriate text-align rule not being applied. For example, this
+				// can occur with a moon.Header that is located inside a moon.Scroller which has
+				// vertical scrollbars visible.
+				this._marquee_detectAlignment();
 			};
 		}),
 


### PR DESCRIPTION
### Issue

This was a case of Friday brain. Adding missing commit to remove `asyncMethod` call. This was supposed to be part of https://github.com/enyojs/moonstone/pull/1649.
### Fix

We remove the `asyncMethod` call to prevent a hitch upon loading of `moon.Marquee` controls and to prevent a significant performance hit when initializing all `moon.Marquee` controls.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
