### PR TITLE
BHV-15860: Invalidate marquee metrics when selecting item.

### DIFF
--- a/source/SelectableItem.js
+++ b/source/SelectableItem.js
@@ -130,7 +130,6 @@
 				return true;
 			}
 			if (this.handleTapEvent) {
-				this.resetMarquee();
 				this.setActive(!this.getActive());
 				this.bubble('onchange');
 			}
@@ -174,6 +173,7 @@
 		activeChanged: function() {
 			this.active = enyo.isTrue(this.active);
 			this.setSelected(this.active);
+			this.resetMarquee();
 			this.bubble('onActivate');
 		}
 	});


### PR DESCRIPTION
### Issue

When a `moon.SelectableItem` is selected and there is enough text to cause it to marquee, the text no longer marquees the proper distance. This is due to the presence of the selection icon, which changes the available space for the marqueeing text.
### Fix

Upon a change in selection state, we `reflow` the `moon.SelectableItem` in order to invalidate the marquee metrics. Additionally, due to some recent changes in the implementation of the selection icon, we can now remove the unnecessary `client` child component and reduce the number of DOM nodes. Lastly, the call to `resetMarquee` was moved from `updateActiveValue` to the `tap` handler as there is a quirk with `moon.Item` that causes the `rendered` method to be fired when the control is upgraded to a full Marquee control; without this change, the call to `resetMarquee` was being made directly after `Spotlight` focus on the control, which caused the marquee to momentarily start, reset, and then start again.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
