### PR TITLE
ENHYO-698: ContextualPopup: Spotlight Does Not Spot Parent upon 'Select Dismiss On'

### DIFF
--- a/samples/ContextualPopupSample.js
+++ b/samples/ContextualPopupSample.js
@@ -224,7 +224,7 @@ enyo.kind({
 		this.$.buttonPopup.setAutoDismiss(!inSender.getActive());
 	},
 	dismissRadioSelection: function(){
-		if(this.$.nestedRadioDismissButton.value) this.$.nestedRadioPopup.hide();
+		if(this.$.nestedRadioDismissButton.value) this.$.nestedRadioPopup.closePopup();
 	},
 	setPosition: function(){
 		this.$.directionButton.applyStyle('left', this.$.leftInput.getValue() === '' ? '40%' : this.$.leftInput.getValue());


### PR DESCRIPTION
Issue.

When using Dismiss on Select, the popup activator was not re-spotted because `hide` was used instead of `closePopup`

Fix.

Switch the method being used to close popup.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson <derek.anderson@lge.com>