### PR TITLE
BHV-16192: Update alignment when content changes.

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -702,6 +702,7 @@
 			if (this.$.marqueeText) {
 				this.$.marqueeText.setContent(this.content);
 			}
+			this._marquee_detectAlignment();
 			this._marquee_reset();
 		},
 


### PR DESCRIPTION
### Issue

When the content of a centered `moon.MarqueeText` is changed such that we no longer need to marquee, the content is not centered.
### Fix

We run the `detectAlignment` method whenever content subsequently changes.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
