### PR TITLE
ENYO-312: Guard against non-existent branding image control.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -941,10 +941,12 @@
 
 			this.inherited(arguments);
 
-			if (this.pattern === 'activity' && this.getPanelInfo(0, this.index).breadcrumb) {
-				this.$.branding.show();
-			} else {
-				this.$.branding.hide();
+			if (this.$.branding) {
+				if (this.pattern == 'activity' && this.getPanelInfo(0, this.index).breadcrumb) {
+					this.$.branding.show();
+				} else {
+					this.$.branding.hide();
+				}
 			}
 		},
 
@@ -1227,7 +1229,9 @@
 		* @private
 		*/
 		brandingSrcChanged: function () {
-			this.$.branding.set('src', this.brandingSrc);
+			if (this.$.branding) {
+				this.$.branding.set('src', this.brandingSrc);
+			}
 		}
 	});
 


### PR DESCRIPTION
### Issue

`moon.Panels` patterns that are not `activity` and not `alwaysviewing` were not creating the `branding` control, which was being accessed in `indexChanged` and `brandingSrcChanged`.
### Fix

We add some guard code when accessing the `branding` control.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
