### PR TITLE
BHV-14242 Remove special override for Japan font

### DIFF
--- a/css/Header.less
+++ b/css/Header.less
@@ -113,15 +113,6 @@
 	border-bottom: @moon-header-border-bottom-width solid @moon-neutral-border-color;
 }
 
-// enyo-locale-non-latin
-/* Special override for Japanese font (LG Display_JP) which, as of 07-Feb-2014
-   has a taller baseline. This corrects both Header and InputHeader. 2014-02-24
-   Please remove the line-height rule below if this font file is changed. */
-.enyo-locale-non-latin.enyo-locale-ja .moon-header-title,
-.enyo-locale-non-latin.enyo-locale-ja .moon-input-header .moon-input-header-input-decorator > .moon-input {
-	line-height: 1.25em;
-}
-
 // enyo-locale-right-to-left
 .enyo-locale-right-to-left .moon-small-header {
 	.moon-header-client {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1593,13 +1593,6 @@
   border-top: 2px solid #ffffff;
   border-bottom: 6px solid #ffffff;
 }
-/* Special override for Japanese font (LG Display_JP) which, as of 07-Feb-2014
-   has a taller baseline. This corrects both Header and InputHeader. 2014-02-24
-   Please remove the line-height rule below if this font file is changed. */
-.enyo-locale-non-latin.enyo-locale-ja .moon-header-title,
-.enyo-locale-non-latin.enyo-locale-ja .moon-input-header .moon-input-header-input-decorator > .moon-input {
-  line-height: 1.25em;
-}
 .enyo-locale-right-to-left .moon-small-header .moon-header-client {
   float: left;
   margin: 38px 40px 0 0;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1593,13 +1593,6 @@
   border-top: 2px solid #ffffff;
   border-bottom: 6px solid #ffffff;
 }
-/* Special override for Japanese font (LG Display_JP) which, as of 07-Feb-2014
-   has a taller baseline. This corrects both Header and InputHeader. 2014-02-24
-   Please remove the line-height rule below if this font file is changed. */
-.enyo-locale-non-latin.enyo-locale-ja .moon-header-title,
-.enyo-locale-non-latin.enyo-locale-ja .moon-input-header .moon-input-header-input-decorator > .moon-input {
-  line-height: 1.25em;
-}
 .enyo-locale-right-to-left .moon-small-header .moon-header-client {
   float: left;
   margin: 38px 40px 0 0;


### PR DESCRIPTION
It was special override for Japan.
As commented as source code, font was updated so we do not need to keep this.
This override made some side effect with updated font.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
