### PR TITLE
ENYO-726: Adding fix for ENYO-437 (2.5.1.1)

### DIFF
--- a/samples/package.js
+++ b/samples/package.js
@@ -66,6 +66,8 @@ enyo.depends(
 	"LabeledTextItemSample.js",
 	"ListActionsSample.css",
 	"ListActionsSample.js",
+	"MarqueeSample.css",
+	"MarqueeSample.js",
 	"ObjectActionHorizontalTypeSample.css",
 	"ObjectActionHorizontalTypeSample.js",
 	"ObjectActionVerticalTypeSample.css",


### PR DESCRIPTION
Cherry-picking changes from https://github.com/enyojs/moonstone/pull/1751 into `2.5.1-release`, creating a PR for tracking purposes.