### PR TITLE
Fixes BHV-15490

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -1173,7 +1173,7 @@
 		*/
 		applyShowAnimation: function (direct) {
 			this.$.clientWrapper.applyStyle('-webkit-transition', direct ? null : '-webkit-transform 0.5s cubic-bezier(0.25, 0.1, 0.25, 1)');
-			this.$.clientWrapper.applyStyle('-webkit-transform', 'translateX(0)');
+			enyo.dom.transform(this.$.clientWrapper, {translateX: 0});
 		},
 
 		/**
@@ -1181,7 +1181,7 @@
 		*/
 		applyHideAnimation: function (direct) {
 			this.$.clientWrapper.applyStyle('-webkit-transition', direct ? null : '-webkit-transform 0.5s cubic-bezier(0.25, 0.1, 0.25, 1)');
-			this.$.clientWrapper.applyStyle('-webkit-transform', 'translateX(100%)');
+			enyo.dom.transform(this.$.clientWrapper, {translateX: '100%'});
 		},
 
 		/**


### PR DESCRIPTION
## Issue

`enyo.dom.getAbsoluteBounds()` was using the style property to retrieve the value of the CSS transform which returns the explicit value set (e.g. the percentage), not the calculated value. Furthermore, it did not account for `matrix` transforms, only `translateX`, `translateY`, and `matrix3d`.
## Fix
- Use enyo.dom.getComputedStyle and account for matrix transforms in getAbsoluteBounds.
- Use enyo.dom.transform for panels animation

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
