### PR TITLE
BHV-16550: moon.Tooltip getting wrong position in 'RTL' Mode.

### DIFF
--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -281,7 +281,9 @@
 				}
 
 				//* When there is not enough room on the left, using right-arrow for the tooltip
-				if (window.innerWidth - moonDefaultPadding - pBounds.left - pBounds.width / 2 < b.width){
+				var pBLeft = Math.abs(pBounds.left),
+				    pBRight = Math.abs(pBounds.right);
+				if (window.innerWidth - moonDefaultPadding - pBLeft - pBounds.width / 2 < b.width || b.width < pBounds.left && window.innerWidth > pBRight - pBLeft) {
 					//* use the right-arrow
 					this.removeClass('left-arrow');
 					this.addClass('right-arrow');


### PR DESCRIPTION
Issue:  when siblings of tooltip is translated in 'RTL' mode, position
of tooltip is not properly calculated, causing abnormal positioning of
tooltip.
Fix: added a check, which can calculate current position based on the
its parent bounds.
DCO-1.1-Signed-Off-By: Srinivas V srinivas.v@lge.com
