### PR TITLE
ENYO-577: Fix backward-compatibility for deprecated uppercase properties.

### DIFF
--- a/source/Button.js
+++ b/source/Button.js
@@ -75,11 +75,14 @@
 			/**
 			* @deprecated Replaced by [uppercase]{@link moon.Button#uppercase}.
 			*
+			* Formerly defaulted to `true`, now defaults to `null` and will only have
+			* an effect when explicitly set (for complete backward compatibility).
+			*
 			* @type {Boolean}
-			* @default true
+			* @default null
 			* @public
 			*/
-			contentUpperCase: true
+			contentUpperCase: null
 		},
 
 		/**
@@ -141,12 +144,9 @@
 			if (this.minWidth) this.minWidthChanged();
 			
 			// FIXME: Backwards-compatibility for deprecated property - can be removed when
-			// the contentUpperCase property is fully deprecated and removed. We give the uppercase
-			// property precedence and assign its value to the contentUpperCase property if it has
-			// changed from the default value, otherwise if the value of the contentUpperCase
-			// property has changed from the default value, we assign its value to the uppercase property.
-			if (!this.uppercase) this.contentUpperCase = this.uppercase;
-			else if (!this.contentUpperCase) this.uppercase = this.contentUpperCase;
+			// the contentUpperCase property is fully deprecated and removed. The legacy
+			// property takes precedence if it exists.
+			if (this.contentUpperCase !== null) this.uppercase = this.contentUpperCase;
 
 			this.contentChanged();
 			this.inherited(arguments);

--- a/source/ChannelInfo.js
+++ b/source/ChannelInfo.js
@@ -94,11 +94,14 @@
 			/**
 			* @deprecated Replaced by [uppercaseChannelNo]{@link moon.ChannelInfo#uppercaseChannelNo}.
 			*
+			* Formerly defaulted to `true`, now defaults to `null` and will only have
+			* an effect when explicitly set (for complete backward compatibility).
+			*
 			* @type {Boolean}
-			* @default true
+			* @default null
 			* @public
 			*/
-			channelNoUpperCase: true
+			channelNoUpperCase: null
 		},
 
 		/**
@@ -129,13 +132,9 @@
 			this.inherited(arguments);
 
 			// FIXME: Backwards-compatibility for deprecated property - can be removed when
-			// the channelNoUpperCase property is fully deprecated and removed. We give the
-			// uppercaseChannelNo property precedence and assign its value to the channelNoUpperCase
-			// property if it has changed from the default value, otherwise if the value of the
-			// channelNoUpperCase property has changed from the default value, we assign its value
-			// to the uppercaseChannelNo property.
-			if (!this.uppercaseChannelNo) this.channelNoUpperCase = this.uppercaseChannelNo;
-			else if (!this.channelNoUpperCase) this.uppercaseChannelNo = this.channelNoUpperCase;
+			// the channelNoUpperCase property is fully deprecated and removed. The legacy
+			// property takes precedence if it exists.
+			if (this.channelNoUpperCase !== null) this.uppercaseChannelNo = this.channelNoUpperCase;
 
 			this.channelNoChanged();
 		},

--- a/source/Dialog.js
+++ b/source/Dialog.js
@@ -72,11 +72,14 @@
 			/**
 			* @deprecated Replaced by [uppercase]{@link moon.Dialog#uppercase}.
 			*
+			* Formerly defaulted to `true`, now defaults to `null` and will only have
+			* an effect when explicitly set (for complete backward compatibility).
+			*
 			* @type {Boolean}
-			* @default true
+			* @default null
 			* @public
 			*/
-			titleUpperCase: true
+			titleUpperCase: null
 		},
 
 		/**
@@ -132,12 +135,9 @@
 			this.inherited(arguments);
 
 			// FIXME: Backwards-compatibility for deprecated property - can be removed when
-			// the titleUpperCase property is fully deprecated and removed. We give the uppercase
-			// property precedence and assign its value to the titleUpperCase property if it has
-			// changed from the default value, otherwise if the value of the titleUpperCase property
-			// has changed from the default value, we assign its value to the uppercase property.
-			if (!this.uppercase) this.titleUpperCase = this.uppercase;
-			else if (!this.titleUpperCase) this.uppercase = this.titleUpperCase;
+			// the titleUpperCase property is fully deprecated and removed. The legacy
+			// property takes precedence if it exists.
+			if (this.titleUpperCase !== null) this.uppercase = this.titleUpperCase;
 
 			this.titleChanged();
 			this.subTitleChanged();

--- a/source/Header.js
+++ b/source/Header.js
@@ -198,11 +198,14 @@
 			/**
 			* @deprecated Replaced by [uppercase]{@link moon.Header#uppercase}.
 			*
+			* Formerly defaulted to `true`, now defaults to `null` and will only have
+			* an effect when explicitly set (for complete backward compatibility).
+			*
 			* @type {Boolean}
-			* @default true
+			* @default null
 			* @public
 			*/
