### PR TITLE
ENYO-719: transitionFinished() is not called when panel is changed with ...

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -951,7 +951,7 @@
 		finishTransition: function (sendEvents) {
 			var panels = this.getPanels(),
 				transitioned = typeof this.lastIndex !== 'undefined',
-				method = transitioned ? (sendEvents ? 'transitionFinished' : 'updatePanel') : 'initPanel',
+				method = transitioned ? (!this.animate || sendEvents ? 'transitionFinished' : 'updatePanel') : 'initPanel',
 				i,
 				panel,
 				info,


### PR DESCRIPTION
...pushPanel() when animate is false
### Issue:

Apps are overriding transitionFinished function to do something after indexChanged (animation finished).
But, this function is only called when animate is true.
### Fix:

Adding !this.animate condition on finishTransition to change method from updatePanel to transitionFinished when animate is false.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com
