### PR TITLE
ENYO-592: defaultSpotlightDisappear property in pageUpControl doesn't work in short scroller

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -465,7 +465,7 @@
 					val = this.scrollLeft + delta;
 					// When we hit the right, bounce and end scrolling
 					if (val >= -this.$.scrollMath.rightBoundary) {
-						this.$.pageRightControl.setDisabled(false);
+						this.$.pageLeftControl.setDisabled(false);
 						this.setScrollLeft(-this.$.scrollMath.rightBoundary);
 						this.$.pageRightControl.hitBoundary();
 					} else {


### PR DESCRIPTION
### Issue:

when scrolling a short number of items in datagridlist (from 7 to 12 in the sample) a long press on pageup spots items outside the scroller instead of pagedown.
### Fix:

The issue seems to occur when the page up and down buttons are disabled at the same time. So one possible fix is to add code in doPaginateScroll to undisable the appropriate paging button when the scroller reaches a boundary.

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com
