### PR TITLE
BHV-17852: Paging controls not disabled at bounds

### DIFF
--- a/css/CheckboxItem.less
+++ b/css/CheckboxItem.less
@@ -4,7 +4,7 @@
 	// Checkbox 
 	.moon-checkbox {
 		position: absolute;
-		top: @moon-spotlight-outset - 2;
+		top: @moon-spotlight-outset - 4;
 		right: @moon-spotlight-outset - 4;
 	}
 	// Label 

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -895,7 +895,7 @@
 }
 .moon-checkbox-item .moon-checkbox {
   position: absolute;
-  top: 8px;
+  top: 6px;
   right: 6px;
 }
 .moon-checkbox-item .moon-checkbox-item-label-wrapper {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -895,7 +895,7 @@
 }
 .moon-checkbox-item .moon-checkbox {
   position: absolute;
-  top: 8px;
+  top: 6px;
   right: 6px;
 }
 .moon-checkbox-item .moon-checkbox-item-label-wrapper {

--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -630,26 +630,38 @@
 		* @private
 		*/
 		requestScrollIntoView: function(sender, event) {
-			var showVertical, showHorizontal,
-				bubble = false;
 			if (!enyo.Spotlight.getPointerMode() || event.scrollInPointerMode === true) {
-				showVertical = this.showVertical();
-				showHorizontal = this.showHorizontal();
-				this.scrollBounds = this._getScrollBounds();
-				this.setupBounds();
-				this.scrollBounds = null;
-				if (showVertical || showHorizontal) {
-					this.animateToControl(event.originator, event.scrollFullPage, event.scrollInPointerMode || false);
-					if ((showVertical && this.$.scrollMath.bottomBoundary) || (showHorizontal && this.$.scrollMath.rightBoundary)) {
-						this.alertThumbs();
-					}
-				} else {
-					// Scrollers that don't need to scroll bubble their onRequestScrollIntoView,
-					// to allow items in nested scrollers to be scrolled
-					bubble = true;
-				}
+				return this.scrollToView(event);
 			}
-			return !bubble;
+			return true;
+		},
+
+		/**
+		* Updates scroll bounds by scrolling into a view based on 
+		* event of animator control.
+		*
+		* @private
+		*/
+		scrollToView: function (animator) {
+			var showVertical = this.showVertical(),
+				showHorizontal = this.showHorizontal();
+				
+			this.scrollBounds = this._getScrollBounds();
+			this.setupBounds();
+			this.scrollBounds = null;
+			if (showVertical || showHorizontal) {
+				if(animator && animator.originator) {
+					this.animateToControl(animator.originator, animator.scrollFullPage, animator.scrollInPointerMode || false);
+				}
+				if ((showVertical && this.$.scrollMath.bottomBoundary) || (showHorizontal && this.$.scrollMath.rightBoundary)) {
+					this.alertThumbs();
+					this.updatePagingControlState();
+				}
+				return true;
+			}
+			// Scrollers that don't need to scroll bubble their onRequestScrollIntoView,
+			// to allow items in nested scrollers to be scrolled
+			return false;
 		},
 
 		/**
@@ -660,12 +672,7 @@
 		*/
 		requestSetupBounds: function(sender, event) {
 			if (this.generated) {
-				this.scrollBounds = this._getScrollBounds();
-				this.setupBounds();
-				this.scrollBounds = null;
-				if ((this.showVertical() && this.$.scrollMath.bottomBoundary) || (this.showHorizontal() && this.$.scrollMath.rightBoundary)) {
-					this.alertThumbs();
-				}
+				this.scrollToView(false);
 			}
 			return true;
 		},


### PR DESCRIPTION
Issue: 
Paging controls are not disabled when the scroller bounds are
reached. Two scenarios where it can be observed are;
-Checkbox items inside Scroller. Scroll height of Checkbox items are more than its client height, due to
which scroll bounds are not calculated properly in MoonScrolStrategy.
-When using 5 way key, two times down/up key press is required to
actually disable paging controls. Reason being paging controls are
updated before scrolling has taken place.

Fix:
Top position of Checkbox item is adjusted to have proper bounds.
Paging controls are updated after the scrolling took place i.e in
requestScrolIntoView.
Refractored requestScrollIntoView.

Enyo-DCO-1.1-Signed-off-by: Anish Ramesan anish.ramesan@lge.com
