### PR TITLE
BHV-16056: Suppress tap event when moon.Item is disabled.

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -147,9 +147,6 @@
 		* @private
 		*/
 		expandContract: function () {
-			if (this.disabled) {
-				return true;
-			}
 			if (this.getOpen()) {
 				this.closeDrawerAndHighlightHeader();
 			} else {

--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -226,10 +226,6 @@
 		* @private
 		*/
 		expandContract: function (inSender, inEvent) {
-			if (this.disabled) {
-				return true;
-			}
-
 			this.toggleActive();
 
 			if (this.getActive() && !enyo.Spotlight.getPointerMode()) {

--- a/source/Item.js
+++ b/source/Item.js
@@ -82,6 +82,13 @@
 			if (inEvent.originator === this) {
 				this.bubble('onRequestScrollIntoView');
 			}
+		},
+
+		/**
+		* @private
+		*/
+		tap: function () {
+			return this.disabled;
 		}
 	});
 


### PR DESCRIPTION
### Issue

Disabled `moon.Item` controls still generate tap events.
### Fix

We suppress tap events when disabled. Additionally, we had been explicitly suppressing tap events for the `headerWrapper` in `moon.ExpandableListItem` and its derivatives, and because this control is a `moon.Item` kind, we remove this explicit suppression.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
