### PR TITLE
ENYO-721: Update Travis build process to generate resolution-independent CSS files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   npm -g install jshint &&
   echo -e "\x1b\x5b35;1m*** Checking out Enyo\x1b\x5b0m" &&
   cd .. &&
-  git clone --depth 1 https://github.com/enyojs/enyo.git enyo &&
+  git clone --depth 1 -b 2.5-gordon https://github.com/enyojs/enyo.git enyo &&
   mkdir lib &&
   mv moonstone lib/moonstone
 script:
@@ -16,7 +16,7 @@ script:
   cd css &&
   mv moonstone-dark.css moonstone-dark.css.fromgit &&
   mv moonstone-light.css moonstone-light.css.fromgit &&
-  ../../../enyo/tools/lessc.sh -enyo ../../../enyo/enyo.js all-package.js &&
+  ../../../enyo/tools/lessc.sh -ri -enyo ../../../enyo/enyo.js all-package.js &&
   echo -e "\x1b\x5b35;1m*** Comparing generated CSS to last checked in version\x1b\x5b0m" &&
   diff moonstone-dark.css moonstone-dark.css.fromgit &&
   diff moonstone-light.css moonstone-light.css.fromgit &&


### PR DESCRIPTION
### Issue

Now that have modified our LESS process for generating CSS files, the CSS files generated from Travis no longer match the resolution-independent CSS files.
### Fix

We add the use of the `ri` flag to the Travis build script, and modify the Travis build configuration so that it utilizes the `2.5-gordon` branch when cloning `enyo`.
### Notes

I tried coming up with a solution that didn't involve hardcoding the `2.5-gordon` branch, but the Travis environmental variables only provide the value of the base branch when initially creating a pull request (otherwise it will return the value of the current branch that we are comparing, which is not helpful), and not for subsequent commits on the same branch after the pull request has been opened.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
