### PR TITLE
Bhv 13973 Perf: moon.Button has redundant function call.

### DIFF
--- a/source/Button.js
+++ b/source/Button.js
@@ -129,8 +129,8 @@
 				this.createComponent({name: 'client', kind:'moon.MarqueeText', isChrome: true});
 				this.createComponent({name: 'tapArea', classes: 'button-tap-area', isChrome: true});
 			}
-			this.smallChanged();
-			this.minWidthChanged();
+			if (this.small) this.smallChanged();
+			if (this.minWidth) this.minWidthChanged();
 			this.contentChanged();
 			this.inherited(arguments);
 		},


### PR DESCRIPTION
## Issue

When we create moon.Button, some changed method like smallChanged is called.
However if small property does not have true value, we do not need to call it.

Like this case, we can reduce instantiate time with removing unnecessary function call
## Cause

Did not consider proper calling case
## Fix

Ignore notification from client.
Only if a public property is true, call changed method in initCompoentns

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
