### PR TITLE
ENYO-409: Handle case where date picker has not had a value set yet.

### DIFF
--- a/samples/DatePickerSample.js
+++ b/samples/DatePickerSample.js
@@ -60,9 +60,10 @@ enyo.kind({
 		return true;
 	},
 	setDate: function() {
-		var year = isNaN(parseInt(this.$.yearInput.getValue(), 0)) ? this.$.picker.value.getFullYear() : parseInt(this.$.yearInput.getValue(), 0);
-		var month = isNaN(parseInt(this.$.monthInput.getValue(), 0)) ? this.$.picker.value.getMonth() : parseInt(this.$.monthInput.getValue(), 0) - 1;
-		var day = isNaN(parseInt(this.$.dayInput.getValue(), 0)) ? this.$.picker.value.getDate() : parseInt(this.$.dayInput.getValue(), 0);
+		var current = this.$.picker.value || new Date();
+		var year = isNaN(parseInt(this.$.yearInput.getValue(), 0)) ? current.getFullYear() : parseInt(this.$.yearInput.getValue(), 0);
+		var month = isNaN(parseInt(this.$.monthInput.getValue(), 0)) ? current.getMonth() : parseInt(this.$.monthInput.getValue(), 0) - 1;
+		var day = isNaN(parseInt(this.$.dayInput.getValue(), 0)) ? current.getDate() : parseInt(this.$.dayInput.getValue(), 0);
 		this.$.picker.setValue(new Date(year, month, day));
 	},
 	resetDate: function() {


### PR DESCRIPTION
### Issue

In the `DatePickerSample`, if the `moon.DatePicker` has not yet been expanded, which means it does not currently have a value, pressing the "Set Date" button when any of the input fields (day, month, year) are empty will thrown an exception. This is caused by how the sample is implemented, which uses the relevant date part of the current value of the `moon.DatePicker` for the respective input field that is empty.
### Fix

We default to the current date as our baseline date if the `moon.DatePicker` does not have a current value.
### Notes

Please note that https://github.com/enyojs/moonstone/pull/1736 needs to be merged in order for the `DatePickerSample` to load.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
