### PR TITLE
CMB-3553: Buttons text are left aligned in DataGridList Sample

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -594,6 +594,12 @@
 		_marquee_puppetMaster: null,
 
 		/**
+		* We avoid small distance of flow by giving a threshold value of distance.
+		* @private
+		*/
+		_marquee_threshold: 2,
+
+		/**
 		* @method
 		* @private
 		*/
@@ -797,7 +803,7 @@
 		*/
 		_marquee_shouldAnimate: function (distance) {
 			distance = (distance && distance >= 0) ? distance : this._marquee_calcDistance();
-			return (distance > 0);
+			return (distance > this._marquee_threshold);
 		},
 
 		/**


### PR DESCRIPTION
### Issue:

Button text is left aligned on initial render which should be center aligned.
This problem happens due to 1px difference between node.scrollWidth - node.clientWidth in _marquee_calcDistance when it is rendered initially. So, _marquee_shouldAnimate returns true even if it doesn't need to scroll. This result in _marquee_detectAlignment set text-alignment as left.
In addition to this issue, we can see that marque text are flow when it has very small distance to move like 1 or 2 px. Which looks like also problem.
### Fix:

Add distance tolerance property on marquee to avoid this kind of 1px error and stupid marquee happens.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
