### PR TITLE
ENYO-373: Add moon.initContainer() feature

### DIFF
--- a/source/moon-container-init.js
+++ b/source/moon-container-init.js
@@ -1,0 +1,38 @@
+(function (enyo, scope) {
+	enyo.kind({
+		name: 'moon.ContainerInitializer',
+		components: [
+			{kind: 'moon.Drawers', drawers: [{}], components: [
+				{kind: 'moon.Panels', pattern: 'activity', components: [
+					{components: [
+						{kind: 'moon.TooltipDecorator', components: [{kind: 'moon.Button'},{kind: 'moon.Tooltip'}]},
+						{kind: 'moon.ToggleButton'},
+						{kind: 'moon.ToggleItem'},
+						{kind: 'moon.FormCheckbox'},
+						{kind: 'moon.Image'},
+						{kind: 'moon.SelectableItem'},
+						{kind: 'moon.ProgressBar'},
+						{kind: 'moon.Slider'},
+						{kind: 'moon.Spinner'},
+						{kind: 'moon.BodyText'},
+						{kind: 'moon.LabeledTextItem'},
+						{kind: 'moon.ImageItem'},
+						{kind: 'moon.Divider'},
+						{kind: 'moon.ContextualPopupDecorator', components: [
+							{kind: 'moon.ContextualPopupButton'},
+							{kind: 'moon.ContextualPopup', components: [{}]}
+						]}
+					]}
+				]}
+			]}
+		]
+	});
+
+	window.moon = window.moon || {};
+
+	moon.initContainer = function () {
+		var initializer = new moon.ContainerInitializer();
+		initializer.renderInto(document.body);
+		initializer.destroy();
+	};	
+})(enyo, this);

--- a/source/package.js
+++ b/source/package.js
@@ -82,5 +82,6 @@ enyo.depends(
 	'Image.js',
 	'ImageBadge.js',
 	'ExpandableText.js',
-	'keymap.js'
+	'keymap.js',
+	'moon-container-init.js'
 );


### PR DESCRIPTION
Based on load-time performance investigations done by SoonGil Choi's
team at SWP, we have implemented a new feature in Moonstone that will
let the webOS container do more work on container load, reducing the
launch time for individual apps. Specifically, this feature
(moon.initContainer()) instantiates, renders and destroys a select
set of Moonstone controls. Doing so seems to result in shorter
JavaScript execution when an app is subsequently loaded, most likely
because it causes some expensive JIT compilation to happen prior to
app load.

This feature is being implemented in Moonstone (not in the container)
primarily to avoid fine-grained dependencies between the container
and Moonstone, which could require synchronized updates. It's also
conceivable that this feature could be used in other environments
similar to the webOS container.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
