### PR TITLE
BHV-20509 : add a patch that support same font size between 2.5-upkeep and 2.5-gordo...

### DIFF
--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -7,8 +7,8 @@
 /* LESS file.                                                               */
 
 html {
+  font-size: 1rem;
   font-size: 12px;
-  font-size: 12apx;
 }
 /* ----- MISO ------ */
 @font-face {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -6,6 +6,10 @@
 /* minifier to fall back to using CSS files in place of the same-name       */
 /* LESS file.                                                               */
 
+html {
+  font-size: 12px;
+  font-size: 12apx;
+}
 /* ----- MISO ------ */
 @font-face {
   font-family: "Moonstone Miso";

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -7,8 +7,8 @@
 /* LESS file.                                                               */
 
 html {
+  font-size: 1rem;
   font-size: 12px;
-  font-size: 12apx;
 }
 /* ----- MISO ------ */
 @font-face {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -6,6 +6,10 @@
 /* minifier to fall back to using CSS files in place of the same-name       */
 /* LESS file.                                                               */
 
+html {
+  font-size: 12px;
+  font-size: 12apx;
+}
 /* ----- MISO ------ */
 @font-face {
   font-family: "Moonstone Miso";


### PR DESCRIPTION
## Issue
Nowadays, some app developer are developing their normal and lite version in one source code.
Thus, they changed fixel to rem for supporting normal version and lite version. 
And it works well in the lite version(2.5-gordon, 2.5.3-pre.4.lite.1), but doesn't in normal version(2.5-upkeep, 2.5.3-pre.4)

## Fix
Reason for this issue is basic font-size of html page.
In the 2.5.3-pre.4.lite.1, FHD has a 12px basic font size.
But, in the 2.5.3-pre.4, FHD has a 16px basic font size.
So, add a patch that support same font size between 2.5-upkeep and 2.5-gordon

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com