### PR TITLE
BHV-17980: update _marquee_contentChanged() for text align of marquee te...

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -703,6 +703,7 @@
 				this.$.marqueeText.setContent(this.content);
 			}
 			if (this.generated) {
+				this._marquee_invalidateMetrics();
 				this._marquee_detectAlignment();
 			}
 			this._marquee_reset();


### PR DESCRIPTION
## Issue

In the RTL mode, text align should be right. But, during the marquee flow, marquee text has "text-align:left". At that time, if developer change the content dynamically to short text, the text align to left.(Expected alignment is right)
## Fix

Update _marquee_contentChanged function to apply proper text-align of the text
Since content is already changed, initialize _marquee_distance and _marquee_fits by calling _marquee_invalidateMetrics()

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com
