### PR TITLE
Fixes BHV-11666

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -1119,7 +1119,10 @@
 				this.$.showHideHandle.addClass('right');
 				this.applyShowAnimation();
 			}
-			enyo.Signals.send('onPanelsShown', {initialization: init});
+			enyo.Signals.send('onPanelsShown', {
+				initialization: init,
+				pattern: this.pattern
+			});
 		},
 
 		/**

--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -1021,6 +1021,10 @@
 		* @private
 		*/
 		panelsShown: function(sender, e) {
+			if(e.pattern == 'activity') {
+				this.hide();
+			}
+
 			this._panelsShowing = true;
 			this._controlsShowing = false;
 			this._infoShowing = false;
@@ -1041,6 +1045,7 @@
 		panelsHidden: function(sender, e) {
 			var current;
 
+			this.show();
 			this._panelsShowing = false;
 			this.updateSpotability();
 


### PR DESCRIPTION
## Issue

Video appears to be causing full screen repaints even when in the background causing some lovely jank
## Fix

hide() the video player when the panels are shown and show it again when they're hidden

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
