### PR TITLE
BHV-18452: Added line-height rules to non-latin headers of all sizes

### DIFF
--- a/css/Header.less
+++ b/css/Header.less
@@ -118,6 +118,18 @@
 }
 
 // enyo-locale-non-latin
+.enyo-locale-non-latin .moon-header {
+	.moon-header-title, {
+		line-height: @moon-non-latin-header-text-line-height;
+	}
+	&.moon-medium-header .moon-header-title, {
+		line-height: @moon-non-latin-medium-header-line-height;
+	}
+	&.moon-small-header .moon-header-title, {
+		line-height: @moon-non-latin-small-header-line-height;
+	}
+}
+
 /* Special override for Japanese font (LG Display_JP) which, as of 07-Feb-2014
    has a taller baseline. This corrects both Header and InputHeader. 2014-02-24
    Please remove the line-height rule below if this font file is changed. */

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1576,6 +1576,15 @@
   border-top: 2px solid #ffffff;
   border-bottom: 6px solid #ffffff;
 }
+.enyo-locale-non-latin .moon-header .moon-header-title {
+  line-height: 1.5em;
+}
+.enyo-locale-non-latin .moon-header.moon-medium-header .moon-header-title {
+  line-height: 1.5em;
+}
+.enyo-locale-non-latin .moon-header.moon-small-header .moon-header-title {
+  line-height: 1.5em;
+}
 /* Special override for Japanese font (LG Display_JP) which, as of 07-Feb-2014
    has a taller baseline. This corrects both Header and InputHeader. 2014-02-24
    Please remove the line-height rule below if this font file is changed. */

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1576,6 +1576,15 @@
   border-top: 2px solid #ffffff;
   border-bottom: 6px solid #ffffff;
 }
+.enyo-locale-non-latin .moon-header .moon-header-title {
+  line-height: 1.5em;
+}
+.enyo-locale-non-latin .moon-header.moon-medium-header .moon-header-title {
+  line-height: 1.5em;
+}
+.enyo-locale-non-latin .moon-header.moon-small-header .moon-header-title {
+  line-height: 1.5em;
+}
 /* Special override for Japanese font (LG Display_JP) which, as of 07-Feb-2014
    has a taller baseline. This corrects both Header and InputHeader. 2014-02-24
    Please remove the line-height rule below if this font file is changed. */


### PR DESCRIPTION
These variables already existed, but were not implemented.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
