### PR TITLE
Fixes ENYO-696

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -815,12 +815,14 @@
 		* @private
 		*/
 		_marquee_calcDistance: function () {
-			if (this._marquee_distance !== null) {
-				return this._marquee_distance;
+			var node, rect;
+
+			if (this._marquee_distance == null) {
+				node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode();
+				rect = node.getBoundingClientRect();
+				this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
 			}
-			var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(),
-				rect = node? node.getBoundingClientRect() : {};
-			this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
+
 			return this._marquee_distance;
 		},
 


### PR DESCRIPTION
## Issue

Occasionally, marquee text that can fit within its container will animate 1px unnecessarily. This appears to be due to a rounding difference between scrollWidth and clientWidth for sub-pixel precision values which results in a 1px marquee distance.
## Fix

Use `getClientBoundingRect()` for marquee distance calculation

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
