### PR TITLE
BHV-14030: Refactor/Optimize ExpandableText.less. Enyo-DCO-1.1-Signed-of...

### DIFF
--- a/css/ExpandableText.less
+++ b/css/ExpandableText.less
@@ -10,21 +10,21 @@
 		-webkit-box-orient: vertical;
 	}
 	.moon-expandable-text-button {
-		.moon-body-text;
 		float: right;
 		display: inline-block;
-		padding-right: @moon-expandable-text-button-padding;
+		padding: @moon-spotlight-outset @moon-expandable-text-button-padding @moon-spotlight-outset @moon-spotlight-outset;
 		position: relative;
 
 		&:after {
 			position: absolute;
 			top: @moon-spotlight-outset;
-			right: @moon-spotlight-outset + 1px;
+			right: @moon-spotlight-outset + 1;
 			font-family: @moon-icon-font-family;
 			content: @moon-icon-arrowlargeup;
 			font-size: @moon-expandable-caret-icon-font-size;
 		}
 		&.spotlight {
+			background-color: @moon-accent;
 			color: @moon-white;
 		}
 		&.collapsed:after {
@@ -37,20 +37,17 @@
 }
 
 .enyo-locale-non-latin .moon-expandable-text .moon-expandable-text-button {
-	.enyo-locale-non-latin .moon-body-text;
-
 	&:after {
-		top: @moon-spotlight-outset + 1px;
+		top: @moon-spotlight-outset + 1;
 	}
 }
 
 .enyo-locale-right-to-left .moon-expandable-text .moon-expandable-text-button {
 	float: left;
-	padding-left: @moon-expandable-text-button-padding;
-	padding-right: @moon-spotlight-outset;
+	padding: @moon-spotlight-outset @moon-spotlight-outset @moon-spotlight-outset @moon-expandable-text-button-padding;
 
 	&:after {
-		left: @moon-spotlight-outset + 1px;
+		left: @moon-spotlight-outset + 1;
 		right: auto;
 	}
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4720,30 +4720,10 @@
   -webkit-box-orient: vertical;
 }
 .moon-expandable-text .moon-expandable-text-button {
-  font-family: "MuseoSans 300";
-  font-size: 26px;
-  color: #a6a6a6;
-  line-height: 32px;
   float: right;
   display: inline-block;
-  padding-right: 42px;
+  padding: 10px 42px 10px 10px;
   position: relative;
-}
-.moon-expandable-text .moon-expandable-text-button a:link {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-expandable-text .moon-expandable-text-button a:visited {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-expandable-text .moon-expandable-text-button a:hover {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-expandable-text .moon-expandable-text-button a:active {
-  color: #cf0652;
-  text-decoration: none;
 }
 .moon-expandable-text .moon-expandable-text-button:after {
   position: absolute;
@@ -4754,6 +4734,7 @@
   font-size: 48px;
 }
 .moon-expandable-text .moon-expandable-text-button.spotlight {
+  background-color: #cf0652;
   color: #ffffff;
 }
 .moon-expandable-text .moon-expandable-text-button.collapsed:after {
@@ -4762,18 +4743,12 @@
 .moon-expandable-text .moon-expandable-text-button.hidden {
   display: none;
 }
-.enyo-locale-non-latin .moon-expandable-text .moon-expandable-text-button {
-  font-family: "Moonstone LG Display Light";
-  font-size: 26px;
-  line-height: 32px;
-}
 .enyo-locale-non-latin .moon-expandable-text .moon-expandable-text-button:after {
   top: 11px;
 }
 .enyo-locale-right-to-left .moon-expandable-text .moon-expandable-text-button {
   float: left;
-  padding-left: 42px;
-  padding-right: 10px;
+  padding: 10px 10px 10px 42px;
 }
 .enyo-locale-right-to-left .moon-expandable-text .moon-expandable-text-button:after {
   left: 11px;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4717,30 +4717,10 @@
   -webkit-box-orient: vertical;
 }
 .moon-expandable-text .moon-expandable-text-button {
-  font-family: "MuseoSans 300";
-  font-size: 26px;
-  color: #4b4b4b;
-  line-height: 32px;
   float: right;
   display: inline-block;
-  padding-right: 42px;
+  padding: 10px 42px 10px 10px;
   position: relative;
-}
-.moon-expandable-text .moon-expandable-text-button a:link {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-expandable-text .moon-expandable-text-button a:visited {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-expandable-text .moon-expandable-text-button a:hover {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-expandable-text .moon-expandable-text-button a:active {
-  color: #cf0652;
-  text-decoration: none;
 }
 .moon-expandable-text .moon-expandable-text-button:after {
   position: absolute;
@@ -4751,6 +4731,7 @@
   font-size: 48px;
 }
 .moon-expandable-text .moon-expandable-text-button.spotlight {
+  background-color: #cf0652;
   color: #ffffff;
 }
 .moon-expandable-text .moon-expandable-text-button.collapsed:after {
@@ -4759,18 +4740,12 @@
 .moon-expandable-text .moon-expandable-text-button.hidden {
   display: none;
 }
-.enyo-locale-non-latin .moon-expandable-text .moon-expandable-text-button {
-  font-family: "Moonstone LG Display Light";
-  font-size: 26px;
-  line-height: 32px;
-}
 .enyo-locale-non-latin .moon-expandable-text .moon-expandable-text-button:after {
   top: 11px;
 }
 .enyo-locale-right-to-left .moon-expandable-text .moon-expandable-text-button {
   float: left;
-  padding-left: 42px;
-  padding-right: 10px;
+  padding: 10px 10px 10px 42px;
 }
 .enyo-locale-right-to-left .moon-expandable-text .moon-expandable-text-button:after {
   left: 11px;

--- a/source/ExpandableText.js
+++ b/source/ExpandableText.js
@@ -392,7 +392,7 @@
 		/**
 		* @private
 		*/
-		classes: 'moon-item moon-expandable-text-button',
+		classes: 'moon-body-text moon-expandable-text-button',
 
 		/**
 		* @private


### PR DESCRIPTION
...f-by: Brooke Peterson brooke.peterson@lge.com
### Summary

This PR moves the '.moon-body-text' class directly onto the moon.ExpandableTextButton, so we do not need to use it as a mixin class in the namespace class ('.moon-expandable-text-button').
### Detailed Notes:
1. Moon.ExpandableText already has the text class defined on its client {name: 'client', classes: 'moon-body-text moon-expandable-text-content'}. This is the property way of doing so.
2. In the existing code, moon.ExpandableTextButton used a '.moon-item' class which brings in 'moon-sub-header-text" properties, then use '.moon-body-text' as a mixin class in the '.moon-expandable-text-button' to override the '.moon-sub-header-text' properties. This is not efficient. If we put the '.moon-body-text' directly onto the moon.ExpandableTextButton, and adjust the padding/spotlight bg color in '.moon-expandable-text-button', we do not need the override mixin class and no need to worry about RTL.
3. Using text class directly onto the widget not only reduce lines of css code but also will help performance as switching from view to view these common text classes are cached.
### Test Performed:

Desktop Chrome Version 37.0.2062.124
Master 688 nfs build side loading
