### PR TITLE
[BHV-16348] Issue of co-existing Popup and contextual popup

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -527,22 +527,6 @@
 		/**
 		* @private
 		*/
-		findZIndex: function () {
-			// a default z value
-			var z = this.defaultZ;
-			if (this._zIndex) {
-				z = this._zIndex;
-			} else if (this.hasNode()) {
-				// Re-use existing zIndex if it has one
-				z = Number(enyo.dom.getComputedStyleValue(this.node, 'z-index')) || z;
-			}
-			this._zIndex = z;
-			return this._zIndex;
-		},
-
-		/**
-		* @private
-		*/
 		showingChanged: function () {
 			this.inherited(arguments);
 			this.alterDirection();

--- a/source/Popup.js
+++ b/source/Popup.js
@@ -340,7 +340,6 @@
 				}
 				this.activator = enyo.Spotlight.getCurrent();
 				moon.Popup.count++;
-				this.genereateNextZIndex();
 				this.applyZIndex();
 			}
 			else {
@@ -509,23 +508,6 @@
 				return moon.scrimTransparent.make();
 			}
 			return moon.scrim.make();
-		},
-
-		/**
-		* Calculate what the next z-index should be, set it, and return it.
-		*
-		* @private
-		*/
-		genereateNextZIndex: function() {
-			this._zIndex = (moon.Popup.count * 2) + (this.findZIndex() + 1);
-			return this._zIndex;
-		},
-
-		/**
-		* @private
-		*/
-		applyZIndex: function() {
-			this.applyStyle('z-index', this._zIndex);
 		},
 
 		/**


### PR DESCRIPTION
Issue: If two different popups, both are extended from enyo.Popup exist
at the same time, it creates a conflict behavior as one popup doesn't
have information about the other's z-index.
Fix: The methods that removed that are overridden by moon. Popup and
moon.ContextualPopup
DCO-1.1-Signed-Off-By: Rajyavardhan P rajyavardhan.p@lge.com
