### PR TITLE
ENYO-579: Marquee takes big initiating time on _marquee_detectAlignment

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -662,6 +662,7 @@
 		* @private
 		*/
 		_marquee_detectAlignment: function (forceAnimate, forceRtl) {
+			if (!enyo.Control.prototype.rtl) return;
 			var alignment = null;
 			// If we will be marqueeing, we know the alignment needs to be set based on directionality.
 			if (forceAnimate || this._marquee_shouldAnimate()) {


### PR DESCRIPTION
Issue:
The detect alignment takes long time on creation time.

Fix:
Skip detect alignment when enyo.Control.prototype.rtl is false, so that we can skip detect alignment on non RTL locale.
(This is short term fix.)

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com