### PR TITLE
[BHV-17002]Contextual popup doesn't work as expected when spotlightModal...

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -74,7 +74,8 @@
 		* @private
 		*/
 		eventsToCapture: {
-			onSpotlightKeyDown: 'capturedKeyDown'
+			onSpotlightKeyDown: 'capturedKeyDown',
+			onSpotlightFocus: 'capturedFocus'
 		},
 
 		/**
@@ -450,7 +451,13 @@
 			if (inEvent.keyCode == 13) {
 				this.downEvent = inEvent;
 			}
-			return this.modal;
+			return this.modal && this.spotlightModal;
+		},
+		capturedFocus: function(inSender, inEvent) {
+			if(this.spotlightModal) {
+				enyo.Spotlight.spot(this);
+				return true;
+			}
 		},
 
 		/**


### PR DESCRIPTION
...: true

Issue: When spotlightModal: true on contextual popup other controls
shouldnot get focus
Cause: There is no mechanism in contextual popup to deal with
spotlightmodal and spotlight focus.
Fix: Spotlight focus mechanism is added in the contextual popup to
handle this case.
DCO-1.1-Signed-Off-By: Rajyavardhan P rajyavardhan.p@lge.com
