### PR TITLE
ENYO-354: Ensure we have a node when executing delayed measurements.

### DIFF
--- a/source/Header.js
+++ b/source/Header.js
@@ -309,7 +309,7 @@
 				this.adjustTitleWidth();
 			} else {
 				enyo.asyncMethod(this, function () {
-					if (this.hasNode()) {
+					if (!this.destroyed && this.hasNode()) {
 						this.adjustTitleWidth();
 						_delayedMeasurementFinished = true;
 					}


### PR DESCRIPTION
### Issue

A `moon.Header` can be destroyed soon after its creation. This can lead to the `asyncMethod` call attempting to make measurements on non-existent nodes.
### Fix

We guard against the case where we do not have an attached node. We might also want to investigate other cases where `asyncMethod` is used at create time for delayed work.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
