### PR TITLE
BHV-15435: Allowed custom checkmarks on `CheckboxItem` to be set when in a `DataGridList`

### DIFF
--- a/source/CheckboxItem.js
+++ b/source/CheckboxItem.js
@@ -201,7 +201,7 @@
 		*/
 		rendered: function () {
 			this.inherited(arguments);
-			if (this.hasOwnProperty('src') || this.hasOwnProperty('icon')) {
+			if (this.get('src') != null || this.get('icon') != null) {
 				this.srcChanged();
 				this.iconChanged();
 			}


### PR DESCRIPTION
Empty strings are also now supported.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
