### PR TITLE
BHV-15858: Explicitly show slider knob when slider is re-enabled.

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -923,6 +923,14 @@
 				!this._loaded || 
 				(this.disablePlaybackControlsOnUnload && (this._errorCode || (!this.getSrc() && !this.getSources()) ));
 			this.$.slider.setDisabled(disabled);
+			// We need an explicit call to showKnobStatus as moon.Slider's disabledChanged method
+			// only handles hiding of the knob status. This behavior should not be changed in
+			// disabledChanged, as the normal behavior of moon.Slider is to display the knob status
+			// upon dragging, whereas moon.VideoPlayer is forcing the knob status to be shown when
+			// the slider is visible.
+			if (!disabled) {
+				this.$.slider.showKnobStatus();
+			}
 		},
 
 		/**


### PR DESCRIPTION
### Issue

We were relying on `moon.Slider`'s `disabledChanged` method to handle showing and hiding of the status knob, from `moon.VideoPlayer`. This method only handles hiding of the status knob, necessarily, as the default behavior is to only show the status knob when dragging.
### Fix

`moon.VideoPlayer` forces the status knob to appear even when not dragging, so we add an explicit call to show the status knob when the slider is re-enabled.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
