### PR TITLE
Added a small-res fix to ToggleSwitch's position.

### DIFF
--- a/css/ToggleSwitch.less
+++ b/css/ToggleSwitch.less
@@ -19,6 +19,7 @@
 	}
 	&[checked] {
 		background-color: @moon-checkbox-toggle-switch-checked-bg-color;
+
 		.moon-icon {
 			left:  @moon-toggleswitch-image-width / 2;
 			color: @moon-checkbox-toggle-switch-checked-color;
@@ -26,14 +27,23 @@
 	}
 	&[disabled] {
 		background-color: @moon-checkbox-toggle-switch-bg-color;
+
 		.moon-icon {
 			color: @moon-checkbox-toggle-switch-color;
 		}
 	}
 	&.animated .moon-icon {
 		-webkit-transition: background-color 0.2s, left 0.2s;
+
 		&:after {
 			-webkit-transition: color 0.2s;
 		}
 	}
+}
+
+// Fix a rounding issue for the smaller scale
+.moon-res-hd .moon-checkbox.moon-toggle-switch .small > .small-icon-tap-area {
+	top: 0;
+	bottom: 0;
+	line-height: (@moon-toggleswitch-image-height + 3);
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1031,6 +1031,11 @@ html {
 .moon-checkbox.moon-toggle-switch.animated .moon-icon:after {
   -webkit-transition: color 0.2s;
 }
+.moon-res-hd .moon-checkbox.moon-toggle-switch .small > .small-icon-tap-area {
+  top: 0;
+  bottom: 0;
+  line-height: 3rem;
+}
 .moon-toggle-item {
   display: block;
   position: relative;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1031,6 +1031,11 @@ html {
 .moon-checkbox.moon-toggle-switch.animated .moon-icon:after {
   -webkit-transition: color 0.2s;
 }
+.moon-res-hd .moon-checkbox.moon-toggle-switch .small > .small-icon-tap-area {
+  top: 0;
+  bottom: 0;
+  line-height: 3rem;
+}
 .moon-toggle-item {
   display: block;
   position: relative;


### PR DESCRIPTION
It corrects a rounding and conversion issue on the line-height property that causes the position of the font-symbol inside the element to not remain centered. Webkit appears to be lazily rounding to the wrong pixel in some cases which causes this offset.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
