### PR TITLE
ENYO-424: Prevent tap event when user presses to stop scrolling

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -276,6 +276,7 @@
 		*/
 		down: function(sender, event) {
 			if (!this.isPageControl(event.originator) && this.isScrolling() && !this.isOverscrolling()) {
+				event.preventTap();
 				this.stop();
 			}
 		},


### PR DESCRIPTION
This issue was addressed in enyo.ScrollStrategy, but the moon
version doesn't call the sup method, so applying the same fix here.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