-			titleUpperCase: true
+			titleUpperCase: null
 		},
 
 		/**
@@ -296,12 +299,9 @@
 			this.inherited(arguments);
 
 			// FIXME: Backwards-compatibility for deprecated property - can be removed when
-			// the titleUpperCase property is fully deprecated and removed. We give the uppercase
-			// property precedence and assign its value to the titleUpperCase property if it has
-			// changed from the default value, otherwise if the value of the titleUpperCase property
-			// has changed from the default value, we assign its value to the uppercase property.
-			if (!this.uppercase) this.titleUpperCase = this.uppercase;
-			else if (!this.titleUpperCase) this.uppercase = this.titleUpperCase;
+			// the titleUpperCase property is fully deprecated and removed. The legacy
+			// property takes precedence if it exists.
+			if (this.titleUpperCase !== null) this.uppercase = this.titleUpperCase;
 
 			// Note: This smallchanged() line will be deprecated soon. For backward compatiblity, I leave it for a
 			// while.

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -247,11 +247,14 @@
 			/**
 			* @deprecated Replaced by [uppercase]{@link moon.Slider#uppercase}.
 			*
+			* Formerly defaulted to `true`, now defaults to `null` and will only have
+			* an effect when explicitly set (for complete backward compatibility).
+			*
 			* @type {Boolean}
-			* @default true
+			* @default null
 			* @public
 			*/
-			popupContentUpperCase: true
+			popupContentUpperCase: null
 		},
 
 		/**
@@ -350,18 +353,16 @@
 			}
 
 			// FIXME: Backwards-compatibility for deprecated property - can be removed when
-			// the popupContentUpperCase property is fully deprecated and removed. We give the uppercase
-			// property precedence and assign its value to the popupContentUpperCase property if it has
-			// changed from the default value, otherwise if the value of the popupContentUpperCase property
-			// has changed from the default value, we assign its value to the uppercase property.
-			if (!this.uppercase) this.popupContentUpperCase = this.uppercase;
-			else if (!this.popupContentUpperCase) this.uppercase = this.popupContentUpperCase;
+			// the popupContentUpperCase property is fully deprecated and removed. The legacy
+			// property takes precedence if it exists.
+			if (this.popupContentUpperCase !== null) this.uppercase = this.popupContentUpperCase;
 
 			this.createComponents(this.moreComponents);
 			this.initValue();
 			this.disabledChanged();
 			this.knobClassesChanged();
 			this.popupLabelClassesChanged();
+			this.popupContentChanged();
 			this.tapAreaClassesChanged();
 			this.initSliderStyles();
 		},

--- a/source/Tooltip.js
+++ b/source/Tooltip.js
@@ -132,11 +132,14 @@
 			/**
 			* @deprecated Replaced by [uppercase]{@link moon.Tooltip#uppercase}.
 			*
+			* Formerly defaulted to `true`, now defaults to `null` and will only have
+			* an effect when explicitly set (for complete backward compatibility).
+			*
 			* @type {Boolean}
-			* @default true
+			* @default null
 			* @public
 			*/
-			contentUpperCase: true
+			contentUpperCase: null
 		},
 
 		/**
@@ -174,13 +177,9 @@
 			this.inherited(arguments);
 
 			// FIXME: Backwards-compatibility for deprecated property - can be removed when
-			// the contentUpperCase property is fully deprecated and removed. We give the uppercase
-			// property precedence and assign its value to the contentUpperCase property if it has
-			// changed from the default value, otherwise if the value of the contentUpperCase
-			// property has changed from the default value, we assign its value to the uppercase
-			// property.
-			if (!this.uppercase) this.contentUpperCase = this.uppercase;
-			else if (!this.contentUpperCase) this.uppercase = this.contentUpperCase;
+			// the contentUpperCase property is fully deprecated and removed. The legacy
+			// property takes precedence if it exists.
+			if (this.contentUpperCase !== null) this.uppercase = this.contentUpperCase;
 
 			this.contentChanged();
 		},

--- a/source/VideoInfoHeader.js
+++ b/source/VideoInfoHeader.js
@@ -113,11 +113,14 @@
 			/**
 			* @deprecated Replaced by [uppercase]{@link moon.VideoInfoHeader#uppercase}.
 			*
+			* Formerly defaulted to `true`, now defaults to `null` and will only have
+			* an effect when explicitly set (for complete backward compatibility).
+			*
 			* @type {Boolean}
-			* @default true
+			* @default null
 			* @public
 			*/
-			titleUpperCase: true
+			titleUpperCase: null
 		},
 
 		/**
@@ -149,12 +152,10 @@
 			this.inherited(arguments);
 
 			// FIXME: Backwards-compatibility for deprecated property - can be removed when
-			// the titleUpperCase property is fully deprecated and removed. We give the uppercase
-			// property precedence and assign its value to the titleUpperCase property if it has
-			// changed from the default value, otherwise if the value of the titleUpperCase property
-			// has changed from the default value, we assign its value to the uppercase property.
-			if (!this.uppercase) this.titleUpperCase = this.uppercase;
-			else if (!this.titleUpperCase) this.uppercase = this.titleUpperCase;
+			// the contentUpperCase property is fully deprecated and removed. The legacy
+			// property takes precedence if it exists.
+			if (this.titleUpperCase !== null) this.uppercase = this.titleUpperCase;
+
 			this.titleChanged();
 		},
 


### PR DESCRIPTION
### Issue

We had made a change to use a consistently-named property `uppercase` to control the uppercasing of certain controls. Previously, this had been implemented with various property names and those have since been deprecated. This resulted in some incompatibilities when still using the older property names.
### Fix

We add some glue code to properly utilize the deprecated property values when determining whether or not we should be uppercasing the control.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
