### PR TITLE
BHV-17963: moon.Header showing sub Title on the right side when content ...

### DIFF
--- a/source/Header.js
+++ b/source/Header.js
@@ -624,7 +624,9 @@
 				subtitle = this.get('titleBelow');
 			if ((this.get('type') == 'small') && subtitle) {
 				this.$.title.set('allowHtml', true);
-				this.$.title.set('content', title + '   ' + '<span class="moon-sub-header-text moon-header-sub-title">' + subtitle + '</span>');
+				this.$.title.set('content', enyo.Control.prototype.rtl ? 
+					'<span class="moon-sub-header-text moon-header-sub-title">' + subtitle + '</span>' + '   ' + title :
+					title + '   ' + '<span class="moon-sub-header-text moon-header-sub-title">' + subtitle + '</span>');
 			} else {
 				this.$.title.set('allowHtml', this.get('allowHtml') );
 				this.$.title.set('content', title);


### PR DESCRIPTION
...is English and country is RTL

Issue:
moon.Header is changing it's text-alignment based on whether language setting is RTL or not
But, title and sub-title position is fixed because we are using HTML tag like this: "title <span> subtitle </span>".
So, if we are using English in RTL locale then subtitle is still positioned on right side of title.

Fix:
Switch sub-title position based on enyo.Control.prototype.rtl, so that subtitle can be positioned on left side of title in RTL locale.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
