### PR TITLE
ENYO-437: Add MarqueeSample to package.js

### DIFF
--- a/samples/package.js
+++ b/samples/package.js
@@ -66,6 +66,8 @@ enyo.depends(
 	"LabeledTextItemSample.js",
 	"ListActionsSample.css",
 	"ListActionsSample.js",
+	"MarqueeSample.css",
+	"MarqueeSample.js",
 	"ObjectActionHorizontalTypeSample.css",
 	"ObjectActionHorizontalTypeSample.js",
 	"ObjectActionVerticalTypeSample.css",


### PR DESCRIPTION
### Issue

`MarqueeSample` was missing from the `package.js` file for Moonstone samples. Having this included would aid in testing such aspects as RTL via the Sample.html app.
### Fix

`MarqueeSample` has been added to `package.js`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
