### PR TITLE
BHV-17944: Display an ellipsis for overflowing text in an unfocused input.

### DIFF
--- a/css/Input.less
+++ b/css/Input.less
@@ -10,6 +10,10 @@
 		color: @moon-spotlight-text-color;
 		background-color: @moon-spotlight-background-color;
 	}
+
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .moon-input-decorator {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1827,6 +1827,9 @@
   cursor: pointer;
   background: transparent;
   color: #4b4b4b;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .moon-input::selection {
   color: #ffffff;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1827,6 +1827,9 @@
   cursor: pointer;
   background: transparent;
   color: #4b4b4b;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .moon-input::selection {
   color: #ffffff;

--- a/samples/InputSample.js
+++ b/samples/InputSample.js
@@ -19,6 +19,9 @@ enyo.kind({
 				{kind: "moon.Input", type:"number", placeholder: "Enter number", oninput:"handleInput", onchange:"handleChange"}
 			]},
 			{kind: "moon.InputDecorator", components: [
+				{kind: "moon.Input", placeholder: "Placeholder for value with ellipsis", value: "This is the initial value that is of a certain length to display an ellipsis.", oninput:"handleInput", onchange:"handleChange"}
+			]},
+			{kind: "moon.InputDecorator", components: [
 				{kind: "moon.Input", placeholder: "Dismiss on Enter", dismissOnEnter:true, oninput:"handleInput", onchange:"handleChange"}
 			]},
 			{kind: "moon.InputDecorator", disabled: true, components: [


### PR DESCRIPTION
### Issue

Currently, text that overflows the bounds of a `moon.Input` does not display an ellipsis.
### Fix

We add styling to display an ellipsis for overflowing text in an unfocused `moon.Input`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
