### PR TITLE
Fixes ENYO-526

### DIFF
--- a/source/ExpandableIntegerPicker.js
+++ b/source/ExpandableIntegerPicker.js
@@ -155,7 +155,6 @@
 		bindings: [
 			{from: '.min', to: '.$.picker.min', oneWay: false},
 			{from: '.max', to: '.$.picker.max', oneWay: false},
-			{from: '.value', to: '.$.picker.value'},
 			{from: '.step', to: '.$.picker.step'},
 			{from: '.unit', to: '.$.picker.unit'},
 			{from: '.showCurrentValue', to: '.$.currentValue.showing'},
@@ -198,6 +197,23 @@
 				this.$.picker.reflow();
 				this._needsPickerReflow = false;
 			}
+
+			// if the picker is value-less when opening, set the value as min
+			if (this.open && !this.hasValue()) {
+				this.$.picker.set('value', this.$.picker.min || 0);
+			}
+		},
+
+		/**
+		* Pass the value down to the contained picker if the value is valid. Note that the
+		* validation only ensures it is truthy or 0.
+		*
+		* @private
+		*/
+		valueChanged: function () {
+			if (this.hasValue()) {
+				this.$.picker.set('value', this.value);
+			}
 		},
 
 		/**
@@ -215,7 +231,16 @@
 		* @private
 		*/
 		currentValueText: function () {
-			return (this.value === '') ? this.noneText : this.value + ' ' + this.unit;
+			return !this.hasValue()? this.noneText : this.value + ' ' + this.unit;
+		},
+
+		/**
+		* Utility method to test if the picker is valued
+		*
+		* @private
+		*/
+		hasValue: function () {
+			return !!(this.value || this.value === 0);
 		},
 
 		/**


### PR DESCRIPTION
## Issue

The `value` from the ExpandableIntegerPicker is blindly routed to the contained IntegerPicker via a binding but IntegerPicker isn't designed to handle non-integer values.
## Fix

Since the value-less state is unique to the expandable picker API, only pass the `value` to the picker when the value is valid. Also update `openChanged` to set the value on open if it's currently value-less.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
