### PR TITLE
ENYO-561: Set alignment when control directionality differs from locale directionality.

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -681,8 +681,9 @@
 				if (!alignment && this.centered) {
 					alignment = 'center';
 				}
-				this.set('_marquee_alignment', alignment);
 			}
+
+			this.set('_marquee_alignment', alignment);
 		},
 
 		/**


### PR DESCRIPTION
### Issue

We are detecting and setting alignment in cases where it's not always necessary. We only need to do this to account for instances where the directionality of the control is different from the overall locale directionality.
### Fix

We add some guard code to only run this code when the control directionality differs from the locale directionality.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
