### PR TITLE
Fixes BHV-15753

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -506,6 +506,16 @@
 		/**
 		* @private
 		*/
+		scrollMathStop: enyo.inherit(function (sup) {
+			return function () {
+				sup.apply(this, arguments);
+				this.updatePagingControlState();
+			};
+		}),
+
+		/**
+		* @private
+		*/
 		calcBoundaries: function() {
 			var s = this.$.scrollMath || this,
 				b = this._getScrollBounds()


### PR DESCRIPTION
## Issue

There's a circular dependency between `calcBoundaries` and `_getScrollBounds` where the former calculates the `ScrollMath.bottomBoundary` using the `maxTop` retrieved from the latter but the latter needs the `bottomBoundary` to correctly enable the paging controls but it hasn't been calculated yet.
## Fix

Refactor the paging control logic into its own method and have it called in calcBoundaries since it's establishing the data necessary to do the work.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
