### PR TITLE
BHV-17974: PopUpSample: SpotlightModal doesn't retains its spotlight whe...

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -996,7 +996,9 @@
 
 			enyo.Spotlight.unmute(this);
 			// Spot the active panel
-			enyo.Spotlight.spot(this.getActive());
+			if (sendEvents) {
+				enyo.Spotlight.spot(this.getActive());
+			}
 
 		},
 


### PR DESCRIPTION
...n active.

Issue:
SpotlightModal in PopupSample is not able to retains its spotlight. It goes to the moon.Scroller component.

Fix:
In finishTransition function of Panels, now spotting the component based on the sendEvents value.

DCO-1.1-Signed-Off-By: Anshu Agrawal anshu.agrawal@lge.com
