### PR TITLE
Fixes BHV-15323

### DIFF
--- a/source/Scroller.js
+++ b/source/Scroller.js
@@ -226,12 +226,6 @@
 			this.inherited(arguments);
 			this.spotlightPagingControlsChanged();
 			this.scrollWheelMovesFocusChanged();
-
-			// workaround because the bootstrapping code isn't attached to constructors that have
-			// finished setup before the hook is declared
-			if(enyo.Spotlight && this.spotlight === 'container') {
-				enyo.Spotlight.Container.initContainer(this);
-			}
 		},
 
 		/**


### PR DESCRIPTION
## Issue

Non-deferred constructors can not be initialized as spotlight containers because spotlight hooks enyo.Control.prototype.create but that hook isn't effective if the prototype chain has already been set up for a kind.
## Fix

Maintain an array of finalized constructors and extend those as well
## Notes

This PR removes the workaround for this issue applied to moon.Scroller from PR #1618

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
