### PR TITLE
BHV-17002: Outside controls can get focus when contextual popup opened w...

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -381,8 +381,8 @@
 		*/
 		keydown: function (inSender, inEvent) {
 			if (this.showing && this.autoDismiss && inEvent.keyCode == 27 /* escape */) {
-				enyo.Spotlight.spot(this.activator);
 				this.hide();
+				enyo.Spotlight.spot(this.activator);
 			}
 		},
 
@@ -390,9 +390,9 @@
 		* @private
 		*/
 		closePopup: function (inSender, inEvent) {
-			enyo.Spotlight.spot(this.activator);
 			this.$.closeButton.removeClass('pressed');
 			this.hide();
+			enyo.Spotlight.spot(this.activator);
 		},
 
 		/**
@@ -453,8 +453,12 @@
 			}
 			return this.modal && this.spotlightModal;
 		},
+
+		/**
+		* @private
+		*/		
 		capturedFocus: function(inSender, inEvent) {
-			if(this.spotlightModal) {
+			if(this.modal && this.spotlightModal) {
 				enyo.Spotlight.spot(this);
 				return true;
 			}
@@ -479,9 +483,9 @@
 		*/
 		onLeave: function (oSender, oEvent) {
 			if (oEvent.originator == this) {
-				enyo.Spotlight.spot(this.activator);
 				this.popupActivated = false;
 				this.hide();
+				enyo.Spotlight.spot(this.activator);
 			}
 		},
 


### PR DESCRIPTION
...ith spotlightModal true

This PR is for fixing a regression.

Issue:
What we made change on the previous PR (https://github.com/enyojs/moonstone/pull/1754) is when outside of popup is getting focused then get focus back to popup by capturing event.
But, if user close popup by close button in 5way mode, there is no focus on screen because we get focus back to popup then hide.

Fix:
Hide and then spot on activator. (Not spot then hide)
And I changed the condition to look at modal property also to match condition with capturedKeyDown

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
