### PR TITLE
ENYO-592: Enable all to-be-enabled paging controls first.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -611,12 +611,27 @@
 			var m = this.$.scrollMath,
 				b = this._getScrollBounds(),
 				canVScroll = b.height > b.clientHeight,
-				canHScroll = b.width > b.clientWidth;
+				canHScroll = b.width > b.clientWidth,
+				controls = [ // Compute and store disabled state of paging controls in sortable structure
+					{name: 'pageUpControl', disabled: (b.top <= 0) || !canVScroll},
+					{name: 'pageDownControl', disabled: (b.top >= -1 * m.bottomBoundary) || !canVScroll},
+					{name: 'pageLeftControl', disabled: (b.left <= 0) || !canHScroll},
+					{name: 'pageRightControl', disabled: (b.left >= -1 * m.rightBoundary) || !canHScroll}
+				],
+				control,
+				i;
 
-			this.$.pageUpControl.setDisabled((b.top <= 0) || !canVScroll);
-			this.$.pageDownControl.setDisabled((b.top >= -1 * m.bottomBoundary) || !canVScroll);
-			this.$.pageLeftControl.setDisabled((b.left <= 0) || !canHScroll);
-			this.$.pageRightControl.setDisabled((b.left >= -1 * m.rightBoundary) || !canHScroll);
+			// Sort paging controls by disabled state in ascending order so that enabled items are
+			// at the beginning of the array.
+			controls.sort(function (a, b) {
+				return a.disabled - b.disabled;
+			});
+
+			// Actually set the disabled state of the paging controls
+			for (i = 0; i < controls.length; i++) {
+				control = controls[i];
+				this.$[control.name].set('disabled', control.disabled);
+			}
 		},
 
 		/**

--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -443,7 +443,6 @@
 					val = this.scrollLeft - delta;
 					// When we hit the left, bounce and end scrolling
 					if (val <= -this.$.scrollMath.leftBoundary) {
-						this.$.pageRightControl.setDisabled(false);
 						this.setScrollLeft(-this.$.scrollMath.leftBoundary);
 						this.$.pageLeftControl.hitBoundary();
 					} else {
@@ -454,7 +453,6 @@
 					val = this.scrollTop - delta;
 					// When we hit the top, bounce and end scrolling
 					if (val <= -this.$.scrollMath.topBoundary) {
-						this.$.pageDownControl.setDisabled(false);
 						this.setScrollTop(-this.$.scrollMath.topBoundary);
 						this.$.pageUpControl.hitBoundary();
 					} else {
@@ -465,7 +463,6 @@
 					val = this.scrollLeft + delta;
 					// When we hit the right, bounce and end scrolling
 					if (val >= -this.$.scrollMath.rightBoundary) {
-						this.$.pageLeftControl.setDisabled(false);
 						this.setScrollLeft(-this.$.scrollMath.rightBoundary);
 						this.$.pageRightControl.hitBoundary();
 					} else {
@@ -477,7 +474,6 @@
 					val = this.scrollTop + delta;
 					// When we hit the bottom, bounce and end scrolling
 					if (val >= -this.$.scrollMath.bottomBoundary) {
-						this.$.pageUpControl.setDisabled(false);
 						this.setScrollTop(-this.$.scrollMath.bottomBoundary);
 						this.$.pageDownControl.hitBoundary();
 					} else {

--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -611,19 +611,23 @@
 			var m = this.$.scrollMath,
 				b = this._getScrollBounds(),
 				canVScroll = b.height > b.clientHeight,
-				canHScroll = b.width > b.clientWidth;
+				canHScroll = b.width > b.clientWidth,
+				disablePageUp = (b.top <= 0) || !canVScroll,
+				disablePageDown = (b.top >= -1 * m.bottomBoundary) || !canVScroll,
+				disablePageLeft = (b.left <= 0) || !canHScroll,
+				disablePageRight = (b.left >= -1 * m.rightBoundary) || !canHScroll;
 
-			// Enable all of the paging controls first, so that we are not beholden to any ordering
-			// issues that can cause erratic Spotlight behavior.
-			this.$.pageUpControl.set('disabled', false);
-			this.$.pageDownControl.set('disabled', false);
-			this.$.pageLeftControl.set('disabled', false);
-			this.$.pageRightControl.set('disabled', false);
+			// Enable all of the paging controls (which are not already enabled) first, so that we
+			// are not beholden to any ordering issues that can cause erratic Spotlight behavior.
+			if (!disablePageUp) this.$.pageUpControl.set('disabled', false);
+			if (!disablePageDown) this.$.pageDownControl.set('disabled', false);
+			if (!disablePageLeft) this.$.pageLeftControl.set('disabled', false);
+			if (!disablePageRight) this.$.pageRightControl.set('disabled', false);
 
-			this.$.pageUpControl.set('disabled', (b.top <= 0) || !canVScroll);
-			this.$.pageDownControl.set('disabled', (b.top >= -1 * m.bottomBoundary) || !canVScroll);
-			this.$.pageLeftControl.set('disabled', (b.left <= 0) || !canHScroll);
-			this.$.pageRightControl.set('disabled', (b.left >= -1 * m.rightBoundary) || !canHScroll);
+			if (disablePageUp) this.$.pageUpControl.set('disabled', true);
+			if (disablePageDown) this.$.pageDownControl.set('disabled', true);
+			if (disablePageLeft) this.$.pageLeftControl.set('disabled', true);
+			if (disablePageRight) this.$.pageRightControl.set('disabled', true);
 		},
 
 		/**

--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -611,27 +611,19 @@
 			var m = this.$.scrollMath,
 				b = this._getScrollBounds(),
 				canVScroll = b.height > b.clientHeight,
-				canHScroll = b.width > b.clientWidth,
-				controls = [ // Compute and store disabled state of paging controls in sortable structure
-					{name: 'pageUpControl', disabled: (b.top <= 0) || !canVScroll},
-					{name: 'pageDownControl', disabled: (b.top >= -1 * m.bottomBoundary) || !canVScroll},
-					{name: 'pageLeftControl', disabled: (b.left <= 0) || !canHScroll},
-					{name: 'pageRightControl', disabled: (b.left >= -1 * m.rightBoundary) || !canHScroll}
-				],
-				control,
-				i;
+				canHScroll = b.width > b.clientWidth;
 
-			// Sort paging controls by disabled state in ascending order so that enabled items are
-			// at the beginning of the array.
-			controls.sort(function (a, b) {
-				return a.disabled - b.disabled;
-			});
+			// Enable all of the paging controls first, so that we are not beholden to any ordering
+			// issues that can cause erratic Spotlight behavior.
+			this.$.pageUpControl.set('disabled', false);
+			this.$.pageDownControl.set('disabled', false);
+			this.$.pageLeftControl.set('disabled', false);
+			this.$.pageRightControl.set('disabled', false);
 
-			// Actually set the disabled state of the paging controls
-			for (i = 0; i < controls.length; i++) {
-				control = controls[i];
-				this.$[control.name].set('disabled', control.disabled);
-			}
+			this.$.pageUpControl.set('disabled', (b.top <= 0) || !canVScroll);
+			this.$.pageDownControl.set('disabled', (b.top >= -1 * m.bottomBoundary) || !canVScroll);
+			this.$.pageLeftControl.set('disabled', (b.left <= 0) || !canHScroll);
+			this.$.pageRightControl.set('disabled', (b.left >= -1 * m.rightBoundary) || !canHScroll);
 		},
 
 		/**


### PR DESCRIPTION
### Issue
There can be instances where a paging control becomes disabled, and the corresponding and opposite paging control (which was the last spotted control) has not yet been enabled, causing Spotlight focus to move to the first child of the root.

### Fix
We ensure that the to-be-enabled paging controls are enabled first, so that Spotlight can still spot the opposite (and last spotted) paging control when the currently spotted paging control is disabled. Additionally, we revert the change from https://github.com/enyojs/moonstone/pull/1827 as it is not necessary anymore.

### Notes
Let me know if there are any performance concerns about sorting a 4-item array for each invocation of `updatePagingControlState`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>