### PR TITLE
Fixes font size issue

### DIFF
--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -7,16 +7,19 @@
 /* LESS file.                                                               */
 
 html {
+  font-size: 1rem;
   font-size: 12px;
 }
 /* 720p screen size */
 @media only screen and (max-width: 1280px) {
   html {
+    font-size: 0.6666666666666666rem;
     font-size: 8px;
   }
 }
 @media only screen and (min-width: 2560px) {
   html {
+    font-size: 2rem;
     font-size: 24px;
   }
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -7,16 +7,19 @@
 /* LESS file.                                                               */
 
 html {
+  font-size: 1rem;
   font-size: 12px;
 }
 /* 720p screen size */
 @media only screen and (max-width: 1280px) {
   html {
+    font-size: 0.6666666666666666rem;
     font-size: 8px;
   }
 }
 @media only screen and (min-width: 2560px) {
   html {
+    font-size: 2rem;
     font-size: 24px;
   }
 }

--- a/css/moonstone-rules.less
+++ b/css/moonstone-rules.less
@@ -1,15 +1,18 @@
 html {
+	font-size: 12px;
 	font-size: 12apx;
 }
 
 /* 720p screen size */
 @media only screen and (max-width: 1280px) {
 	html {
+		font-size: 8px;
 		font-size: 8apx;
 	}
 }
 @media only screen and (min-width: 2560px) {
 	html {
+		font-size: 24px;
 		font-size: 24apx;
 	}
 }


### PR DESCRIPTION
## Issue

By using the invalid `apx` value, apps must be built or use the runtime LESS compiler in order to render correctly.
## Fix

By duplicating the font-size property with both `px` and `apx`, the former ensures that debug-mode apps work (because `apx` is ignored as invalid) and built apps work because the converted `apx` value overrides the converted `px` value.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
