### PR TITLE
ENYO-547: ContextualPopup: Add RadioItem inside ContextualPopup

### DIFF
--- a/samples/ContextualPopupSample.js
+++ b/samples/ContextualPopupSample.js
@@ -26,7 +26,7 @@ enyo.kind({
 		{kind: "moon.ContextualPopupDecorator", style:"position: absolute; right: 0px; top: 13%;", components: [
 			{content:"Nested Radio", small:true},
 			{kind: "moon.ContextualPopup", components:[
-				{kind: "moon.RadioItemGroup", onActivate: "buttonActivated", components: [
+				{kind: "moon.RadioItemGroup", components: [
 					{content: "Creek"},
 					{content: "River"},
 					{content: "Ocean"}


### PR DESCRIPTION
Issue.

QA would like a set of nested radio buttons inside a Contextual Popup to ease testing.

Fix.

Added a new contextual Popup button, with Nested Radio buttons.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
