### PR TITLE
ENYO-592: fix for inconsistent spotting of paging controls

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -636,7 +636,7 @@
 				this.$[enable[i]].setDisabled(false);
 			}
 
-			for (var ii = 0; i < disable.length; ii++) {
+			for (var ii = 0; ii < disable.length; ii++) {
 				this.$[disable[ii]].setDisabled(true);
 			}
 		},


### PR DESCRIPTION
Issue.

When using paging controls near bounds, some of the paging controls would become activate after the spot has moved to a different container.

Fix.

Update the disable/enable logic, to group controls into two pools, and then enable controls before disabling ones that may be currently spotted.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com
