### PR TITLE
Fixes BHV-15492

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -166,13 +166,6 @@
 		},
 
 		/**
-		* @private
-		*/
-		setLastFocusedChild: function(control) {
-			enyo.Spotlight.Container.setLastFocusedChild(this.$.viewport, control);
-		},
-
-		/**
 		* Gets the left scroll position within the scroller.
 		*
 		* @returns {Number} The left scroll position.

--- a/source/Scroller.js
+++ b/source/Scroller.js
@@ -190,7 +190,7 @@
 		*/
 		scrollToControl: function (control, scrollFullPage, animate, setLastFocusedChild) {
 			if (setLastFocusedChild) {
-				this.$.strategy.setLastFocusedChild(control);
+				this.setLastFocusedChild(control);
 			}
 			this.$.strategy.animateToControl(control, scrollFullPage, animate);
 		},
@@ -232,6 +232,13 @@
 			if(enyo.Spotlight && this.spotlight === 'container') {
 				enyo.Spotlight.Container.initContainer(this);
 			}
+		},
+
+		/**
+		* @private
+		*/
+		setLastFocusedChild: function(control) {
+			enyo.Spotlight.Container.setLastFocusedChild(this, control);
 		},
 
 		/**


### PR DESCRIPTION
## Issue

Call to setLastFocusedChild in Scroller.scrollToControl assumes that the this.$.viewport is the spotlight container and as such is telling it to remember which control was scrolled to.
## Fix

Configuring last focused child on scroller because it is now the spotlight container.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
