### PR TITLE
ENYO-483: Replace calls to stabilize() with explicit scroll events

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -198,7 +198,7 @@
 			// ScrollMath.stabilize(), ensuring
 			// that we stay in bounds
 			m.setScrollX(-left);
-			if (p != m.x) {
+			if (p != -m.x) {
 				// We won't get a native scroll event,
 				// so need to make one ourselves
 				m.doScroll();
@@ -218,7 +218,7 @@
 			// ScrollMath.stabilize(), ensuring
 			// that we stay in bounds
 			m.setScrollY(-top);
-			if (p != m.y) {
+			if (p != -m.y) {
 				// We won't get a native scroll event,
 				// so need to make one ourselves
 				m.doScroll();


### PR DESCRIPTION
A recent launch time regression for the SmartShare app was traced
back to extraneous layouts in the app, which were caused by
unnecessary onScroll events resulting from calls to
ScrollMath.stabilize(). In Enyo core, we reworked stabilize() to
eliminate the unnecessary scroll events. However,
moon.ScrollStrategy was relying on stabilize() generating scroll
events to implement the hold-to-repeat behavior of its paging
controls, so in this PR we replace the calls to stabilize() with
explicit calls to generate the required scroll events.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
