### PR TITLE
BHV-18024: Display negative sign properly for locale

### DIFF
--- a/samples/SliderSample.js
+++ b/samples/SliderSample.js
@@ -21,6 +21,11 @@ enyo.kind({
 				onChanging: "customChanging", onChange: "customChanged", onAnimateFinish: "customAnimateFinish"
 			},
 
+			{kind: "moon.Divider", content: "Slider 4: Negative Values"},
+			{name: "slider4", kind: "moon.Slider",
+				value: 0, min: -100, max: 100, showPercentage: false, onChanging: "sliderChanging", onChange: "sliderChanged"
+			},
+
 			{kind: "moon.Divider", content:"Change Value"},
 			{classes: "moon-hspacing", components: [
 				{kind: "moon.InputDecorator", components: [

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -336,9 +336,7 @@
 		*/
 		create: function() {
 			this.inherited(arguments);
-			if (typeof ilib !== 'undefined') {
-				this._nf = new ilib.NumFmt({type: 'percentage'});
-			}
+			this.showPercentageChanged();
 			this.createComponents(this.moreComponents);
 			this.initValue();
 			this.disabledChanged();
@@ -411,6 +409,21 @@
 		tapAreaClassesChanged: function(was) {
 			this.$.tapArea.removeClass(was);
 			this.$.tapArea.addClass(this.tapAreaClasses);
+		},
+
+		/**
+		* @private
+		*/
+		showPercentageChanged: function(was) {
+			if (enyo.exists(ilib)) {
+				this._nf = new ilib.NumFmt({type: this.showPercentage ? 'percentage' : 'number'});
+			} else {
+				this._nf = {
+					format: this.showPercentage ?
+						function(v) { return v + '%'; } :
+						function(v) { return v; }
+				};
+			}
 		},
 
 		/**
@@ -627,14 +640,8 @@
 		* @private
 		*/
 		calcPopupLabel: function(val) {
-			if (this.showPercentage) {
-				if (typeof ilib !== 'undefined') {
-					val = this._nf.format(Math.round(val));
-				} else {
-					val = Math.round(val) + '%';
-				}
-			}
-			return val;
+			if (this.showPercentage) val = Math.round(val);
+			return this._nf.format(val);
 		},
 
 		/**


### PR DESCRIPTION
moon.Slider was only applying locale-specific formatting to its
value when showPercentage was true. Consequently, the placement
of the negative sign for negative numbers (when showPercentage was
false, as it normally would be for a slider supporting negative
values) was not locale-sensitive. This caused problems because
the text direction of the slider's value popup was properly set
per locale, but the value string was not, resulting in the negative
sign being displayed on the wrong side for some locales.

To address this issue, we now apply locale-specific formatting of
the popup value in all cases.

Also modifying the Slider sample to include a slider with a
negative range, making this type of issue easier to test going
forward. (Credit to Aaron Tam.)

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
