### PR TITLE
ENYO-470: Replace image asset references with sensible icon alternatives.

### DIFF
--- a/samples/HeaderAutoCollapsingSample.js
+++ b/samples/HeaderAutoCollapsingSample.js
@@ -4,8 +4,8 @@ enyo.kind({
 	components: [
 		{kind: "moon.Panels", classes:"enyo-fit", pattern: "activity", components: [
 			{kind: "moon.Panel", classes:"moon-6h", collapsingHeader:true, title:"Scroll Me", titleBelow:"To test the auto-collapsing", subTitleBelow:"Feature of moon.Panel", headerComponents: [
-				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png"},
-				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-next.png"}
+				{kind: "moon.IconButton", icon: "check"},
+				{kind: "moon.IconButton", icon: "arrowlargeright"}
 			], components: [
 				{kind:"moon.Scroller", fit:true, components: [
 					{kind:"enyo.Repeater", count:50, onSetupItem:"setupItem", components: [
@@ -14,8 +14,8 @@ enyo.kind({
 				]}
 			]},
 			{kind: "moon.Panel", classes:"moon-6h", joinToPrev:true, collapsingHeader:true, title:"Me too", titleBelow:"Another header", subTitleBelow:"That collapses on scroll", headerComponents: [
-				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png"},
-				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-next.png"}
+				{kind: "moon.IconButton", icon: "check"},
+				{kind: "moon.IconButton", icon: "arrowlargeright"}
 			], components: [
 				{kind:"moon.Scroller", fit:true, components: [
 					{kind:"enyo.Repeater", count:50, onSetupItem:"setupItem", components: [
@@ -24,8 +24,8 @@ enyo.kind({
 				]}
 			]},
 			{kind: "moon.Panel", classes:"moon-6h", collapsingHeader:true, title:"Yet another", headerComponents: [
-				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png"},
-				{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-next.png"}
+				{kind: "moon.IconButton", icon: "check"},
+				{kind: "moon.IconButton", icon: "arrowlargeright"}
 			], components: [
 				{kind:"moon.Scroller", fit:true, components: [
 					{kind:"enyo.Repeater", count:50, onSetupItem:"setupItem", components: [

--- a/samples/InputHeaderSample.js
+++ b/samples/InputHeaderSample.js
@@ -8,8 +8,8 @@ enyo.kind({
 				kind: "moon.Panel",
 				classes: "moon-10h",
 				headerOptions: {kind: "moon.InputHeader", components: [
-					{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png"},
-					{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-next.png"}
+					{kind: "moon.IconButton", icon: "check"},
+					{kind: "moon.IconButton", icon: "arrowlargeright"}
 				]},
 				onInputHeaderInput: "handleInput",
 				onInputHeaderChange: "handleChange",
@@ -23,8 +23,8 @@ enyo.kind({
 				classes: "moon-8h",
 				joinToPrev: true,
 				headerOptions: {kind: "moon.InputHeader", components: [
-					{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-like.png"},
-					{kind: "moon.IconButton", src: "../patterns-samples/assets/icon-next.png"}
+					{kind: "moon.IconButton", icon: "check"},
+					{kind: "moon.IconButton", icon: "arrowlargeright"}
 				]},
 				onInputHeaderInput: "handleInput",
 				onInputHeaderChange: "handleChange",


### PR DESCRIPTION
### Issue

The `InputHeaderSample` and `HeaderAutoCollapsingSample` both had numerous references to stale image assets for their `IconButton` controls.
### Fix

The stale references have been replaced with sensible icon substitutions.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
