### PR TITLE
BHV-18751: Size thumb properly in overscroll with small content

### DIFF
--- a/source/Thumb.js
+++ b/source/Thumb.js
@@ -72,7 +72,7 @@
 				var bd = this.scrollBounds[this.sizeDimension], sbd = this.scrollBounds[d];
 				var overs = 0, overp = 0, over = 0;
 				var ratio = this.getSizeRatio();
-				if (bd >= sbd) {
+				if (bd > sbd) {
 					this.hide();
 					return;
 				}


### PR DESCRIPTION
Due to a recent change in enyo.Scroller, a scroll thumb now appears
in the case where content size is too small to require scrolling,
but the user attempts to scroll with the scroll wheel, resulting in
an overscroll "bounce".

This change actually seems good from a user experience point of
view, but due to some existing logic in moon.ScrollThumb, the thumb
was not properly sized in this case (was shown at minimum size).

This PR updates the logic so that the thumb will be properly sized.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
