### PR TITLE
[BHV-15343]Contextual popup doesn't work properly when hide() from appli...

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -194,6 +194,20 @@
 			this.contentChanged();
 			this.inherited(arguments);
 		},
+		/**
+		FixMe: overriding the control's default hide method to support the existing sequential tapping
+		and the dependent decorator code inorder to handle some special cases.
+		*/
+		hide: function(inSender, e) {
+			
+			 if (this.tapCaptured) {
+				this.tapCaptured = false;			
+			} else {
+				this.popupActivated = false;
+			}
+			this.inherited(arguments);
+
+		},
 
 		/**
 		* Performs control-specific tasks before/after showing {@link moon.ContextualPopup}.
@@ -446,6 +460,7 @@
 			// If same activator tapped sequentially, we notice that this popup is already activeted.
 			if (inEvent.dispatchTarget.isDescendantOf(this.activator)) {
 				this.popupActivated = true;
+				this.tapCaptured = true;
 			} else {
 				this.popupActivated = false;
 			}


### PR DESCRIPTION
...cation side

Issue: When contextual popup is closed from application side, it doesn't
update some properties properly which causes this behavior
Fix: control's hide() method is overridden in  contextual popup to
update the properties properly.
DCO-1.1-Signed-Off-By: Rajyavardhan P rajyavardhan.p@lge.com
