### PR TITLE
[BHV-14151]Scrim: Scrim is not preventing mouse hover event on Scroller

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -265,9 +265,10 @@
 		* @private
 		*/
 		mouseEntered: function(sender,event) {
-			var dt = event.dispatchTarget
-			if(this.showing && !dt.isDescendantOf(this))
+			var dt = event.dispatchTarget;
+			if(this.showing && !dt.isDescendantOf(this)) {
 				return true;
+			}
 		},
 
 		/**


### PR DESCRIPTION
Issue: When Popup is showing scroller paging controls are getting focus
because of 'onenter' event.
Fix: "onenter" event is captured and handled within the popup if pop is
showing.
observation: though enter event is not triggered on the popup and its
contents when popup is showing. for safer side a checkpoint is given.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P rajyavardhan.p@lge.com
