### PR TITLE
ENYO-429: Account for RTL directionality in panel handle.

### DIFF
--- a/css/Panels.less
+++ b/css/Panels.less
@@ -84,6 +84,7 @@
 		width: 100%;
 		line-height: 100vh;
 		margin-left: -10px;
+		margin-right: 10px;
 		background-color: @moon-panels-handle-bg-color;
 		font-family: @moon-icon-font-family;
 		font-size: @moon-panel-handle-icon-font-size;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3064,6 +3064,7 @@
   width: 100%;
   line-height: 100vh;
   margin-left: -10px;
+  margin-right: 10px;
   background-color: #4b4b4b;
   font-family: "Moonstone Icons";
   font-size: 144px;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3064,6 +3064,7 @@
   width: 100%;
   line-height: 100vh;
   margin-left: -10px;
+  margin-right: 10px;
   background-color: #4b4b4b;
   font-family: "Moonstone Icons";
   font-size: 144px;


### PR DESCRIPTION
### Issue

When in RTL mode, the panel handle does not appear. This is due to the switch in directionality and the fact that the `margin-left` property is not effective in this case.
### Fix

We add a `margin-right` property that appropriately positions the handle.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
