### PR TITLE
ENYO-557: Handle formatting of minutes when ilib is not loaded.

### DIFF
--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -540,6 +540,9 @@
 			return hour;
 		},
 
+		/**
+		* @private
+		*/
 		formatMinute: function (minute) {
 			return minute;
 		},


### PR DESCRIPTION
### Issue

When `ilib` is not loaded we are attempting to format the minute with a non-existent method, causing an error.
### Fix

We implement the `formatMinute` method in `moon.TimePicker`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
