### PR TITLE
ENYO-524: Set animationEnd to always noop when showing popup.

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -325,10 +325,10 @@
 		*/
 		showingChanged: function() {
 			if (this.showing) {
+				// need to call this early to prevent race condition where animationEnd
+				// originated from a "hide" context but we are already in a "show" context
+				this.animationEnd = enyo.nop;
 				if (this.animate) {
-					// need to call this early to prevent race condition where animationEnd
-					// originated from a "hide" context but we are already in a "show" context
-					this.animationEnd = enyo.nop;
 					// if we are currently animating the hide transition, release
 					// the events captured when popup was initially shown
 					if (this.isAnimatingHide) {


### PR DESCRIPTION
### Issue

Because `moon.Popup` can be shown without any animation (i.e. direct hide/show), it's possible that the popup can be hidden normally (i.e. with animation), and then immediately shown directly. This causes the scrim state to become out of sync (as we read the current showing state to show/hide the scrim, and thus at the end of the hiding animation, the showing state is `true`).
### Fix

We had previously only noop'ed `animationEnd` when showing the popup in an animated state - we now do this in the non-animated state as well.
### Note

OSX auto-corrected "noop" to "hoop", which looked close enough at a glance.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
