### PR TITLE
BHV-15108: ScrollerVertical: Misaligned Label displays next to SimplePicker

### DIFF
--- a/css/Header.less
+++ b/css/Header.less
@@ -104,6 +104,11 @@
 		display: inline-block;
 		left: auto;
 	}
+
+	// vertically aligns client text with standard height widgets
+	.moon-header-client-text {
+		line-height: @moon-button-small-height;
+	}
 }
 
 // neutral

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1599,6 +1599,9 @@
   display: inline-block;
   left: auto;
 }
+.moon-header .moon-header-client-text {
+  line-height: 60px;
+}
 .moon-neutral .moon-header {
   border-top: 2px solid #ffffff;
   border-bottom: 6px solid #ffffff;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1599,6 +1599,9 @@
   display: inline-block;
   left: auto;
 }
+.moon-header .moon-header-client-text {
+  line-height: 60px;
+}
 .moon-neutral .moon-header {
   border-top: 2px solid #ffffff;
   border-bottom: 6px solid #ffffff;

--- a/samples/ScrollerVerticalSample.js
+++ b/samples/ScrollerVerticalSample.js
@@ -3,7 +3,7 @@ enyo.kind({
 	classes: "moon enyo-unselectable enyo-fit",
 	components: [
 		{kind: "moon.Panel", classes: "enyo-fit", headerType: "medium", title: "Vertical Scroller", headerComponents: [
-			{content: "Spacing: "},
+			{content: "Spacing: ", classes: "moon-header-client-text"},
 			{kind: "moon.SimplePicker", name: "spacingPicker", classes: "moon-4h", onChange: "spacingChanged", components: [
 				{content: "default", spacingClass: ""},
 				{content: "small", spacingClass: "moon-vspacing-s", active:true},


### PR DESCRIPTION
### Issue:

a vertical align style in header client which was correct for buttons and widgets was not correct for text
### Fix:

add a line-height style to header client text equal to the height of the standard widget

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
