### PR TITLE
ENYO-431: Run detectAlignment when content changes, only when generated.

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -680,7 +680,7 @@
 		*/
 		_marquee_alignmentChanged: function () {
 			this.applyStyle('text-align', this._marquee_alignment);
-			this._marquee_distance = null;
+			this._marquee_invalidateMetrics();
 		},
 
 		/**
@@ -702,7 +702,9 @@
 			if (this.$.marqueeText) {
 				this.$.marqueeText.setContent(this.content);
 			}
-			this._marquee_detectAlignment();
+			if (this.generated) {
+				this._marquee_detectAlignment();
+			}
 			this._marquee_reset();
 		},
 
@@ -785,7 +787,7 @@
 			}
 
 			this.startJob('stopMarquee', '_marquee_stopAnimation', this.marqueePause);
-	        return true;
+			return true;
 		},
 
 		/**


### PR DESCRIPTION
### Issue

When attempting to fix BHV-16192 via https://github.com/enyojs/moonstone/pull/1726, we introduced a situation where the `detectAlignment` method is run before the control is rendered, which results in a `_marquee_distance` of 0 being calculated and cached. Because `moon.Marquee` does not recalculate the distance to marquee if the distance has already been computed, this resulted in some controls not marqueeing (this did not affect controls whose alignment we determined needed to be set, which caused an invalidation of the `_marquee_distance` value).
### Fix

We guard the calling of `detectAlignment` such that it only runs in `contentChanged` when the control is rendered. Additionally, we also execute the full `_marquee_invalidateMetrics` method when alignment changes, to handle cases where we've previously determined the marquee fits but the alignment has changed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
