### PR TITLE
ENYO-403: Set selection state when setting multi-selection state.

### DIFF
--- a/samples/DataGridListSample.js
+++ b/samples/DataGridListSample.js
@@ -37,9 +37,14 @@ enyo.kind({
 	bindings: [
 		{from: ".collection", to: ".$.dataList.collection"},
 		{from: ".collection", to: ".$.gridList.collection"},
-		{from: ".$.selectionToggle.value", to:".$.gridList.selection", oneWay: false},
-		{from: ".$.multiSelectToggle.value", to:".$.gridList.multipleSelection", oneWay: false},
-		{from: ".$.groupSelectToggle.value", to: ".$.gridList.groupSelection", oneWay: false}
+		{from: ".$.selectionToggle.value", to: ".$.gridList.selection", oneWay: false},
+		{from: ".$.multiSelectToggle.value", to: ".$.gridList.multipleSelection", oneWay: false},
+		{from: ".$.groupSelectToggle.value", to: ".$.gridList.groupSelection", oneWay: false},
+		{from: ".$.multiSelectToggle.value", to: ".$.selectionToggle.value", oneWay: false,
+			transform: function (value, dir) {
+				return dir == 1 ? (value ? value : this.$.selectionToggle.value) : false;
+			}
+		}
 	],
 	create: function () {
 		this.inherited(arguments);


### PR DESCRIPTION
### Issue

This is a sample-specific issue. Because we are binding `moon.ToggleButton` values to both the `selection` and `multipleSelection` properties, setting the `multipleSelection` property has no effect on the `selection` property.
### Fix

We add some logic to bind the states of the two buttons such that selection is enabled whenever multiple selection is enabled, but not vice versa. Also, made the spacing more consistent in the bindings, hence the additional modified lines.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
