### PR TITLE
BHV-17758: moon.Tooltip can not adjust position when absoluteShowing is false

### DIFF
--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -204,7 +204,7 @@
 		* @private
 		*/
 		showTooltip: function(inSender, inEvent) {
-			if (!this.activator.getAbsoluteShowing()) {
+			if (!this.activator || !this.activator.getAbsoluteShowing()) {
 				return;
 			}
 			this.show();


### PR DESCRIPTION
### Issue:

Tooltip is adjust it's position after show.
When tooltip got a requestShow, it try to show itself after 500ms.
But, if it's parent hidden within 500ms and show it again then
tooltip will not able to measure it's position because getAbsoluteBounds will return 0;
### Fix:

Check absoluteShowing just before show tooltip, so it can stop show job when it's parent hidden.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
