### PR TITLE
Fixes BHV-17758

### DIFF
--- a/source/TooltipDecorator.js
+++ b/source/TooltipDecorator.js
@@ -157,11 +157,12 @@
 		*/
 		showingChangedHandler: enyo.inherit(function (sup) {
 			return function (sender, event) {
-				if(!event.showing) {
+				sup.apply(this, arguments);
+				if (!event.showing) {
 					this.requestHideTooltip();
 				}
 			};
-		}),
+		})
 	});
 
 })(enyo, this);


### PR DESCRIPTION
## Issue

If the TooltipDecorator or any of is ancestors is hidden before the Tooltip job to show has fired, the Tooltip will still show but at the wrong position because the bounds of the activator are all `0` because it is hidden.
## Fix

Cancel any pending tooltips if the decorator or any of its ancestors is hidden
## Notes

Replaces PR #1767 

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
