### PR TITLE
ENYO-373: Remove moon.Slider from set of pre-[initialized, rendered, destroyed] controls.

### DIFF
--- a/source/moon-container-init.js
+++ b/source/moon-container-init.js
@@ -12,7 +12,6 @@
 						{kind: 'moon.Image'},
 						{kind: 'moon.SelectableItem'},
 						{kind: 'moon.ProgressBar'},
-						{kind: 'moon.Slider'},
 						{kind: 'moon.Spinner'},
 						{kind: 'moon.BodyText'},
 						{kind: 'moon.LabeledTextItem'},


### PR DESCRIPTION
### Issue

We had made a change (https://github.com/enyojs/moonstone/pull/1729) to initialize, render, and destroy a select set of controls to improve load-time performance. Unfortunately, the inclusion of `moon.Slider` caused some unforeseen side-effects with WebKit, which resulted in some rendering discrepancies.
### Fix

`moon.Slider` is no longer included as part of this optimization.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
