### PR TITLE
ENYO-432: Add sample Input with initial value.

### DIFF
--- a/samples/InputSample.js
+++ b/samples/InputSample.js
@@ -19,6 +19,9 @@ enyo.kind({
 				{kind: "moon.Input", type:"number", placeholder: "Enter number", oninput:"handleInput", onchange:"handleChange"}
 			]},
 			{kind: "moon.InputDecorator", components: [
+				{kind: "moon.Input", placeholder: "Placeholder for initial value", value: "This is the initial value", oninput:"handleInput", onchange:"handleChange"}
+			]},
+			{kind: "moon.InputDecorator", components: [
 				{kind: "moon.Input", placeholder: "Placeholder for value with ellipsis", value: "This is the initial value that is of a certain length to display an ellipsis.", oninput:"handleInput", onchange:"handleChange"}
 			]},
 			{kind: "moon.InputDecorator", components: [


### PR DESCRIPTION
### Issue

There are no samples that demonstrate a `moon.Input` with an initial text value. This would aid in testing issues with the VKB.
### Fix

Add a `moon.Input` that has an initial value.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
