### PR TITLE
ENYO-442: Utilize method for temporarily suppressing events.

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -183,42 +183,42 @@
 			}
 
 			values = this.calcPickerValues();
-			this.silence();
 
-			for(f = 0, l = doneArr.length; f < l; f++) {
-				o = doneArr[f];
+			this.muzzle(function () {
+				for(f = 0, l = doneArr.length; f < l; f++) {
+					o = doneArr[f];
 
-				switch (o) {
-				case 'd':
-					digits = (ordering.indexOf('dd') > -1) ? 2 : null;
-					this.createComponent(
-						{classes: 'moon-date-picker-wrap', components:[
-							{kind:'moon.IntegerPicker', name:'day', classes:'moon-date-picker-field', wrap:true, digits:digits, min:1,
-							max:this.monthLength(values.fullYear, values.month), value: values.date},
-							{name: 'dayLabel', content: this.dayText, classes: 'moon-date-picker-label moon-divider-text'}
-						]});
-					break;
-				case 'M':
-					digits = (ordering.indexOf('MM') > -1) ? 2 : null;
-					this.createComponent(
-						{classes: 'moon-date-picker-wrap', components:[
-							{kind:'moon.IntegerPicker', name:'month', classes:'moon-date-picker-field', wrap:true, min:1, max:values.maxMonths, value:values.month},
-							{name: 'monthLabel', content: this.monthText, classes: 'moon-date-picker-label moon-divider-text'}
-						]});
-					break;
-				case 'y':
-					this.createComponent(
-						{classes: 'moon-date-picker-wrap year', components:[
-							{kind:'moon.IntegerPicker', name:'year', classes:'moon-date-picker-field year', value:values.fullYear, min:this.getMinYear(), max:this.getMaxYear()},
-							{name: 'yearLabel', content: this.yearText, classes: 'moon-date-picker-label moon-divider-text'}
-						]});
-					break;
-				default:
-					break;
+					switch (o) {
+					case 'd':
+						digits = (ordering.indexOf('dd') > -1) ? 2 : null;
+						this.createComponent(
+							{classes: 'moon-date-picker-wrap', components:[
+								{kind:'moon.IntegerPicker', name:'day', classes:'moon-date-picker-field', wrap:true, digits:digits, min:1,
+								max:this.monthLength(values.fullYear, values.month), value: values.date},
+								{name: 'dayLabel', content: this.dayText, classes: 'moon-date-picker-label moon-divider-text'}
+							]});
+						break;
+					case 'M':
+						digits = (ordering.indexOf('MM') > -1) ? 2 : null;
+						this.createComponent(
+							{classes: 'moon-date-picker-wrap', components:[
+								{kind:'moon.IntegerPicker', name:'month', classes:'moon-date-picker-field', wrap:true, min:1, max:values.maxMonths, value:values.month},
+								{name: 'monthLabel', content: this.monthText, classes: 'moon-date-picker-label moon-divider-text'}
+							]});
+						break;
+					case 'y':
+						this.createComponent(
+							{classes: 'moon-date-picker-wrap year', components:[
+								{kind:'moon.IntegerPicker', name:'year', classes:'moon-date-picker-field year', value:values.fullYear, min:this.getMinYear(), max:this.getMaxYear()},
+								{name: 'yearLabel', content: this.yearText, classes: 'moon-date-picker-label moon-divider-text'}
+							]});
+						break;
+					default:
+						break;
+					}
 				}
-			}
+			});
 
-			this.unsilence();
 			this.inherited(arguments);
 		},
 

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -504,11 +504,13 @@
 		setChildPickers: function (inOld) {
 			if (this.value) {
 				var hour = this.value.getHours();
-				this.$.hour.setValue(hour);
-				this.$.minute.setValue(this.value.getMinutes());
-				if (this.meridiemEnable === true) {
-					this.$.meridiem.setValue(hour > 11 ? 1 : 0);
-				}
+				this.muzzle(function () {
+					this.$.hour.setValue(hour);
+					this.$.minute.setValue(this.value.getMinutes());
+					if (this.meridiemEnable === true) {
+						this.$.meridiem.setValue(hour > 11 ? 1 : 0);
+					}
+				});
 			}
 			this.$.currentValue.setContent(this.formatValue());
 		},


### PR DESCRIPTION
### Issue
We are currently using a pair of `silence` and `unsilence` calls to temporarily suppress events in situations where it is either required (to prevent undefined object errors) or helpful (to prevent unnecessary execution of change handlers). We've added a `muzzle` function that can be utilized now.

### Fix
`moon.DatePicker` has been updated to use the `muzzle` function, while we've added the use of `muzzle` for `moon.TimePicker` to prevent unnecessary execution of change handlers.

### Notes
This PR is dependent on https://github.com/enyojs/enyo/pull/922.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>