### PR TITLE
BHV-16204: moon.ListActions optionSelected handler can behave wrong

### DIFF
--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -476,8 +476,12 @@
 		* @private
 		*/
 		optionSelected: function(sender, e) {
+			this.startJob('expandContractJob', 'expandContractJob', 300);
+		},
+
+		expandContractJob: function(sender, e) {
 			if (this.getOpen() && this.autoCollapse && !this.noAutoCollapse) {
-				this.startJob('expandContract', 'expandContract', 300);
+				this.expandContract();
 			}
 		},
 


### PR DESCRIPTION
## Issue:

The optionSelected handler is checking open status then start expandContract as a job.
But, when expandContract is called we can not guarantee that open variable is still true because it has 300ms delay.
This can cause timing problem when developer call expandContract directly and that call is called between the 300ms delay.
## Fix:

Check open status when expandContract is called so that there is no timing gap.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
