### PR TITLE
BHV-15468 Update playing progress bar which is actually used.

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -1712,8 +1712,11 @@
 		* @private
 		*/
 		updatePosition: function() {
-			this.updateFullscreenPosition();
-			this.updateInlinePosition();
+			if (this.inline) {
+				this.updateInlinePosition();
+			} else {
+				this.updateFullscreenPosition();
+			}
 		},
 		
 		/** 


### PR DESCRIPTION
FullScreenPosion bar and inlInePosition bar are mutual.
If one thing is shown, the other thing is not shown.
They does not shown at same time.
In this case, we do not need to update both at every single time.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
