### PR TITLE
ENYO-468: Remove conditional related to falsy locale.

### DIFF
--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -181,8 +181,8 @@
 			};
 
 			fmtParams.locale = this.locale;
-			this.iLibLocale = null;
 			ilib.setLocale(this.locale);
+			this.iLibLocale = ilib.getLocale();
 			this._tf = new ilib.DateFmt(fmtParams);
 		},
 
@@ -331,6 +331,7 @@
 			// Our own locale property has changed, so we need to rebuild our child pickers
 			if (typeof ilib !== 'undefined') {
 				ilib.setLocale(this.locale);
+				this.iLibLocale = ilib.getLocale();
 			}
 			this.refresh();
 		},


### PR DESCRIPTION
### Issue

When switching between multiple samples in Sampler, the locale was not being reset.
### Fix

`ilib` had recently made a change to support the setting of `null` values for the locale, which would set the locale to "local" by default. This eliminates the need for the conditional when initializing `moon.DateTimePickerBase` as the default value of locale is `null`, which will appropriately set the locale. Additionally, there is some clean-up for the use of the `iLibLocale` var.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
