### PR TITLE
ENYO-286: moon.Scroller halts when content is focused

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -81,10 +81,10 @@
 		handlers: {
 			onRequestScrollIntoView : 'requestScrollIntoView',
 			onRequestSetupBounds	: 'requestSetupBounds',
-			onSpotlightFocused      : 'enter',
 			onenter                 : 'enter',
-			onSpotlightBlur         : 'leave',
-			onleave                 : 'leave'
+			onleave                 : 'leave',
+			onSpotlightFocused      : 'manageSpotlightFocus',
+			onSpotlightBlur         : 'manageSpotlightFocus'
 		},
 
 		/**
@@ -351,7 +351,8 @@
 		*/
 		enter: function(sender, event) {
 			this.hovering = true;
-			this.setupBounds();
+			this.calcBoundaries();
+			this.enableDisableScrollColumns();
 			this.showHideScrollColumns(true);
 			this.updateHoverOnPagingControls(true);
 		},
@@ -364,6 +365,17 @@
 		leave: function(sender, event) {
 			this.hovering = false;
 			this.showHideScrollColumns(false);
+		},
+
+		/**
+		* Show / hide pagination controls in response to 5-way focus / blur events.
+		*
+		* @private
+		*/
+		manageSpotlightFocus: function(sender, event) {
+			if (!enyo.Spotlight.getPointerMode()) {
+				this.showHideScrollColumns(event.type == 'onSpotlightFocused');
+			}
 		},
 
 		/**


### PR DESCRIPTION
Due to a recent regression, moon.Scroller stops scrolling as soon
as an item inside it is focused.

This regression occurred because we started using
`onSpotlightFocused` and `onSpotlightBlur` events to detect when
focus entered / left the scroller; previously, we had used
`onSpotlightContainerEnter` and `onSpotlightContainerLeave`. In
making this change, we reused existing handlers for pointer-based
`enter` and `leave` events, but these handlers called
`setupBounds()`, which in turn invoked logic in `enyo.ScrollMath`
that caused scrolling to stop.

We now create a separate handler to deal with the Spotlight events,
which we ignore when in Pointer mode. As a bonus, we also replace
the call to `setupBounds()` in the `enter` handler and instead call
just the subroutines that we need to show / hide the pagination
controls.

These changes have been tested against all of the Moonstone
scroller samples.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
