### PR TITLE
ENYO-523: Leaving the ContextualPopupDecorator checks pointer mode

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -7,7 +7,7 @@
 	* @property {Object} activator - A reference to the activating object.
 	* @public
 	*/
-	
+
 	/**
 	* Fires when the contextual popup is to be hidden. No additional data is included
 	* with this event.
@@ -16,7 +16,7 @@
 	* @type {Object}
 	* @public
 	*/
-	
+
 	/**
 	* Fires when the contextual popup is activated. Extends {@link enyo.Popup#onActivate}.
 	*
@@ -25,7 +25,7 @@
 	* @property {Object} sentFromPopup - A reference to the popup.
 	* @public
 	*/
-	
+
 	/**
 	* {@link moon.ContextualPopup} is a popup window control with Moonstone visual
 	* styling applied. It extends {@link enyo.Popup} and is designed to be used with
@@ -200,9 +200,9 @@
 		and the dependent decorator code inorder to handle some special cases.
 		*/
 		hide: function(inSender, e) {
-			
+
 			 if (this.tapCaptured) {
-				this.tapCaptured = false;			
+				this.tapCaptured = false;
 			} else {
 				this.popupActivated = false;
 			}
@@ -250,7 +250,7 @@
 			var rHeight = (r.height === undefined) ? (r.bottom - r.top) : r.height;
 			var rWidth = (r.width === undefined) ? (r.right - r.left) : r.width;
 
-			return {top: r.top + pageYOffset, left: r.left + pageXOffset, height: rHeight, width: rWidth, bottom: r.top + pageYOffset + rHeight, right: r.left + pageXOffset + rWidth};			
+			return {top: r.top + pageYOffset, left: r.left + pageXOffset, height: rHeight, width: rWidth, bottom: r.top + pageYOffset + rHeight, right: r.left + pageXOffset + rWidth};
 		},
 
 		/**
@@ -282,7 +282,7 @@
 				var bounds = {top: null, left: null};
 
 				if(this.direction === 'left') {
-					if(clientRect.width + popupMargin < this.activatorOffset.left) { 
+					if(clientRect.width + popupMargin < this.activatorOffset.left) {
 						this.resetDirection();
 						this.addClass('right');
 
@@ -456,7 +456,7 @@
 
 		/**
 		* @private
-		*/		
+		*/
 		capturedFocus: function(inSender, inEvent) {
 			if(this.modal && this.spotlightModal) {
 				enyo.Spotlight.spot(this);
@@ -482,7 +482,7 @@
 		* @private
 		*/
 		onLeave: function (oSender, oEvent) {
-			if (oEvent.originator == this) {
+			if (oEvent.originator == this && !enyo.Spotlight.getPointerMode()) {
 				this.popupActivated = false;
 				this.hide();
 				enyo.Spotlight.spot(this.activator);


### PR DESCRIPTION
Also, incidental automated trailing whitespace clean-up.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
