### PR TITLE
Fixes BHV-15125

### DIFF
--- a/source/ToggleText.js
+++ b/source/ToggleText.js
@@ -9,6 +9,7 @@
 	*
 	* @class moon.ToggleText
 	* @extends moon.Checkbox
+	* @deprecated Replaced by {@link moon.ToggleButton} and {@link moon.ToggleItem}
 	* @ui
 	* @public
 	*/


### PR DESCRIPTION
## Issue

moon.ToggleText inherited the `src` and `icon` properties from moon.Checkbox but they are not supported for this kind. As a result, the change handlers were attempting to configure a control that didn't exist in moon.ToggleText.
## Fix

Override the change handlers to no-op and mark those properties as private.
## Note

Regression from PR #1426

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy ryan.duffy@lge.com
