### PR TITLE
BHV-19184: Prevent pointer events from IntegerPicker's client area.

### DIFF
--- a/css/IntegerPicker.less
+++ b/css/IntegerPicker.less
@@ -23,6 +23,7 @@
 .spotlight .moon-scroll-picker {
 	background: @moon-spotlight-border-color;
 	color: @moon-spotlight-text-color;
+	pointer-events: none;
 }
 
 .moon-scroll-picker-item {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1722,6 +1722,7 @@
 .spotlight .moon-scroll-picker {
   background: #cf0652;
   color: #ffffff;
+  pointer-events: none;
 }
 .moon-scroll-picker-item {
   white-space: nowrap;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1722,6 +1722,7 @@
 .spotlight .moon-scroll-picker {
   background: #cf0652;
   color: #ffffff;
+  pointer-events: none;
 }
 .moon-scroll-picker-item {
   white-space: nowrap;


### PR DESCRIPTION
### Issue

In `moon.IntegerPicker` controls, tapping the client area while the control was scrolling to a value would interrupt the scroll animation and could potentially leave the currently displayed value in an undesired position.
### Fix

We use the `pointer-events:none` CSS rule.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
