### PR TITLE
BHV-15468: VideoPlayer Video is terminated due to lack of virtual memory

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -1490,8 +1490,7 @@
 		*/
 		updateInlinePosition: function() {
 			var percentComplete = this.duration ? Math.round(this._currentTime * 1000 / this.duration) / 10 : 0;
-			var prStatus = this.$.progressStatus;
-			if (prStatus.hasNode()) prStatus.applyStyle('width', percentComplete + '%');
+			this.$.progressStatus.applyStyle('width', percentComplete + '%');
 			this.$.currTime.setContent(this.formatTime(this._currentTime) + ' / ' + this.formatTime(this.duration));
 		},
 
@@ -1713,8 +1712,11 @@
 		* @private
 		*/
 		updatePosition: function() {
-			this.updateFullscreenPosition();
-			this.updateInlinePosition();
+			if (this.isFullscreen() || !this.getInline()) {
+				this.updateFullscreenPosition();
+			} else {
+				this.updateInlinePosition();
+			}
 		},
 		
 		/** 


### PR DESCRIPTION
### Issue:

VideoPlayer was calling applyStyle on the progressStatus control when it had no node, resulting in an endlessly concatenating style string, partly because the framework does not resolve styles, pre-attachment to DOM.
### Fix:

check if progressStatus has a node, before calling applyStyle

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
