### PR TITLE
ENYO-530 : DataGridList: Paging control state isn't updated

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -641,6 +641,7 @@
 				if (showVertical || showHorizontal) {
 					this.animateToControl(event.originator, event.scrollFullPage, event.scrollInPointerMode || false);
 					if ((showVertical && this.$.scrollMath.bottomBoundary) || (showHorizontal && this.$.scrollMath.rightBoundary)) {
+						this.updatePagingControlState();
 						this.alertThumbs();
 					}
 				} else {


### PR DESCRIPTION
After applying https://github.com/enyojs/moonstone/commit/c2658694e490b6e27fa45fbcbf5d16be8216cebb, updatePagingControlState() handles paging controls' enable/disable status
But after calling **this.animateToControl(event.originator, event.scrollFullPage, event.scrollInPointerMode || false);** in requestScrollIntoView, we should check paging controls' enable/disable status one more time.
Because **moon.ScrollStrategy._getScrollBounds()** will return bounds of previous status when it is called before this.animateToControl

Enyo-DCO-1.1-Signed-off-by: SoonGil Choi soongil.choi@lge.com
