### PR TITLE
ENYO-578: Include renamed file in manifest.

### DIFF
--- a/samples/package.js
+++ b/samples/package.js
@@ -1,5 +1,5 @@
 enyo.depends(
-	"sample.css",
+	"Sample.css",
 	"AccordionSample.css",
 	"AccordionSample.js",
 	"ActivityPanelsSample.css",


### PR DESCRIPTION
### Issue

We had renamed `sample.css` to `Sample.css` via https://github.com/enyojs/moonstone/commit/463d1d but did not update `package.js`, resulting in some minification errors that did not stop the build process. This ultimately led to the Sampler application not appearing in the builds.
### Fix

Update `package.js` with the renamed file.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
