### PR TITLE
Account for fractional pixels when performing percentage transformations.

### DIFF
--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -165,16 +165,27 @@
 		/**
 		* @private
 		*/
-		create: function() {
-			this.inherited(arguments);
-			this.animateChanged();
-			this.initializeActiveItem();
-			this.disabledChanged();
-			this.selectedIndexChanged();
-			this.updateMarqueeDisable();
-			this.blockChanged();
-			this.showHideNavButtons();
-		},
+		create: enyo.inherit(function (sup) {
+			return function () {
+				sup.apply(this, arguments);
+				this.animateChanged();
+				this.initializeActiveItem();
+				this.disabledChanged();
+				this.updateMarqueeDisable();
+				this.blockChanged();
+				this.showHideNavButtons();
+			};
+		}),
+
+		/**
+		* @private
+		*/
+		rendered: enyo.inherit(function (sup) {
+			return function () {
+				sup.apply(this, arguments);
+				this.selectedIndexChanged();
+			};
+		}),
 
 		/**
 		* @private
@@ -367,7 +378,14 @@
 		* @private
 		*/
 		selectedIndexChanged: function() {
-			enyo.dom.transform(this.$.client, {translateX: (this.selectedIndex * -100) + '%'});
+			// FIXME: Accounting for issue with sub-pixels and setting a percentage transformation.
+			// It appears that percentage transformations utilize the nearest whole-pixel value.
+			if (!this._clientWidth) this._clientWidth = this.$.client.generated && this.$.client.hasNode().getBoundingClientRect().width;
+			if (this.$.client.generated && this._clientWidth) { // correction for rounding (after we can measure the control width)
+				enyo.dom.transform(this.$.client, {translateX: enyo.dom.unit(this.selectedIndex * this._clientWidth * -1, 'rem')});
+			} else { // initial (rounded) transformation
+				enyo.dom.transform(this.$.client, {translateX: (this.selectedIndex * -100) + '%'});
+			}
 			this.updateMarqueeDisable();
 			this.setSelected(this.getClientControls()[this.selectedIndex]);
 			this.fireChangedEvent();


### PR DESCRIPTION
### Issue

When specifying transformations in terms of percentages, fractional pixel values are rounded when computing the transformation value. This can result in rounding errors, specifically manifesting themselves in `moon.SimplePicker` when set to a large enough index for the rounding errors to compound.
### Fix

A temporary fix involves setting the corrected value based on a one-time measurement of the control width, when rendered. This minimizes the amount of unwanted animation from the initial picker value to the currently specified index, but there can still be a slightly noticeable shift. To fully eliminate this shift, we need to set the transformation before rendering, either via percentage as was originally implemented, or pre-computing the pixel amount based on some fixed value, which is not the case here as we require a post-render measurement.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
