### PR TITLE
BHV-15254: MoonScroller: vertical thumb display issue

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -697,6 +697,7 @@
 		* @private
 		*/
 		showHideVerticalScrollColumns: function(show) {
+			this.$.vthumb.update(this);
 			this.$.vColumn.addRemoveClass('visible', show || this.spotlightPagingControls);
 		},
 


### PR DESCRIPTION
Cause:
when we are scrolling ''scrollToControl(control)'' to specific element
once after destroying components of scroller and creating some of them,
scroll thumb is not getting appropriate values, because onenter event is
showing the scroll thumb with the old values.

Fix: updating scroll thumb with the current instance of  strategy before
showing it.
Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com
