### PR TITLE
Fixes ENYO-723

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -740,6 +740,10 @@
 		* @private
 		*/
 		_marquee_startAnimation: function (sender, ev) {
+			// if this control hasn't been generated, there's no need to follow through on
+			// marquee requests as we'll be unable to correctly measure the distance delta yet
+			if (!this.generated) return;
+
 			var distance = this._marquee_calcDistance();
 
 			// If there is no need to animate, return early


### PR DESCRIPTION
## Issue
`_marquee_calcDistance` expects a valid node to measure its natural and clipped dimensions. In cases where the control hasn't been generated but a marquee has been requested (e.g. an onRequestMarqueeStart event waterfalled down from a containing contro), this measurement fails.

## Fix
Prevent starting marquee when the control hasn't been generated

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)