### PR TITLE
BHV-19877: Remove obsolete reset() override in grid delegate

### DIFF
--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -130,19 +130,6 @@
 			* @method
 			* @private
 			*/
-			reset: enyo.inherit(function (sup) {
-				return function (list) {
-					sup.apply(this, arguments);
-					this.updateMetrics(list);
-					list.refresh();
-					list.$.scroller.scrollTo(0, 0, false);
-				};
-			}),
-
-			/**
-			* @method
-			* @private
-			*/
 			updateBounds: enyo.inherit(function (sup) {
 				return function (list) {
 					sup.apply(this, arguments);


### PR DESCRIPTION
Moonstone has been overriding the vertical grid delegate's reset()
method. Among other things, the overridden method results in
generating the list's pages not once but twice each time reset()
is called.

There weren't any inline comments to indicate the reasons
for overriding, but it looks like none of the code in the
overridden method is required anymore:
- Inherited method now has equivalent scrolling functionality
- Grid list pages generate and lay out properly without the
  additional metrics update and page generation. (Verified that
  this is true both with and without scroll controls forced to
  show, and regardless of whether there is enough content to
  scroll.)

There was a note in the Git history regarding scrollToIndex, so I
also tested to ensure that scrollToIndex still works as expected
(though it looks as if reset() is no longer hit in the
scrollToIndex() code path in any case).

Based on all of the above, it looks like we can safely remove the
overridden method.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)
