### PR TITLE
Fixes ENYO-555

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -337,6 +337,9 @@
 		* @private
 		*/
 		showingChanged: function() {
+			// reset flag to prevent hiding popup when Enter pressed on unspottable popup
+			this.preventHide = false;
+			
 			if (this.showing) {
 				if (this.isAnimatingHide) {
 					// need to call this early to prevent race condition where animationEnd


### PR DESCRIPTION
## Issue

If the popup has no spottable children, an [Enter] key down will cause it to be hidden because Spotlight will try to spot the nearest or last control for a 5-way key down. Since there isn't a spottable child, a control outside the popup is focused which triggers `capturedFocus` which hides the Popup.
## Fix

Remember that the key down event was [Enter] if the Popup has no spottable children and prevent the hide in `capturedFocus`.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
