### PR TITLE
BHV-14914, BHV-13377: Tooltip positioning issues

### DIFF
--- a/source/Icon.js
+++ b/source/Icon.js
@@ -185,6 +185,24 @@
 		},
 
 		/**
+		* @private
+		*/
+		handlers: {
+			/**
+			* This is a horrible hack to prevent event bubble caching from messing up
+			* moon.Tooltip positioning (BHV-13377). In short, we don't need to do anything
+			* with onenter ourselves, but we need it to pass through us on the way to
+			* moon.TooltipDecorator, which uses inSender to figure out who the tooltip
+			* activator should be.
+			*
+			* TODO: Something better.
+			*
+			* @private
+			*/
+			onenter: "doNothing"
+		},
+
+		/**
 		* @returns {String} The value of the [src]{@link moon.Icon#src} property.
 		* @public
 		*/

--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -195,7 +195,7 @@
 		*/
 		requestShow: function (inSender, inEvent) {
 			observer.set('active', this);
-			this.activator = inSender;
+			this.activator = inEvent.originator;
 			this.startJob('showJob', 'show', this.showDelay);
 			return true;
 		},
@@ -221,7 +221,6 @@
 		showingChanged: function () {
 			this.cancelShow();
 			this.inherited(arguments);
-			this.adjustPosition(true);
 		},
 
 		/**
@@ -245,9 +244,6 @@
 					pBounds = this.parent.getAbsoluteBounds(),
 					acBounds =null;
 
-				// Sometimes enyo.Spotlight.getCurrent() is null.
-				// In this case, we can rely on onRequestShowTooltip event sender.
-				this.activator = enyo.Spotlight.getCurrent() || this.activator;
 				acBounds = this.activator.getAbsoluteBounds();
 
 				//* Calculate the difference between decorator and activating

--- a/source/TooltipDecorator.js
+++ b/source/TooltipDecorator.js
@@ -74,10 +74,10 @@
 		* @private
 		*/
 		handlers: {
-			onenter: 'enter',
-			onleave: 'leave',
-			onSpotlightFocused: 'spotFocused',
-			onSpotlightBlur: 'spotBlur',
+			onenter: 'requestShowTooltip',
+			onleave: 'requestHideTooltip',
+			onSpotlightFocused: 'requestShowTooltip',
+			onSpotlightBlur: 'requestHideTooltip',
 			onRequestMuteTooltip: 'mute',
 			onRequestUnmuteTooltip: 'unmute'
 		},
@@ -128,34 +128,6 @@
 		/**
 		* @private
 		*/
-		enter: function (inSender, inEvent) {
-			this.requestShowTooltip(inSender, inEvent);
-		},
-
-		/**
-		* @private
-		*/
-		leave: function () {
-			this.requestHideTooltip();
-		},
-
-		/**
-		* @private
-		*/
-		spotFocused: function () {
-			this.requestShowTooltip();
-		},
-
-		/**
-		* @private
-		*/
-		spotBlur: function () {
-			this.requestHideTooltip();
-		},
-
-		/**
-		* @private
-		*/
 		tap: function () {
 			this.requestHideTooltip();
 		},
@@ -165,7 +137,7 @@
 		*/
 		requestShowTooltip: function (inSender, inEvent) {
 			if (this.autoShow && !enyo.Spotlight.isFrozen()) {
-				this.waterfallDown("onRequestShowTooltip", inEvent, inSender);
+				this.waterfallDown("onRequestShowTooltip", {originator: inSender}, this);
 			}
 		},
 


### PR DESCRIPTION
We have had some tooltip positioning issues, mostly in edge
cases (e.g., tooltips for disabled controls, controls with
invisible tap areas, controls that are dynamically shown or
hidden).

The implementation is a bit tricky; tooltips are usually shown in
response to onSpotlightFocused events, but can also be shwon in
response to onenter events to cover the case where the control
associated with the tooltip is not spottable.

Previously, Tooltip was attempting to determine its activator
whenever a request to show came in, but systematically discarding
that activator in favor of the currently spotted control whenever
possible. This opened the door to issues when switching between
Spotlight modes or when controls were dynaimcally shown / hidden.

We now consistently use the tooltip activator to position tooltips,
no longer assuming that the currently spotted control is our
activator. Doing so required us to rework the way we determine the
activator to make it more reliable, regardless of whether the
tooltip request originated with an onSpotlightFocused event or an
onenter event. TooltipDecorator now uses the sender of the bubbled-
up event to determine which of its children is the activator; we
can't use the originator in the case of onenter events, because
such events ofen emanate from somewhere within the activator's DOM
structure. Then, rather than waterfalling the same event that
bubbled up, we waterfall a synthesized event, with our reliably-
determined activator as the event originator.

This worked fine in all known cases, except that tooltips for
Icon and IconButton were positioned relative to the icon's tap
target, not its visual representation. It turns out that this was
an issue with cached bubble targets, which made the sender of the
onenter event unreliable. We are currently using a hack to get
around this issue: we register a non-existent event handler for
onenter on moon.Icon, which is enough to trick the bubble
caching mechanism.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)

To identify
