### PR TITLE
ENYO-454: Update paging control state minimally during scrolling.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -500,22 +500,10 @@
 		/**
 		* @private
 		*/
-		scrollMathStop: enyo.inherit(function (sup) {
+		scrollMathScroll: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
 				this.updatePagingControlState();
-			};
-		}),
-
-		/**
-		* @private
-		*/
-		scrollMathScroll: enyo.inherit(function (sup) {
-			return function () {
-				if (this.isOverscrolling()) {
-					this.updatePagingControlState();
-				}
-				sup.apply(this, arguments);
 			};
 		}),
 


### PR DESCRIPTION
### Issue

Before we streamlined the logic for displaying the paging controls for BHV-15753, the disabled state of the paging controls would be calculated in `_getScrollBounds` for each `onscroll` event. This allowed for an instance during scrolling where the top paging control became disabled with the bottom paging control enabled (due to overscrolling, which allows this to occur before `onScrollStop` normally fires), as once the top paging button is pressed, the bottom paging button will become enabled during scrolling. The opposite was also true (bottom paging control was disabled while the top paging control was still enabled). In Spotlight, when a control becomes disabled, we attempt to spot the last spotted control before spotting the first spottable control on the page. With the aforementioned fix, we eliminated the tight-coupling between the update of the paging control state and the logic in `_getScrollBounds`, as we are running this logic in response to `onScrollMathStop` and no longer for each `onscroll` event. But the setting of the disabled states is ordered in such a way that we always set the disabled state for the top paging control first, which triggers Spotlight logic to determine the last spotted control; at this point, we have not had a chance to update the bottom paging control yet (as it is still disabled), and so Spotlight spots the first child of the root. If we reverse the order of these calls, we have the opposite problem.
### Fix

We now call `updatePagingControlState` in response to `onScroll` events from ScrollMath, as this is technically what was occurring before the original fix. As a bonus, we no longer need to explicitly handle `onScrollStop` events from ScrollMath.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
