### PR TITLE
ENYO-544: Handle onStabilize event in MoonScrollStrategy.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -194,10 +194,8 @@
 		setScrollLeft: function(left) {
 			var m = this.$.scrollMath,
 				p = this.scrollLeft;
-			// This will result in a call to
-			// ScrollMath.stabilize(), ensuring
-			// that we stay in bounds
 			m.setScrollX(-left);
+			m.stabilize();
 			if (p != -m.x) {
 				// We won't get a native scroll event,
 				// so need to make one ourselves
@@ -214,10 +212,8 @@
 		setScrollTop: function(top) {
 			var m = this.$.scrollMath,
 				p = this.scrollTop;
-			// This will result in a call to
-			// ScrollMath.stabilize(), ensuring
-			// that we stay in bounds
 			m.setScrollY(-top);
+			m.stabilize();
 			if (p != -m.y) {
 				// We won't get a native scroll event,
 				// so need to make one ourselves


### PR DESCRIPTION
### Issue

With the recent optimizations for scrolling, there was an issue with the scroll position not updating properly after scrollable content size had changed.
### Fix

We ensure that `scrollMath` in `MoonScrollStrategy` handles the `onStabilize` event.
### Note

Please ignore the branch name - was originally going to stick it under a pre-existing issue.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
