### PR TITLE
BHV-18230: Sync ScrollMath when not animating to new scroll position.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -236,6 +236,7 @@
 				x = Math.max(Math.min(x, b.maxLeft), 0);
 				y = Math.max(Math.min(y, b.maxTop),  0);
 				this.effectScroll(x, y);
+				this.syncScrollMath();
 				this.bubble('onScroll');
 			} else {
 				this._scrollTo(x, y);


### PR DESCRIPTION
### Issue

In a scenario where we have triggered a `requestScrollIntoView` for a control in a list that is placed at some location at the bottom of the place, when we attempt to press the "page up" control, no scrolling occurs. This only occurs where the size of the scrollable content is such that when the "page up" control is pressed, we would need to scroll to the very top of the list, which is effectively a `scrollTop` value of 0. When utilizing `requestScrollIntoView`, we effectively bypass using `ScrollMath.scrollTo` and instead use `MoonScrollStrategy.effectScroll`, which can result in the `ScrollMath` values being out of sync. In this particular scenario, as we had never scrolled before, the `y` value of `ScrollMath` remains at 0, which does not get updated when we focus the scroller and scroll into view the last control. Thus, when we press the "page up" control, we are trying to scroll to the very top, which is a `y` value of 0, which is not different than our current value, resulting in no scrolling action.
### Fix

We make an explicit call to sync `ScrollMath` in `MoonScrollStrategy.scrollTo` when we are not animating the scroll, as this path bypasses `ScrollMath` normally.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
