### PR TITLE
Fix for Spotlight Tooltips

### DIFF
--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -194,19 +194,18 @@
 		* @private
 		*/
 		requestShow: function (inSender, inEvent) {
+			observer.set('active', this);
 
-            observer.set('active', this);
-
-            //if the event has no type, and is in pointer mode
-            //otherwise spotlight moved, and trigged another
-            //event on another control
-            if(!inEvent.type || enyo.Spotlight.getPointerMode()){
-                //initiated by spotlight
-                //using the originator ensures the touch
-                //target is passed
-                this.activator = inEvent.originator;
-                this.startJob('showJob', 'show', this.showDelay);
-            }
+			//if the event has no type, and is in pointer mode
+			//otherwise spotlight moved, and trigged another
+			//event on another control
+			if(!inEvent.type || enyo.Spotlight.getPointerMode()){
+				//initiated by spotlight
+				//using the originator ensures the touch
+				//target is passed
+				this.activator = inEvent.originator;
+				this.startJob('showJob', 'show', this.showDelay);
+			}
 
 			return true;
 		},
@@ -256,7 +255,7 @@
 					pBounds = this.parent.getAbsoluteBounds(),
 					acBounds = null;
 
-                // Sometimes enyo.Spotlight.getCurrent() is null.
+				// Sometimes enyo.Spotlight.getCurrent() is null.
 				// In this case, we can rely on onRequestShowTooltip event sender.
 				this.activator = enyo.Spotlight.getCurrent() || this.activator;
 				acBounds = this.activator.getAbsoluteBounds();


### PR DESCRIPTION
Programmatically changing spot focus, or moving to 5 way, after Pointer mode is engaged, causes Tooltips to follow positioning based on Spot, and not ownership (tool tips appear over the wrong element).

I added a check to verify that spotlight is engaging the tooltip, and not another event (please check for robustness of this code). 

One thing to note, this may appear as a regression on Disabled Buttons, but the Event being cast is from an inner element. This behavior is now consistent with how Tooltips are working on Disabled Icon Buttons, which needs to be addressed in BHV-13377.

I also changed inSender to inEvent.originator to remain consistent with a desire to stay away from inSender.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
