### PR TITLE
ENYO-373: Pass parameter to prevent adding moon.ContainerInitializer to roots.

### DIFF
--- a/source/moon-container-init.js
+++ b/source/moon-container-init.js
@@ -31,7 +31,7 @@
 
 	moon.initContainer = function () {
 		var initializer = new moon.ContainerInitializer();
-		initializer.renderInto(document.body);
+		initializer.renderInto(document.body, true);
 		initializer.destroy();
 	};	
 })(enyo, this);


### PR DESCRIPTION
### Issue

When initializing a select set of controls for performance reasons, the container for these controls is initialized as the Spotlight root, which causes subsequent Spotlight issues when controls do not have a spottable parent and instead use the Spotlight root.
### Fix

Instead of making a quick patch to Spotlight (a full solution here will require some more design), we made a change to `enyo.Control.renderInto` (https://github.com/enyojs/enyo/pull/906) to accept a boolean parameter to prevent adding of a control to the view roots. Here, we pass true for `moon.ContainerInitializer`. Thanks to @ryanjduffy for the initial fix.
### Notes

This PR depends on https://github.com/enyojs/enyo/pull/906. This also needs to be cherry-picked into the `branch-2.5.2-pre.4` branch.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
