### PR TITLE
BHV-17152: Changing InputHeader functionality for making the Behavioral ...

### DIFF
--- a/source/Header.js
+++ b/source/Header.js
@@ -576,13 +576,6 @@
 		/**
 		* @private
 		*/
-		valueChanged: function () {
-			this.$.titleInput.detectTextDirectionality((this.$.titleInput.value || this.$.titleInput.value === 0 || this.$.titleInput.value === '0') ? this.$.titleInput.value : this.$.titleInput.get('placeholder'));
-		},
-
-		/**
-		* @private
-		*/
 		adjustTitleWidth: function() {
 			var type = this.get('type'),
 				// Measure client area's width + 40px of spacing
@@ -649,7 +642,6 @@
 			this.$.titleInput.set('placeholder', this.getTitleUpperCase()
 					? enyo.toUpperCase(this.placeholder || this.title || this.content)
 					: (this.placeholder || this.title || this.content) );
-			this.valueChanged();
 		},
 
 		/**


### PR DESCRIPTION
...same between Input and InputHeader when RTL is true.

Issue:

Make the RTL as true and run moon.InputHeader sample. You will see titleAbove, titleBelow on the right side of the screen but the moon.InputHeader will be on left side.
Fix:

Not calling the detectTextDirectionality function to override the ltr direction
DCO-1.1-Signed-Off-By: Anshu Agrawal anshu.agrawal@lge.com
