### PR TITLE
BHV-18764 : ExpandablePicker has backward capability issues regarding to...

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -231,7 +231,7 @@
 				var override = {client: {highlander: !this.multipleSelection}};
 				this.kindComponents = enyo.Component.overrideComponents(this.kindComponents, override);
 				sup.apply(this, arguments);
-			}
+			};
 		}),
 
 		/**


### PR DESCRIPTION
... active property
## Issue

After https://github.com/enyojs/moonstone/pull/1740, enyo.Group.active is called before highlander property is set because bellowing binding is added in CheckboxItem

```
{from: 'active', to: '$.input.active', oneWay: false}
```

Thus, although multipleSelection is true, enyo.Group.active will handle it like multipleSelection: false
## Fix

Since this is timing issue, override initComponents() and mixing in the desired value for client.highlander

Enyo-DCO-1.1-Signed-off-by: SoonGil Choi (soongil.choi@lge.com)
