### PR TITLE
BHV-17199: VideoPlayer : playback controls & slider popup display issue

### DIFF
--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -601,7 +601,7 @@
 		* @private
 		*/
 		components: [
-			{kind: 'enyo.Signals', onPanelsShown: 'panelsShown', onPanelsHidden: 'panelsHidden', onPanelsHandleFocused: 'panelsHandleFocused', onPanelsHandleBlurred: 'panelsHandleBlurred', onFullscreenChange: 'fullscreenChanged', onkeyup:'remoteKeyHandler'},
+			{kind: 'enyo.Signals', onPanelsShown: 'panelsShown', onPanelsHidden: 'panelsHidden', onPanelsHandleFocused: 'panelsHandleFocused', onPanelsHandleBlurred: 'panelsHandleBlurred', onFullscreenChange: 'fullscreenChanged', onkeyup:'remoteKeyHandler', onSpotlightModeChanged: "resetPreviewMode"},
 			{name: 'videoContainer', classes: 'moon-video-player-container', components: [
 				{name: 'video', kind: 'enyo.Video', classes: 'moon-video-player-video',
 					ontimeupdate: 'timeUpdate', onloadedmetadata: 'metadataLoaded', durationchange: 'durationUpdate', onloadeddata: 'dataloaded', onprogress: '_progress', onPlay: '_play', onpause: '_pause', onStart: '_start',  onended: '_stop',
@@ -749,6 +749,15 @@
 		playbackControlsTapped: function() {
 			if (this.disablePlaybackControls) {
 				this.bubble('onPlaybackControlsTapped');
+			}
+		},
+		/** 
+		* @private
+		*/
+		resetPreviewMode: function(){
+			if(!enyo.Spotlight.getPointerMode() && this.$.slider.isInPreview() && !this.inline) {
+				this.$.controls.setShowing(true);
+				this.$.slider.endPreview();
 			}
 		},
 


### PR DESCRIPTION
Issue: when spot is moved away from video transport slider, playback
controls are not shown and slider-popup position is not updated.
Cause: when spotlight model gets changed to 5-way mode we're not
handling.
Fix: showing playback controls and setting the previewMode to its
default value when spotlightModel changes to 5-way.
DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com
