### PR TITLE
Revert "CMB-3553: Buttons text are left aligned in DataGridList Sample"

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -594,12 +594,6 @@
 		_marquee_puppetMaster: null,
 
 		/**
-		* We avoid small distance of flow by giving a threshold value of distance.
-		* @private
-		*/
-		_marquee_threshold: 2,
-
-		/**
 		* @method
 		* @private
 		*/
@@ -804,7 +798,7 @@
 		*/
 		_marquee_shouldAnimate: function (distance) {
 			distance = (distance && distance >= 0) ? distance : this._marquee_calcDistance();
-			return (distance > this._marquee_threshold);
+			return (distance > 0);
 		},
 
 		/**


### PR DESCRIPTION
## Issue

There is  regression issue.
Even though text is ellipsis, but it is not start marquee
## Cause

Adding marquee threshold causes mis calculation for starting marquee
## Fix

Revert previous commit.
Although that fix is for making alignment for button text, It makes a side. (More major issue)

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
