### PR TITLE
BHV-15753: Refresh scroll bounds upon entering scroller.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -353,6 +353,7 @@
 			this.hovering = true;
 			this.calcBoundaries();
 			this.enableDisableScrollColumns();
+			this._getScrollBounds();
 			this.showHideScrollColumns(true);
 			this.updateHoverOnPagingControls(true);
 		},


### PR DESCRIPTION
### Issue

We had previously made an optimization to the `enter` handler to remove unnecessary calls, and as a result the scroll bounds were not being refreshed as necessary, resulting in the paging controls not always having the correct enabled/disabled state. This is partly related to `moon.DataList` not rendering its contents immediately, as the initial bounds are incorrect.
### Fix

Technically, the previous call to `setThumbSizeRatio` method was calling `_getScrollBounds` (which calculates scroll bounds and also updates the disabled state of the paging controls, altogether), so we call that directly here.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
