### PR TITLE
Fixes BHV-15438

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -83,7 +83,7 @@
 			onRequestSetupBounds	: 'requestSetupBounds',
 			onSpotlightFocused      : 'enter',
 			onenter                 : 'enter',
-			onSpotlightBlur         : 'leave',
+			onSpotlightBlur         : 'spotlightBlur',
 			onleave                 : 'leave'
 		},
 
@@ -354,6 +354,20 @@
 			this.setupBounds();
 			this.showHideScrollColumns(true);
 			this.updateHoverOnPagingControls(true);
+		},
+
+		/**
+		* If the user 5-ways away from a control, call `leave` knowing that onSpotlightFocused
+		* will call `enter` if the next spotted control is within the scroller.
+		*
+		* If the user is in pointer mode, do nothing; they need to `leave` the scroller.
+		*
+		* @private
+		*/
+		spotlightBlur: function (sender, event) {
+			if(!enyo.Spotlight.getPointerMode()) {
+				this.leave(sender, event);
+			}
 		},
 
 		/**


### PR DESCRIPTION
## Issue

Current code was expecting a onSpotlightFocused within the scroller to always immediately follow onSpotlightBlur. This is not the case if the scroller is sparsely populated with spottable controls.
## Fix

Hide scrollbars only when spotlight blurring in 5-way and wait for onleave event in pointer mode.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
