### PR TITLE
BHV-15606: VideoPlayer slider not updating on switch from full to inline when paused

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -255,8 +255,11 @@
 
 			/**
 			* When `false`, the player starts in fullscreen mode; when `true`, it starts in inline 
-			* mode. Meant to be initialized on startup, use moon.VideoPlayer#onRequestToggleFullscreen
-			* to dynamically toggle between fullscreen and inline.
+			* mode. As this is meant to be initialized on startup, fire the 
+			* [onRequestToggleFullscreen]{@link enyo.VideoPlayer#event:onRequestToggleFullscreen}
+			* event from a child control or call 
+			* [toggleFullScreen]{@link enyo.VideoPlayer#toggleFullScreen} to dynamically toggle
+			* between fullscreen and inline mode.
 			*
 			* @type {Boolean}
 			* @default false


### PR DESCRIPTION
### Issue:

we changed videoplayer to not update inline controls when full-screen, and vice-versa. This resulted in the slider not updating, when paused.
### Fix:

call updatePosition() on fullscreenChanged()

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
