### PR TITLE
changed method, to get it off the showingChanged chain

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -360,7 +360,6 @@
 					// animation is finished, fire it now, so interactive control is returned to the
 					// applicaiton while our popup is animating to the closed position.
 					this.showHideScrim(this.showing);
-					var args = arguments;
 				} else {
 					// Run inherited immediately
 					this.inherited(arguments);


### PR DESCRIPTION
## Issue

We wanted standardized events for the Popup. We wanted to throw a Before or Pre state event, as well as clean up the popup to ensure that Show/Hide are called when truly completed. 
## Fix

Moved moonstone off of the showingChanged chain. Modified enyo.Popup.showingChanged to pass calls to showHideMethod. showingChanged now calls showHideEvent which was abstracted out of the original showingChanged.

This goes with another PR in the Enyo branch(https://github.com/enyojs/enyo/pull/880). The enyo branch must go through first to preserve backwards compatibility, until this PR goes through, events will not be accurate for popup.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
