### PR TITLE
ENYO-554: Only check and reset locale when navigating to samples within the app.

### DIFF
--- a/samples/Sample.js
+++ b/samples/Sample.js
@@ -166,9 +166,6 @@
 			this.$.router.trigger({location: this.get('location'), change: true});
 		},
 		sampleChanged: function () {
-			if (typeof ilib !== 'undefined' && ilib.getLocale() != this.locale) {
-				this.localeChanged(ilib.getLocale(), this.locale);
-			}
 			if (this.get('sample')) {
 				this.openSample();
 			} else {
@@ -192,6 +189,7 @@
 		backToList: function () {
 			this.set('sample', '');
 			this.$.router.trigger({location: this.get('location'), change: true});
+			this.checkLocale();
 		},
 		reload: function () {
 			window.location.reload();
@@ -199,6 +197,7 @@
 		chooseSample: function (sender, ev) {
 			var sampleName = ev.originator.get('sampleName');
 			this.set('sample', sampleName);
+			this.checkLocale();
 		},
 		openSample: function () {
 			var s = this.get('sample'),
@@ -369,6 +368,12 @@
 				document.head.insertAdjacentHTML('beforeend', node );
 			} else {
 				document.head.appendChild( node );
+			}
+		},
+		checkLocale: function () {
+			// Reset locale in the event one of the samples changes it
+			if (typeof ilib !== 'undefined' && ilib.getLocale() != this.locale) {
+				this.localeChanged(ilib.getLocale(), this.locale);
 			}
 		}
 	});


### PR DESCRIPTION
### Issue

We were resetting the locale upon initialization of the Sampler, specifically when navigating to a specific sample, which prevented the locale specified in the URL hash from being used.
### Fix

We only validate and reset the locale when navigating to samples within the app.
### Notes

I used the wrong branch name for this - it should be ENYO-554.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
