### PR TITLE
Fixes BHV-13602

### DIFF
--- a/css/ListActions.less
+++ b/css/ListActions.less
@@ -73,6 +73,10 @@
 	* {
 		pointer-events: auto;		
 	}
+
+	&.stacked .moon-list-actions-menu {
+		display: block;
+	}
 }
 .moon-list-actions-drawer-client {
 	position: absolute;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -2607,6 +2607,9 @@
 .moon-list-actions-drawer * {
   pointer-events: auto;
 }
+.moon-list-actions-drawer.stacked .moon-list-actions-menu {
+  display: block;
+}
 .moon-list-actions-drawer-client {
   position: absolute;
   width: 100%;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -2604,6 +2604,9 @@
 .moon-list-actions-drawer * {
   pointer-events: auto;
 }
+.moon-list-actions-drawer.stacked .moon-list-actions-menu {
+  display: block;
+}
 .moon-list-actions-drawer-client {
   position: absolute;
   width: 100%;

--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -316,7 +316,7 @@
 		beforeOpenDrawer: function(standardHeight, type) {
 			this.standardHeight = standardHeight;
 			if (type !== 'large') {
-				this.set(this.stacked, 'false');
+				this.set('stacked', false);
 			}
 		},
 
@@ -428,7 +428,6 @@
 			var optionGroup, i;
 
 			for (i = 0; (optionGroup = this.listActionComponents[i]); i++) {
-				optionGroup.applyStyle('display', 'block');
 				// Stacked contols get natural height (which prevents scrolling), such that they stack
 				// within outer scroller which is allowed to scroll all controls; this is a problem for
 				// DataLists, which require an explicit height, making them unsuitable for use in
@@ -448,7 +447,6 @@
 			containerHeight = this.getContainerBounds().height;
 
 			for (i = 0; (optionGroup = this.listActionComponents[i]); i++) {
-				optionGroup.applyStyle('display', 'inline-block');
 				optionGroup.applyStyle('height', containerHeight + 'px');
 			}
 		},


### PR DESCRIPTION
## Issue

Setting `display` style in code was conflicting with setting `showing: false` on list action controls
## Fix

Move display style into CSS files so it can be overridden correctly by `showing`

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
