### PR TITLE
BHV-15607: Gave languages with tall characters more breathing room in input fields

### DIFF
--- a/css/Input.less
+++ b/css/Input.less
@@ -17,27 +17,47 @@
 .enyo-locale-non-latin .moon-input {
 	.enyo-locale-non-latin .moon-body-text;
 }
-//test thai character with higher and lower accents: ไััุุ
-.enyo-locale-non-latin.enyo-locale-th .moon-input {
-	font-size: 24px;
-	line-height: 52px;
-}
 .moon-neutral .moon-input {
    color: @moon-input-font-color;
 }
-.moon-input-decorator.moon-focused .moon-input {
-	cursor: text;
+.moon-input-decorator {
+	.moon-focused .moon-input {
+		cursor: text;
+	}
+	.moon-disabled .moon-input {
+		cursor: default;
+	}
+	> input::-webkit-input-placeholder {
+		color: @moon-input-placeholder-color;
+	}
+	> input:-moz-placeholder {
+		color: @moon-input-placeholder-color;
+	}
+	// IE10
+	> input:-ms-input-placeholder {
+		color: @moon-input-placeholder-color;
+	}
 }
-.moon-input-decorator.moon-disabled .moon-input {
-	cursor: default;
-}
-.moon-input-decorator > input::-webkit-input-placeholder {
-	color: @moon-input-placeholder-color;
-}
-.moon-input-decorator > input:-moz-placeholder {
-	color: @moon-input-placeholder-color;
-}
-/* IE10 */
-.moon-input-decorator > input:-ms-input-placeholder {
-	color: @moon-input-placeholder-color;
+
+.enyo-locale-non-latin {
+	// Languages with combining accent characters
+	&.enyo-locale-th, // Thai - Test Chars: ฟิ้ไััุุ
+	&.enyo-locale-ar, // Arabic
+	&.enyo-locale-fa, // Farsi
+	&.enyo-locale-ur, // Urdu
+	&.enyo-locale-ku, // Kurdish
+	&.enyo-locale-he, // Hebrew
+	&.enyo-locale-hi, // Hindi
+	&.enyo-locale-ta, // Tamil
+	&.enyo-locale-te, // Telugu
+	&.enyo-locale-kn, // Kannada
+	&.enyo-locale-ml, // Malayalam
+	&.enyo-locale-mr, // Marathi
+	&.enyo-locale-bn, // Bengali
+	&.enyo-locale-pa {// Panjabi
+		.moon-input-decorator .moon-input {
+			font-size: 24px;
+			line-height: 48px
+		}
+	}
 }

--- a/css/InputDecorator.less
+++ b/css/InputDecorator.less
@@ -1,48 +1,65 @@
 /* InputDecorator.css */
-.moon-input-decorator:not(.moon-input-header-input-decorator) {
+.moon-input-decorator:not(.moon-input-header-input-decorator),
+.moon-textarea-decorator {
 	.moon-divider-text;
 	margin: 5px;
-	padding: 9px 30px;
-	border-radius: 34px;
 	border: @moon-input-border-width solid transparent;
 	background-color: @moon-input-decorator-bg-color;
-	box-sizing:border-box;
-}
+	box-sizing: border-box;
 
-
-.enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator){
-  padding:5px 30px 9px;
+	&.spotlight {
+		border-color: @moon-spotlight-border-color;
+	}
+	&.moon-focused {
+		border-color: @moon-active-border-color;
+	}
 }
-.enyo-locale-non-latin.enyo-locale-th .moon-input-decorator:not(.moon-input-header-input-decorator) {
-	padding: 1px 30px;
-	height: 60px;
+.moon-input-decorator,
+.moon-textarea-decorator {
+	&.moon-disabled {
+		opacity: @moon-disabled-opacity;
+	}
+}
+.moon-input-decorator:not(.moon-input-header-input-decorator) {
+	padding: 9px 30px;
+	border-radius: 34px;
 }
 .moon-textarea-decorator {
-  .moon-divider-text;
-  margin: 5px;
-  padding: 9px 14px;
-  border-radius: 10px;
-  border: @moon-input-border-width solid transparent;
-  background-color: @moon-input-decorator-bg-color;
-  box-sizing:border-box;
+	padding: 9px 14px;
+	border-radius: 10px;
 }
 
-
-.enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator), .enyo-locale-non-latin .moon-textarea-decorator {
-	.enyo-locale-non-latin .moon-divider-text;
+.moon-expandable-input .moon-input-decorator:not(.moon-input-header-input-decorator) {
+	margin: 5px 0;
 }
 
+.enyo-locale-non-latin {
+	.moon-input-decorator:not(.moon-input-header-input-decorator),
+	.moon-textarea-decorator {
+		.enyo-locale-non-latin .moon-divider-text;
+	}
+	.moon-input-decorator:not(.moon-input-header-input-decorator) {
+		padding-top: 5px;
+	}
 
-.moon-input-decorator:not(.moon-input-header-input-decorator).spotlight, .moon-textarea-decorator.spotlight {
-	border: @moon-input-border-width solid @moon-spotlight-border-color;
-}
-.moon-input-decorator.moon-disabled, .moon-textarea-decorator.moon-disabled {
-	opacity: @moon-disabled-opacity;
-}
-.moon-input-decorator:not(.moon-input-header-input-decorator).moon-focused, .moon-textarea-decorator.moon-focused {
-	border: @moon-input-border-width solid @moon-active-border-color;
-}
-
-.moon-expandable-input .moon-input-decorator:not(.moon-input-header-input-decorator){
-  margin:5px 0;
+	// Languages with combining accent characters
+	&.enyo-locale-th, // Thai
+	&.enyo-locale-ar, // Arabic
+	&.enyo-locale-fa, // Farsi
+	&.enyo-locale-ur, // Urdu
+	&.enyo-locale-ku, // Kurdish
+	&.enyo-locale-he, // Hebrew
+	&.enyo-locale-hi, // Hindi
+	&.enyo-locale-ta, // Tamil
+	&.enyo-locale-te, // Telugu
+	&.enyo-locale-kn, // Kannada
+	&.enyo-locale-ml, // Malayalam
+	&.enyo-locale-mr, // Marathi
+	&.enyo-locale-bn, // Bengali
+	&.enyo-locale-pa {// Panjabi
+		.moon-input-decorator:not(.moon-input-header-input-decorator) {
+			padding-top: 1px;
+			padding-bottom: 1px;
+		}
+	}
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1853,17 +1853,13 @@
   font-size: 26px;
   line-height: 32px;
 }
-.enyo-locale-non-latin.enyo-locale-th .moon-input {
-  font-size: 24px;
-  line-height: 52px;
-}
 .moon-neutral .moon-input {
   color: #4b4b4b;
 }
-.moon-input-decorator.moon-focused .moon-input {
+.moon-input-decorator .moon-focused .moon-input {
   cursor: text;
 }
-.moon-input-decorator.moon-disabled .moon-input {
+.moon-input-decorator .moon-disabled .moon-input {
   cursor: default;
 }
 .moon-input-decorator > input::-webkit-input-placeholder {
@@ -1872,39 +1868,59 @@
 .moon-input-decorator > input:-moz-placeholder {
   color: #868686;
 }
-/* IE10 */
 .moon-input-decorator > input:-ms-input-placeholder {
   color: #868686;
 }
+.enyo-locale-non-latin.enyo-locale-th .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ar .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-fa .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ur .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ku .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-he .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-hi .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ta .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-te .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-kn .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ml .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-mr .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-bn .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-pa .moon-input-decorator .moon-input {
+  font-size: 24px;
+  line-height: 48px;
+}
 /* InputDecorator.css */
-.moon-input-decorator:not(.moon-input-header-input-decorator) {
-  font-family: "MuseoSans 700 Italic";
-  font-size: 22px;
-  color: #a6a6a6;
-  margin: 5px;
-  padding: 9px 30px;
-  border-radius: 34px;
-  border: 5px solid transparent;
-  background-color: #ffffff;
-  box-sizing: border-box;
-}
-.enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  padding: 5px 30px 9px;
-}
-.enyo-locale-non-latin.enyo-locale-th .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  padding: 1px 30px;
-  height: 60px;
-}
+.moon-input-decorator:not(.moon-input-header-input-decorator),
 .moon-textarea-decorator {
   font-family: "MuseoSans 700 Italic";
   font-size: 22px;
   color: #a6a6a6;
   margin: 5px;
-  padding: 9px 14px;
-  border-radius: 10px;
   border: 5px solid transparent;
   background-color: #ffffff;
   box-sizing: border-box;
+}
+.moon-input-decorator:not(.moon-input-header-input-decorator).spotlight,
+.moon-textarea-decorator.spotlight {
+  border-color: #cf0652;
+}
+.moon-input-decorator:not(.moon-input-header-input-decorator).moon-focused,
+.moon-textarea-decorator.moon-focused {
+  border-color: #a6a6a6;
+}
+.moon-input-decorator.moon-disabled,
+.moon-textarea-decorator.moon-disabled {
+  opacity: 0.6;
+}
+.moon-input-decorator:not(.moon-input-header-input-decorator) {
+  padding: 9px 30px;
+  border-radius: 34px;
+}
+.moon-textarea-decorator {
+  padding: 9px 14px;
+  border-radius: 10px;
+}
+.moon-expandable-input .moon-input-decorator:not(.moon-input-header-input-decorator) {
+  margin: 5px 0;
 }
 .enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator),
 .enyo-locale-non-latin .moon-textarea-decorator {
@@ -1912,20 +1928,25 @@
   font-size: 28px;
   font-style: normal;
 }
-.moon-input-decorator:not(.moon-input-header-input-decorator).spotlight,
-.moon-textarea-decorator.spotlight {
-  border: 5px solid #cf0652;
+.enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator) {
+  padding-top: 5px;
 }
-.moon-input-decorator.moon-disabled,
-.moon-textarea-decorator.moon-disabled {
-  opacity: 0.6;
-}
-.moon-input-decorator:not(.moon-input-header-input-decorator).moon-focused,
-.moon-textarea-decorator.moon-focused {
-  border: 5px solid #a6a6a6;
-}
-.moon-expandable-input .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  margin: 5px 0;
+.enyo-locale-non-latin.enyo-locale-th .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ar .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-fa .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ur .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ku .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-he .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-hi .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ta .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-te .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-kn .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ml .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-mr .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-bn .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-pa .moon-input-decorator:not(.moon-input-header-input-decorator) {
+  padding-top: 1px;
+  padding-bottom: 1px;
 }
 /* ProgressBar.css */
 .moon-progress-bar {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1852,17 +1852,13 @@
   font-size: 26px;
   line-height: 32px;
 }
-.enyo-locale-non-latin.enyo-locale-th .moon-input {
-  font-size: 24px;
-  line-height: 52px;
-}
 .moon-neutral .moon-input {
   color: #4b4b4b;
 }
-.moon-input-decorator.moon-focused .moon-input {
+.moon-input-decorator .moon-focused .moon-input {
   cursor: text;
 }
-.moon-input-decorator.moon-disabled .moon-input {
+.moon-input-decorator .moon-disabled .moon-input {
   cursor: default;
 }
 .moon-input-decorator > input::-webkit-input-placeholder {
@@ -1871,39 +1867,59 @@
 .moon-input-decorator > input:-moz-placeholder {
   color: #868686;
 }
-/* IE10 */
 .moon-input-decorator > input:-ms-input-placeholder {
   color: #868686;
 }
+.enyo-locale-non-latin.enyo-locale-th .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ar .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-fa .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ur .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ku .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-he .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-hi .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ta .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-te .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-kn .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-ml .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-mr .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-bn .moon-input-decorator .moon-input,
+.enyo-locale-non-latin.enyo-locale-pa .moon-input-decorator .moon-input {
+  font-size: 24px;
+  line-height: 48px;
+}
 /* InputDecorator.css */
-.moon-input-decorator:not(.moon-input-header-input-decorator) {
-  font-family: "MuseoSans 700 Italic";
-  font-size: 22px;
-  color: #4b4b4b;
-  margin: 5px;
-  padding: 9px 30px;
-  border-radius: 34px;
-  border: 5px solid transparent;
-  background-color: #ffffff;
-  box-sizing: border-box;
-}
-.enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  padding: 5px 30px 9px;
-}
-.enyo-locale-non-latin.enyo-locale-th .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  padding: 1px 30px;
-  height: 60px;
-}
+.moon-input-decorator:not(.moon-input-header-input-decorator),
 .moon-textarea-decorator {
   font-family: "MuseoSans 700 Italic";
   font-size: 22px;
   color: #4b4b4b;
   margin: 5px;
-  padding: 9px 14px;
-  border-radius: 10px;
   border: 5px solid transparent;
   background-color: #ffffff;
   box-sizing: border-box;
+}
+.moon-input-decorator:not(.moon-input-header-input-decorator).spotlight,
+.moon-textarea-decorator.spotlight {
+  border-color: #cf0652;
+}
+.moon-input-decorator:not(.moon-input-header-input-decorator).moon-focused,
+.moon-textarea-decorator.moon-focused {
+  border-color: #a6a6a6;
+}
+.moon-input-decorator.moon-disabled,
+.moon-textarea-decorator.moon-disabled {
+  opacity: 0.35;
+}
+.moon-input-decorator:not(.moon-input-header-input-decorator) {
+  padding: 9px 30px;
+  border-radius: 34px;
+}
+.moon-textarea-decorator {
+  padding: 9px 14px;
+  border-radius: 10px;
+}
+.moon-expandable-input .moon-input-decorator:not(.moon-input-header-input-decorator) {
+  margin: 5px 0;
 }
 .enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator),
 .enyo-locale-non-latin .moon-textarea-decorator {
@@ -1911,20 +1927,25 @@
   font-size: 28px;
   font-style: normal;
 }
-.moon-input-decorator:not(.moon-input-header-input-decorator).spotlight,
-.moon-textarea-decorator.spotlight {
-  border: 5px solid #cf0652;
+.enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator) {
+  padding-top: 5px;
 }
-.moon-input-decorator.moon-disabled,
-.moon-textarea-decorator.moon-disabled {
-  opacity: 0.35;
-}
-.moon-input-decorator:not(.moon-input-header-input-decorator).moon-focused,
-.moon-textarea-decorator.moon-focused {
-  border: 5px solid #a6a6a6;
-}
-.moon-expandable-input .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  margin: 5px 0;
+.enyo-locale-non-latin.enyo-locale-th .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ar .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-fa .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ur .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ku .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-he .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-hi .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ta .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-te .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-kn .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-ml .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-mr .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-bn .moon-input-decorator:not(.moon-input-header-input-decorator),
+.enyo-locale-non-latin.enyo-locale-pa .moon-input-decorator:not(.moon-input-header-input-decorator) {
+  padding-top: 1px;
+  padding-bottom: 1px;
 }
 /* ProgressBar.css */
 .moon-progress-bar {


### PR DESCRIPTION
This change also includes a reorganized set of CSS for `Input`s and `InputDecorator`s, to be more concise.
In addition to making this change for Thai and Farsi, like the ticket title suggests, it includes all languages with tall characters, as suggested by @ehoogerbeets.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
