### PR TITLE
ENYO-304: Suppress tooltip when Control moves beneath pointer

### DIFF
--- a/source/TooltipDecorator.js
+++ b/source/TooltipDecorator.js
@@ -137,7 +137,9 @@
 		*/
 		requestShowTooltip: function (inSender, inEvent) {
 			if (this.autoShow && !enyo.Spotlight.isFrozen()) {
-				this.waterfallDown("onRequestShowTooltip", {originator: inSender}, this);
+				if (inEvent.type == 'onSpotlightFocused' || enyo.Spotlight.getPointerMode()) {
+					this.waterfallDown('onRequestShowTooltip', {originator: inSender}, this);
+				}
 			}
 		},
 


### PR DESCRIPTION
In the edge case where a) Spotlight has just been forced from
pointer mode to 5-way mode; and b) a Tooltip-enabled Control
suddenly appears / moves to a location that places it beneath the
pointer, a Tooltip currently appears over the Control.

This is because (to support Tooltips on non-Spottable elements)
Tooltips can be triggered by 'onenter' events, and 'onenter' fires
whenever the pointer enters the area represented by a given
Control – even if it's the Control, not the pointer, that has
moved.

We address this edge case with some simple guard code – if we're
not in Pointer mode, don't allow 'onenter' to trigger a Tooltip.

Note that this change doesn't address a related inefficiency,
which is that both the 'onenter' trigger and the
'onSpotlightFocused' trigger fire when moving the pointer over a
Spottable Control. This is fairly benign, as it just results in a
small bit of extra JavaScript execution. Addressing it would
require more fundamental changes to the way we trigger Tooltips,
which doesn't seem worth the effort or risk at this point in time.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
