### PR TITLE
BHV-16443: Determine visibility of branding independent of index change handler.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -447,7 +447,7 @@
 					this._directHide();
 				}
 			}
-			this.indexChanged();
+			this.displayBranding();
 		},
 
 		/**
@@ -941,13 +941,7 @@
 
 			this.inherited(arguments);
 
-			if (this.$.branding) {
-				if (this.pattern == 'activity' && this.getPanelInfo(0, this.index).breadcrumb) {
-					this.$.branding.show();
-				} else {
-					this.$.branding.hide();
-				}
-			}
+			this.displayBranding();
 		},
 
 		/**
@@ -1222,6 +1216,19 @@
 		hideAnimationComplete: function () {
 			if (this.handleShowing) {
 				this.$.showHideHandle.removeClass('hidden');
+			}
+		},
+
+		/**
+		* @private
+		*/
+		displayBranding: function () {
+			if (this.$.branding) {
+				if (this.pattern == 'activity' && this.getPanelInfo(0, this.index).breadcrumb) {
+					this.$.branding.show();
+				} else {
+					this.$.branding.hide();
+				}
 			}
 		},
 


### PR DESCRIPTION
### Issue

The `indexChanged` handler had been added to `rendered`, which caused some unintended side effects as this triggered some transition methods and events.
### Fix

We decouple the logic that determines breadcrumb visibility from the `indexChanged` handler.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
