### PR TITLE
BHV-15258: When @moon-checkbox-icon-width: 32, horizontal scroller does not appear

### DIFF
--- a/css/Checkbox.less
+++ b/css/Checkbox.less
@@ -6,13 +6,6 @@
 		visibility: hidden;
 		margin: 0;
 		padding: 0;
-		> .small-icon-tap-area {
-			top: 0;
-			bottom: 0;
-			left: 0;
-			right: 0;
-			line-height: @moon-checkbox-icon-height;
-		}
 	}
 	&[checked]  .moon-icon {
 		visibility: visible;

--- a/css/CheckboxItem.less
+++ b/css/CheckboxItem.less
@@ -26,6 +26,10 @@
 		}
 	}
 
+	.moon-icon.small > .small-icon-tap-area {
+		left: 0;
+		right: 0;
+	}
 }
 
 .moon-neutral .moon-checkbox[checked]:after {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -901,13 +901,6 @@
   margin: 0;
   padding: 0;
 }
-.moon-checkbox .moon-icon > .small-icon-tap-area {
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  line-height: 32px;
-}
 .moon-checkbox[checked] .moon-icon {
   visibility: visible;
 }
@@ -940,6 +933,10 @@
 .moon-checkbox-item.left-handed .moon-checkbox-item-label-wrapper {
   margin-right: 0px;
   margin-left: 32px;
+}
+.moon-checkbox-item .moon-icon.small > .small-icon-tap-area {
+  left: 0;
+  right: 0;
 }
 .moon-neutral .moon-checkbox[checked]:after {
   color: #ffffff;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -901,13 +901,6 @@
   margin: 0;
   padding: 0;
 }
-.moon-checkbox .moon-icon > .small-icon-tap-area {
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  line-height: 32px;
-}
 .moon-checkbox[checked] .moon-icon {
   visibility: visible;
 }
@@ -940,6 +933,10 @@
 .moon-checkbox-item.left-handed .moon-checkbox-item-label-wrapper {
   margin-right: 0px;
   margin-left: 32px;
+}
+.moon-checkbox-item .moon-icon.small > .small-icon-tap-area {
+  left: 0;
+  right: 0;
 }
 .moon-neutral .moon-checkbox[checked]:after {
   color: #ffffff;


### PR DESCRIPTION
### Issue:

checkbox icon was overflowing the item dimensions and causing a scroller to appear
### Fix:

reduce the dimensions of the tap area for the checkbox icon, remove the width attribute of the checkbox and let it auto-size, adjust the position of the icon in checkbox item

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
