### PR TITLE
ENYO-548: added dismiss, and cleaned up quotes

### DIFF
--- a/samples/ContextualPopupSample.js
+++ b/samples/ContextualPopupSample.js
@@ -41,7 +41,7 @@ enyo.kind({
 					 small: true,
 					 toggleOnLabel: 'select dismiss on',
 					 toggleOffLabel: 'select dismiss off'
-					},
+					}
 				]}
 			]
 		},


### PR DESCRIPTION
Issue.

QA would like the ability to dismiss a popup after a radio selection.

Fix.

Added toggle to allow popup to dismiss when a radio button is selected. 

Also cleaned up double to single quotes for consistency in this source file

Reviewed-By: Derek Anderson (derek.anderson@lge.com) 
