### PR TITLE
ENYO-719: Allow transitionFinished to be called when transitioning a non-animated panel.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -951,7 +951,7 @@
 		finishTransition: function (sendEvents) {
 			var panels = this.getPanels(),
 				transitioned = typeof this.lastIndex !== 'undefined',
-				method = transitioned ? (sendEvents ? 'transitionFinished' : 'updatePanel') : 'initPanel',
+				method = transitioned ? 'transitionFinished' : 'initPanel',
 				i,
 				panel,
 				info,


### PR DESCRIPTION
### Issue

In `2.5-gordon`, we are not animating panels by default. This prevents `transitionFinished` from being called on `moon.Panel`.
### Fix

Because `transitionFinished` is calling `updatePanel` by default, we modify the logic to only conditionally call `transitionFinished` when changing panel indices, otherwise call `initPanel`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
