### PR TITLE
 BHV-17974 PopUpSample: SpotlightModal doesn't retain spotlight when active

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -957,7 +957,7 @@
 				popFrom,
 				toIndex = this.toIndex,
 				fromIndex = this.fromIndex,
-				lastSpot = enyo.Spotlight.getLastControl(this),
+				lastSpot = enyo.Spotlight.getLastControl(),
 				activePanel = this.getActive(),
 				spottable = enyo.Spotlight.Util.isChild(activePanel, lastSpot) ? lastSpot : activePanel;
 


### PR DESCRIPTION
Issue.

When panels are reflowed, `finishTransition` is setting spot back on the active panel, and not on the last spotted child. However, we can not rely on sendEvents, because Card Arranger for instance does not transition by default, thus breaking the spot on card change. 

Fix.

We check to see if the last spotted control is a child of the currently active panel. If it is, we spot that child, otherwise we spot the container (active panel). 

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
