### PR TITLE
ENYO-654: Allow panels handle to show when panels are hidden.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -161,7 +161,7 @@
 				]},
 				{name: 'client', tag: null}
 			]},
-			{name: 'showHideHandle', kind: 'enyo.Control', classes: 'moon-panels-handle hidden', canGenerate: false, ontap: 'handleTap', onSpotlightLeft: 'handleSpotLeft', onSpotlightRight: 'handleSpotRight', onSpotlightFocused: 'handleFocused', onSpotlightBlur: 'handleBlur'},
+			{name: 'showHideHandle', kind: 'moon.PanelsHandle', classes: 'hidden', canGenerate: false, ontap: 'handleTap', onSpotlightLeft: 'handleSpotLeft', onSpotlightRight: 'handleSpotRight', onSpotlightFocused: 'handleFocused', onSpotlightBlur: 'handleBlur'},
 			{name: 'showHideAnimator', kind: 'enyo.StyleAnimator', onComplete: 'animationComplete'}
 		],
 
@@ -1011,23 +1011,6 @@
 		},
 
 		/**
-		* Returns `true` if this and all parents are showing.
-		*
-		* @private
-		*/
-		getAbsoluteShowing: enyo.inherit(function (sup) {
-			return function() {
-				var b = this.getBounds();
-
-				if ((b.height === 0 && b.width === 0)) {
-					return false;
-				}
-
-				return sup.apply(this, arguments);
-			};
-		}),
-
-		/**
 		* @private
 		*/
 		showingChanged: function (inOldValue) {
@@ -1237,6 +1220,51 @@
 			if (this.$.branding) {
 				this.$.branding.set('src', this.brandingSrc);
 			}
+		}
+	});
+
+	/**
+	* `moon.PanelsHandle` is a helper kind for {@link moon.Panels} which implements a spottable
+	*  handle that the user can interact with to hide and show the `moon.Panels` control.
+	*
+	* @class moon.PanelsHandle
+	* @extends enyo.Control
+	* @ui
+	* @public
+	*/
+	enyo.kind(
+		/** @lends moon.PanelsHandle.prototype */ {
+
+		/**
+		* @private
+		*/
+		name: 'moon.PanelsHandle',
+
+		/*
+		* @private
+		*/
+		kind: 'enyo.Control',
+
+		/*
+		* @private
+		*/
+		classes: 'moon-panels-handle',
+
+		/*
+		* We override getAbsoluteShowing so that the handle's spottability is not dependent on the
+		* showing state of its parent, the {@link moon.Panels} control.
+		* 
+		* @private
+		*/
+		getAbsoluteShowing: function (ignoreBounds) {
+			var bounds = !ignoreBounds ? this.getBounds() : null;
+
+			if (!this.generated || this.destroyed || !this.showing || (bounds &&
+				bounds.height === 0 && bounds.width === 0)) {
+				return false;
+			}
+
+			return true;
 		}
 	});
 


### PR DESCRIPTION
### Issue

This is a regression from https://github.com/enyojs/moonstone/commit/027f64. Now that we are properly calling the super method for `getAbsoluteShowing` in `moon.Panels`, whenever we attempt to spot the handle, we are examining the absolute showing state of the parent of the handle, which is the `moon.Panels` control that is potentially hidden. Previously, this would be incorrectly skipped (though probably intentionally) in the hierarchy and the parent of the panels control would be examined, which would likely be showing.
### Fix

We are now overriding `getAbsoluteShowing` for the handle specifically, via a separate kind. Additionally, I didn't see any reason to keep our override of `getAbsoluteShowing` in `moon.Panels` anymore (I believe it was originally put into place to support this unique case with the handle) as I couldn't find any calls to `getAbsoluteShowing()` or `getAbsoluteShowing(false)`, just calls to `getAbsoluteShowing(true)`, which can effectively be handled by the base kind's implementation of `getAbsoluteShowing`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
