### PR TITLE
Enyo 525 Use native digit in Date and Time picker

### DIFF
--- a/samples/TimePickerSample.js
+++ b/samples/TimePickerSample.js
@@ -13,7 +13,6 @@ enyo.kind({
 				{kind: "moon.ExpandablePicker", name: "pickerLocale", noneText: "No Locale Selected", content: "Choose Locale", onChange:"pickerHandler", components: [
 					{content: "Use Default Locale", active: true},
 					{content: 'jp-JP'},
-					{content: 'fa-IR'},
 					{content: 'en-US'},
 					{content: 'ko-KR'},
 					{content: "th-TH"},	//Thailand

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -323,6 +323,7 @@
 				type: 'time',
 				time: 'h',
 				clock: clockPref !== 'locale' ? clockPref : undefined,
+				useNative: false,
 				timezone: 'local'
 			};
 			if (this.locale) {


### PR DESCRIPTION
## Issue

DatePicker and TimePicker shows western digit even though its locale is "fa-IR"
## Cause

`useNative: false` property in ilib.DateFmt prevent to use native character
## Fix

Remove `useNative: false`

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
