### PR TITLE
Removing trailing comma to address JSHint issue.

### DIFF
--- a/samples/ImageSample.js
+++ b/samples/ImageSample.js
@@ -8,6 +8,6 @@ enyo.kind({
 		{kind: 'moon.Image', src: 'http://lorempixel.com/256/256/city/1/', alt: 'UHD'},
 		{kind: 'moon.Divider', content: 'Multi-res'},
 		{kind: 'moon.BodyText', content: 'The below image will change its source resolution based on the screen size at the time this sample is loaded.'},
-		{kind: 'moon.Image', src: {'hd': 'http://lorempixel.com/64/64/city/1/', 'fhd': 'http://lorempixel.com/128/128/city/1/', 'uhd': 'http://lorempixel.com/256/256/city/1/'}, alt: 'Large'},
+		{kind: 'moon.Image', src: {'hd': 'http://lorempixel.com/64/64/city/1/', 'fhd': 'http://lorempixel.com/128/128/city/1/', 'uhd': 'http://lorempixel.com/256/256/city/1/'}, alt: 'Large'}
 	]
 });


### PR DESCRIPTION
### Issue

Due to some confounding factors such as mismatched CSS already causing Travis failures, we merged in a sample with a trailing comma, which causes a JSHint failure.
### Fix

We remove the trailing comma in the sample. Because this is a sample and on a non-mainline branch, I'm going to push this low-risk change in directly so that we can rebase another fix that needs to be merged.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
