### PR TITLE
ENYO-690: Add media queries for setting root size.

### DIFF
--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -6,6 +6,15 @@
 /* minifier to fall back to using CSS files in place of the same-name       */
 /* LESS file.                                                               */
 
+html {
+  font-size: 12px;
+}
+/* 720p screen size */
+@media only screen and (max-width: 1280px) {
+  html {
+    font-size: 8px;
+  }
+}
 /* ----- MISO ------ */
 @font-face {
   font-family: "Moonstone Miso";

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -6,6 +6,15 @@
 /* minifier to fall back to using CSS files in place of the same-name       */
 /* LESS file.                                                               */
 
+html {
+  font-size: 12px;
+}
+/* 720p screen size */
+@media only screen and (max-width: 1280px) {
+  html {
+    font-size: 8px;
+  }
+}
 /* ----- MISO ------ */
 @font-face {
   font-family: "Moonstone Miso";

--- a/css/moonstone-rules.less
+++ b/css/moonstone-rules.less
@@ -1,3 +1,14 @@
+html {
+	font-size: 12apx;
+}
+
+/* 720p screen size */
+@media only screen and (max-width: 1280px) {
+	html {
+		font-size: 8apx;
+	}
+}
+
 // Import font styles
 @import "moonstone-fonts.less";
 


### PR DESCRIPTION
### Issue

We need to set the appropriate root `font-size` based on the screen resolution.
### Fix

We use the appropriate media queries to set the `font-size` of our `html` element.
### Notes

Travis is expected to fail as the generated CSS will not be the same as what Travis expects due to the changes we made for compiling LESS.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
