### PR TITLE
BHV-16740: Block focus and tap event when listActions is open

### DIFF
--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -516,8 +516,12 @@
 				return true;
 			}
 		},
+		
+		/**
+		* @private
+		*/
 		capturedTap: function(sender, e) {
-			if (this.getOpen() && e.dispatchTarget && !e.dispatchTarget.isDescendantOf(this.$.drawer)) {
+			if (this.get('open') && e.dispatchTarget && !e.dispatchTarget.isDescendantOf(this.$.drawer)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Issue:
- Panel body items can be focused in pointer mode when listActions are open
- Focus can not move from listActions to panel body but can move opposite direction.

Fix:
- We can block tap and focus event while listActions are open without adding scrim.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
