### PR TITLE
ENYO-525 Use native character for Date & Time picker

### DIFF
--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -174,7 +174,6 @@
 		initILib: function () {
 			var fmtParams = {
 				type: this.iLibFormatType,
-				useNative: false,
 				timezone: 'local',
 				length: 'full',
 				date: 'dmwy'

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -323,7 +323,6 @@
 				type: 'time',
 				time: 'h',
 				clock: clockPref !== 'locale' ? clockPref : undefined,
-				useNative: false,
 				timezone: 'local'
 			};
 			if (this.locale) {


### PR DESCRIPTION
## Issue

DatePicker and TimePicker shows western digit even though its locale is "fa-IR"
## Cause

`useNative: false` property in ilib.DateFmt prevent to use native character
## Fix

Remove `useNative: false`

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
