### PR TITLE
Fix for: ENYO-435 (taken from #1757)

### DIFF
--- a/samples/IntegerPickerSample.html
+++ b/samples/IntegerPickerSample.html
@@ -11,6 +11,7 @@
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
+	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../moonstone/package.js" type="text/javascript"></script>
 	<script src="../../spotlight/package.js" type="text/javascript"></script>
 	<!-- -->

--- a/samples/IntegerPickerSample.js
+++ b/samples/IntegerPickerSample.js
@@ -11,7 +11,21 @@ enyo.kind({
 			{kind: 'moon.FormCheckbox', content: 'Animate', checked: true, prop: 'animate', onchange: 'checked'},
 			{kind: 'moon.FormCheckbox', content: 'Wrap', prop: 'wrap', onchange: 'checked'},
 			{kind: 'moon.FormCheckbox', content: 'Padding (5 digits)', onchange: 'paddingChecked'},
-			{kind: 'moon.FormCheckbox', content: 'Disabled', prop: 'disabled', onchange: 'checked'}
+			{kind: 'moon.FormCheckbox', content: 'Disabled', prop: 'disabled', onchange: 'checked'},
+			{kind: "moon.ExpandablePicker", name:"localePicker", noneText: "No Language Selected", content: "Choose Locale", onChange: "setLocale", components: [
+				{content: 'Use Default Locale', active: true},
+				{content: "en-US"}, //United States, firstDayOfWeek: 0				
+				{content: "fa-IR"}, //Iran persian calendar
+				{content: "th-TH"}, //Thailand
+				{content: "jp-JP"}, //Japan
+				{content: "ko-KO"}, //Korea
+				{content: "und-AE"}, //United Arab Emirates
+				{content: "und-AG"}, //Antigua and Barbuda
+				{content: "de-DE"}, // Germany
+				{content: "fr-FR"}, // France
+				{content: "it-IT"}, // Italy
+				{content: "es-ES"} // Spain
+			]}
 		]},
 		{kind: 'moon.Divider', content: 'Result'},
 		{kind: 'moon.BodyText', name: 'value', content: 'No change yet'}
@@ -27,5 +41,14 @@ enyo.kind({
 	paddingChecked: function (sender, event) {
 		this.$.picker.set('digits', sender.checked? 5 : null);
 		this.$.picker.render();
+	},
+	setLocale: function(sender, inEvent) {
+		if (ilib) {
+			var locale = inEvent.selected.content,
+				val = (locale == "Use Default Locale") ? null : locale;
+			ilib.setLocale(val);
+			this.$.picker.setLocale(val);			
+		}
+		return true;
 	}
 });

--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -53,6 +53,17 @@
 		* @lends moon.IntegerPicker.prototype
 		*/
 		published: {
+			/**
+			*
+			* Current locale used for formatting. May be set after the control is
+			* created, in which case the control will be updated to reflect the
+			* new value.  Only valid if [iLib]{@glossary ilib} is loaded.
+			*
+			* @type {String}
+			* @default ''
+			* @public
+			*/
+			locale: '',
 
 			/**
 			* When `true`, button is shown as disabled and does not generate tap events.
@@ -227,6 +238,9 @@
 		create: function () {
 			this.inherited(arguments);
 			this.verifyValue();
+			if (typeof ilib !== 'undefined') {
+				this.initILib();
+			}
 			this.updateOverlays();
 		},
 
@@ -273,9 +287,27 @@
 		/**
 		* @private
 		*/
+		initILib: function () {
+			this.locale = this.locale || new ilib.LocaleInfo(this.locale || undefined).locale;
+
+			var fmtParams = {
+				locale: this.locale,
+				type: "number",
+				style: "nogrouping"
+			};
+
+			this._numFmt = new ilib.NumFmt(fmtParams);
+		},
+
+		/**
+		* @private
+		*/
 		setupItem: function (inSender, inEvent) {
-			var index = inEvent.index;
+			var index = this._index = inEvent.index;
 			var content = this.labelForValue(this.indexToValue(index % this.range));
+			if (typeof ilib !== 'undefined') {
+				content = this._numFmt.format(content);
+			}
 			this.$.item.setContent(content);
 		},
 
@@ -293,6 +325,13 @@
 			}
 
 			return value;
+		},
+		/**
+		* @private
+		*/
+		localeChanged: function () {
+			this.initILib();
+			this.$.repeater.renderRow(this._index);
 		},
 
 		/**

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -81,21 +81,21 @@
 	});
 	
 	/**
-	* {@link moon.HourPicker} is a helper kind used by {@link moon.TimePicker}. It is
-	*  not intended for use in other contexts.
+	* {@link moon.HourMinutePickerBase} is a helper kind used by {@link moon.TimePicker}. 
+	*  It is not intended for use in other contexts.
 	*
-	* @class moon.HourPicker
+	* @class moon.MinutePicker
 	* @extends moon.IntegerPicker
 	* @ui
 	* @protected
 	*/
 	enyo.kind(
-		/** @lends moon.HourPicker.prototype */ {
+		/** @lends moon.HourMinutePickerBase.prototype */ {
 
 		/**
 		* @private
 		*/
-		name: 'moon.HourPicker',
+		name: 'moon.HourMinutePickerBase',
 
 		/**
 		* @private
@@ -110,28 +110,12 @@
 		/**
 		* @private
 		*/
-		min: 0,
-
-		/**
-		* @private
-		*/
-		max: 23,
-
-		/**
-		* @private
-		*/
-		value: null,
-
-		/**
-		* @private
-		*/
 		formatter: null,
 
 		/**
 		* @private
 		*/
 		wrap: true,
-
 
 		/**
 		* @private
@@ -148,9 +132,94 @@
 		* @private
 		*/
 		setupItem: function (inSender, inEvent) {
-			var hour = this.format(inEvent.index % this.range);
-			this.$.item.setContent(hour);
-		},
+			var value = this.format(inEvent.index % this.range);
+			this.$.item.setContent(value);
+		}
+	});
+	/**
+	* {@link moon.MinutePicker} is a helper kind used by {@link moon.TimePicker}. 
+	*  It is not intended for use in other contexts.
+	*
+	* @class moon.MinutePicker
+	* @extends moon.HourMinutePickerBase
+	* @ui
+	* @protected
+	*/
+	enyo.kind(
+		/** @lends moon.MinutePicker.prototype */ {
+
+		/**
+		* @private
+		*/
+		name: 'moon.MinutePicker',
+		/**
+		* @private
+		*/
+		kind: 'moon.HourMinutePickerBase',
+
+		/**
+		* @private
+		*/
+		min: 0,
+
+		/**
+		* @private
+		*/
+		max: 59,
+
+		/**
+		 * Formats the minute at `index` for the current locale
+		 *
+		 * @param  {Number} index - Minute between 0 and 59
+		 * @return {String}       - Formatted minute
+		 * @private
+		 */
+		format: function (index) {
+			var minute;
+
+			if (this.date) { // ilib enabled
+				this.date.minute = index;
+				minute = this.formatter.format(this.date);
+			} else {	// Have TimePicker format the minutes
+				minute = this.formatter.formatMinute(index);
+			}
+
+			return minute;
+		}
+	});
+
+	/**
+	* {@link moon.HourPicker} is a helper kind used by {@link moon.TimePicker}. It is
+	*  not intended for use in other contexts.
+	*
+	* @class moon.HourPicker
+	* @extends moon.HourMinutePickerBase
+	* @ui
+	* @protected
+	*/
+	enyo.kind(
+		/** @lends moon.HourPicker.prototype */ {
+
+		/**
+		* @private
+		*/
+		name: 'moon.HourPicker',
+
+		/**
+		* @private
+		*/
+		kind: 'moon.HourMinutePickerBase',
+
+		/**
+		* @private
+		*/
+		min: 0,
+
+		/**
+		* @private
+		*/
+		max: 23,
+
 
 		/**
 		 * Formats the hour at `index` for the current locale
@@ -192,7 +261,6 @@
 			};
 		})
 	});
-	
 	/**
 	* {@link moon.TimePicker} is a [control]{@link enyo.Control} used to allow the
 	* selection of (or to simply display) a time expressed in hours and minutes, with an
@@ -323,13 +391,15 @@
 				type: 'time',
 				time: 'h',
 				clock: clockPref !== 'locale' ? clockPref : undefined,
-				useNative: false,
 				timezone: 'local'
 			};
 			if (this.locale) {
 				fmtParams.locale = this.locale;
 			}
 			this.hourFormatter = new ilib.DateFmt(fmtParams);
+
+			fmtParams.time = 'm';
+			this.minuteFormatter = new ilib.DateFmt(fmtParams);
 	
 			// Get localized meridiem values
 			if (this.meridiemEnable) {
@@ -362,7 +432,7 @@
 					doneArr.push(o);
 				}
 			}
-	
+
 			for(f = 0, l = doneArr.length; f < l; f++) {
 				o = doneArr[f];
 				var valueHours = this.value ? this.value.getHours() : 0;
@@ -381,7 +451,7 @@
 				case 'm':
 					this.createComponent(
 						{classes: 'moon-date-picker-wrap', components:[
-							{kind: 'moon.IntegerPicker', name:'minute', classes:'moon-date-picker-field', min:0, max:59, wrap:true, digits: 2, value: valueMinutes},
+							{kind: 'moon.MinutePicker', name:'minute', formatter: this.minuteFormatter || this, value: valueMinutes},
 							{name: 'minuteLabel', content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}
 						]}
 					);


### PR DESCRIPTION
To avoid history conflicts and dups, have squashed these commits into a single diff commit.

Originally from https://github.com/enyojs/moonstone/pull/1757, see below for details.

Squashed commit of the following:

commit 6e8dc4c1d5a01131a7036c74e9bc01eb019d0ea8
Author: DavidUm david.um@lge.com
Date:   Sat Nov 22 04:41:44 2014 +0900

```
ENYO-435 Resolve conflicts with master again

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
```

commit db676cc406c047c58ae7d7cd5ee832f127fafde9
Author: DavidUm david.um@lge.com
Date:   Sat Nov 22 04:35:01 2014 +0900

```
ENYO-435 Resolve conflicts with master

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
```

commit ffe722cca574757cf6246012c49e451bf49cd2cb
Author: DavidUm david.um@lge.com
Date:   Sat Nov 22 02:55:19 2014 +0900

```
ENYO-435 Merged with Enyo-423

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
```

commit 2b4d40436cd21728b48ed57a012b9bc781b88bd2
Author: DavidUm david.um@lge.com
Date:   Fri Nov 21 09:29:34 2014 +0900

```
ENYO-435 Add hour and minute picker has proper padding.
In some locale, minute '0' should display as "00"

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
```

commit 8d87446f6dceaef3579a39d7fe483ea2eca435b6
Author: DavidUm david.um@lge.com
Date:   Fri Nov 21 03:13:31 2014 +0900

```
ENYO-435 Add default locale option

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
```

commit 7909e1d52fc9dd139a46b86cd38d0aacf697795b
Author: david.um david.um@lge.com
Date:   Wed Nov 19 15:24:56 2014 -0800

```
ENYO-435 Avoid using grouping in digits
This option will remove "," in thousand unit.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
```

commit 5e078cb7b280362f81d07d4cc3465d0f890e8b40
Author: DavidUm david.um@lge.com
Date:   Fri Nov 7 07:22:48 2014 +0900

```
ENYO-435 When locale changed, re-render current value
Todo: we'd better supprot an API to get 'index' from current value.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
```

commit 9a159b9d09d635268185a31c2fb6663f939f4261
Author: DavidUm david.um@lge.com
Date:   Fri Nov 7 07:21:29 2014 +0900

```
ENYO-435 Prepare locale changing option to sample

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
```

commit 90a0b46619e7f95d1dba33ba1e05a3693ccff943
Author: DavidUm david.um@lge.com
Date:   Fri Nov 7 07:00:13 2014 +0900

```
ENYO-435 Translate digits in IntegerPicker
This is requested from HE.
Some region like Iran has own number and they want to use it.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
```
