### PR TITLE
Fixes BHV-17852

### DIFF
--- a/css/CheckboxItem.less
+++ b/css/CheckboxItem.less
@@ -1,5 +1,6 @@
 .moon-checkbox-item {
 	position: relative;
+	overflow: hidden;
 
 	// Checkbox 
 	.moon-checkbox {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -892,6 +892,7 @@
 }
 .moon-checkbox-item {
   position: relative;
+  overflow: hidden;
 }
 .moon-checkbox-item .moon-checkbox {
   position: absolute;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -892,6 +892,7 @@
 }
 .moon-checkbox-item {
   position: relative;
+  overflow: hidden;
 }
 .moon-checkbox-item .moon-checkbox {
   position: absolute;


### PR DESCRIPTION
## Issue

Without overflow: hidden, when a CheckboxItem is included in a ListAction list, it can be spotted by 5-way but may cause the paging controls to be incorrect. This occurs when spotting the last item in the list because it is scrolled into view but the overflowing tap area does not completely come into the viewport causing the scroller to report there is still more to scroll.
## Fix

Hide overflow of checkbox items
## Note

Requires PR #1787

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
