### PR TITLE
ENYO-457: Header: Focus Does Not Display in Input after 5way

### DIFF
--- a/source/Input.js
+++ b/source/Input.js
@@ -104,9 +104,6 @@
 			if (this.dismissOnEnter) {
 				if (oEvent.keyCode == 13 && this._bFocused) {
 					this.blur();
-					if (enyo.Spotlight.getPointerMode()) {
-						enyo.Spotlight.unspot();
-					}
 				}
 			}
 		},


### PR DESCRIPTION
### Issue:

ENYO-457 and BHV-14227 both seem to to result from BHV-10720, which, when input loses the focus, unspots the input decorator based on the pointer mode. The initial issue, BHV-10720, seems to be a very minor issue, so I think this code unspotting the input decorator should be removed.
### Fix:

Remove the code which unspots the input decorator when the input loses focus

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
