### PR TITLE
ENYO-591: Clean up DataList page assignment logic

### DIFF
--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -117,14 +117,14 @@
 			}),
 
 			/**
+			* Overriding scrollToControl() to specify Moonstone-specific scroller options.
+			* No need to call the super method, so we don't wrap in enyo.inherit().
+			*
 			* @private
 			*/
-			scrollToIndex: enyo.inherit(function (sup) {
-				return function(list, i) {
-					var scrollerArgs = [false, false, true];
-					sup.call(this, list, i, scrollerArgs);
-				};
-			}),
+			scrollToControl: function(list, control) {
+				list.$.scroller.scrollToControl(control, false, false, true);
+			},
 
 			/**
 			* @method

--- a/source/DataList.js
+++ b/source/DataList.js
@@ -505,14 +505,14 @@
 			}),
 
 			/**
+			* Overriding scrollToControl() to specify Moonstone-specific scroller options.
+			* No need to call the super method, so we don't wrap in enyo.inherit().
+			*
 			* @private
 			*/
-			scrollToIndex: enyo.inherit(function (sup) {
-				return function(list, i) {
-					var scrollerArgs = [false, false, true];
-					sup.call(this, list, i, scrollerArgs);
-				};
-			})
+			scrollToControl: function(list, control) {
+				list.$.scroller.scrollToControl(control, false, false, true);
+			}
 		};
 		enyo.kind.extendMethods(moon.DataList.delegates.vertical, exts, true);
 		enyo.kind.extendMethods(moon.DataList.delegates.vertical, {


### PR DESCRIPTION
NOTE: This pull request is dependent on the following Enyo PR:

https://github.com/enyojs/enyo/pull/951

We have recently had some issues (e.g. ENYO-575, BHV-18217) that
arose because DataList would sometimes assign invalid (negative)
page indices.

We made point fixes to address these specific issues (including
one fix that we knew was just a quickfix for a deeper issue), but
in the process it became apparent that some general cleanup in this
area would yield more understandable / maintainable code and
probably nip similar issues in the bud.

Most of this cleanup work was done in Enyo core, but doing so
allows us to remove a lot of code from Moonstone, which now
inherits its DataList and DataGridList delegates' scrollToIndex()
functionality almost entirely from core.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
