### PR TITLE
BHV-18888 : DataGridList scroll to top and shows empty page when add mod...

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -1015,19 +1015,17 @@
 		*
 		* @private
 		*/
-		getAbsoluteShowing: function () {
-			var b = this.getBounds();
+		getAbsoluteShowing: enyo.inherit(function (sup) {
+			return function() {
+				var b = this.getBounds();
 
-			if ((b.height === 0 && b.width === 0)) {
-				return false;
-			}
+				if ((b.height === 0 && b.width === 0)) {
+					return false;
+				}
 
-			if (this.parent && this.parent.getAbsoluteShowing) {
-				return this.parent.getAbsoluteShowing();
-			} else {
-				return true;
-			}
-		},
+				return sup.apply(this, arguments);
+			};
+		}),
 
 		/**
 		* @private


### PR DESCRIPTION
...el to invisible list (priority 4)
## Issue

When moon.Panels is last parent and is hidden, moon.Panels.getAbsoluteShowing() return true
Thus, when moon.Panels and DataList inside Panels hide, DataList thinks that current showing status is true
## Fix

Refactor moon.Panels.getAbsoluteShowing() to call getAbsoluteShowing() of superkind

Enyo-DCO-1.1-Signed-off-by: SoonGil Choi (soongil.choi@lge.com)
