### PR TITLE
ENYO-524: Fix moon.Popup scrim state issue

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -325,27 +325,21 @@
 		*/
 		showingChanged: function() {
 			if (this.showing) {
-				if (this.animate) {
+				if (this.isAnimatingHide) {
 					// need to call this early to prevent race condition where animationEnd
 					// originated from a "hide" context but we are already in a "show" context
 					this.animationEnd = enyo.nop;
+					enyo.Popup.count--;
 					// if we are currently animating the hide transition, release
 					// the events captured when popup was initially shown
-					if (this.isAnimatingHide) {
-						if (this.captureEvents) {
-							this.release();
-						}
-						this.isAnimatingHide = false;
+					if (this.captureEvents) {
+						this.release();
 					}
+					this.isAnimatingHide = false;
 				}
 				this.activator = enyo.Spotlight.getCurrent();
-				moon.Popup.count++;
-				this.applyZIndex();
 			}
 			else {
-				if (moon.Popup.count > 0) {
-					moon.Popup.count--;
-				}
 				if (this.generated) {
 					this.respotActivator();
 				}
@@ -368,6 +362,7 @@
 						if (ev.originator === this) {
 							// Delay inherited until animationEnd
 							this.inherited(args);
+							this.animationEnd = enyo.nop;
 							this.isAnimatingHide = false;
 						}
 					});


### PR DESCRIPTION
Issue:

When animating, moon.Popup uses the animationend event to delay
certain showingChanged() logic (including the logic to show / hide
the scrim) until after the animation completes. If the popup is
shown again before the hide animation is done, we need to remove
the animationend handler and perform a subset of its operations
immediately. The logic we were using to detect this case had not
been updated to accommodate the recently added directShow()
feature, which meant that the scrim state could get out of sync
in certain circumstances -- specifically, when the popup was
"directly" shown while a hide animation was still in progress.

Fix:

Update the logic in showingChanged() to make sure we remove the
animationend handler whenever we're shown while a hide animation
is in progress.

Also: Remove vestigial moon.Popup.count logic and ensure that we
properly update enyo.Popup.count in the case where we short-
circuit the animationend handler.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
