### PR TITLE
ENYO-399: Prevent event propagation for sub-pickers at create time.

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -183,10 +183,11 @@
 			}
 
 			values = this.calcPickerValues();
+			this.silence();
 
 			for(f = 0, l = doneArr.length; f < l; f++) {
 				o = doneArr[f];
-				
+
 				switch (o) {
 				case 'd':
 					digits = (ordering.indexOf('dd') > -1) ? 2 : null;
@@ -216,6 +217,8 @@
 					break;
 				}
 			}
+
+			this.unsilence();
 			this.inherited(arguments);
 		},
 


### PR DESCRIPTION
### Issue

There was a recent change (https://github.com/enyojs/moonstone/blob/master/source/IntegerPicker.js#L266) that caused the propagation of a change event at create time. This affected `moon.DatePicker`, which creates pickers for day, month, and year (which in turn fire change events now upon creation), in addition to handling change events from these pickers using a single change handler. When handling these change events, `moon.DatePicker` attempts to access the day component first, but this may not have been created yet, depending on the date format.
### Fix

We do not need to handle these change events at create time, so we silence event propagation during the creation of these sub-pickers.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
