### PR TITLE
Fixes ENYO-530, BHV-17852

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -542,7 +542,10 @@
 				clearTimeout(this._updatePagingJob);
 			}
 
-			this._updatePagingJob = setTimeout(this.bindSafely('updatePagingControlState'), 32);
+			this._updatePagingJob = setTimeout(this.bindSafely(function () {
+				this.updatePagingControlState();
+				this._updatePagingJob = null;
+			}), 32);
 		},
 
 		/**


### PR DESCRIPTION
## Issue

When scrolling without animation, `updatePagingControlState` wasn't being called because it was only called during bounds setup and in response to ScrollMath.onScroll. Actions like `scrollTo` or 5-waying to a control in a list would therefore not correctly update the paging controls.
## Fix

Move paging control state check into effectScroll where all scroll actions bottleneck.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
