### PR TITLE
moved sampler from scrollTo to focusOn to correct spotlight behavior

### DIFF
--- a/samples/DataListSample.js
+++ b/samples/DataListSample.js
@@ -37,7 +37,7 @@ enyo.kind({
 			, add = []
 			, i = records.length
 			, len = (i + (!isNaN(amount)? amount: 0));
-		
+
 		for (; i<len; ++i) {
 			add.push({
 				on: false,
@@ -46,7 +46,7 @@ enyo.kind({
 				label: "Label " + i
 			});
 		}
-		
+
 		return add;
 	},
 	scrollToIndex: function (sender, event) {
@@ -54,7 +54,7 @@ enyo.kind({
 		if (this.isScrolled || newIndex !== this.currentIndex) {
 			this.currentIndex = newIndex;
 			this.$.drawers.closeDrawers();
-			this.$.repeater.scrollToIndex(newIndex);
+			this.$.repeater.focusOnIndex(newIndex);
 			this.isScrolled = false;
 		}
 	},


### PR DESCRIPTION
Issue: Moon DataList Sample - When updating `scrollToIndex`, and then attempting to use spotlight, would cause the list to scroll to a different nearest neighbor. 

Fix: Switched the Sample to use `focusOnIndex` , which also calls `scrollToIndex`, and ensures that the index is spotted.

Also cleaned up some whitespace.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
