### PR TITLE
ENYO-466: Tooltips shouldn't receive mouse events, so now they don't.

### DIFF
--- a/css/Tooltip.less
+++ b/css/Tooltip.less
@@ -3,6 +3,7 @@
 	height: @moon-tooltip-height;
 	-webkit-transform: translateZ(0);
 	transform: translateZ(0);
+	pointer-events: none;
 }
 .moon-tooltip-label {
 	.moon-small-button-text;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3450,6 +3450,7 @@
   height: 68px;
   -webkit-transform: translateZ(0);
   transform: translateZ(0);
+  pointer-events: none;
 }
 .moon-tooltip-label {
   font-family: "Moonstone Miso Bold";

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3450,6 +3450,7 @@
   height: 68px;
   -webkit-transform: translateZ(0);
   transform: translateZ(0);
+  pointer-events: none;
 }
 .moon-tooltip-label {
   font-family: "Moonstone Miso Bold";


### PR DESCRIPTION
When moving the cursor over a translucent-but-present part of the tooltip flag, the tooltip decorator would lose focus/spotlight, causing the tooltip to dismiss and later re-appear. Setting the Tooltip to not be able to receive mouse events makes much more sense, as tooltips by their very definition aren't interact-able.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
