### PR TITLE
ENYO-737: moon.Dialog client area layout by float not Fittable

### DIFF
--- a/css/Dialog.less
+++ b/css/Dialog.less
@@ -18,7 +18,16 @@
 }
 .moon-dialog-client {
 	padding: 36px 0 0;
+	float: right;
 }
 .moon-dialog-client > * {
 	margin-left: @moon-grid-gutter-width;
+	margin-right: 0;
+}
+.enyo-locale-right-to-left .moon-dialog-client {
+	float: left;
+}
+.enyo-locale-right-to-left .moon-dialog-client > * {
+	margin-left: 0;
+	margin-right: @moon-grid-gutter-width;
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3460,9 +3460,18 @@
 }
 .moon-dialog-client {
   padding: 36px 0 0;
+  float: right;
 }
 .moon-dialog-client > * {
   margin-left: 20px;
+  margin-right: 0;
+}
+.enyo-locale-right-to-left .moon-dialog-client {
+  float: left;
+}
+.enyo-locale-right-to-left .moon-dialog-client > * {
+  margin-left: 0;
+  margin-right: 20px;
 }
 .moon-tooltip {
   z-index: 20;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3460,9 +3460,18 @@
 }
 .moon-dialog-client {
   padding: 36px 0 0;
+  float: right;
 }
 .moon-dialog-client > * {
   margin-left: 20px;
+  margin-right: 0;
+}
+.enyo-locale-right-to-left .moon-dialog-client {
+  float: left;
+}
+.enyo-locale-right-to-left .moon-dialog-client > * {
+  margin-left: 0;
+  margin-right: 20px;
 }
 .moon-tooltip {
   z-index: 20;

--- a/source/Dialog.js
+++ b/source/Dialog.js
@@ -114,13 +114,12 @@
 			{name: 'closeButton', kind: 'moon.IconButton', icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', showing:false},
 
 			{
-				layoutKind: 'FittableColumnsLayout',
 				components: [
-					{fit: true, components: [
+					{name: 'client', classes: 'moon-dialog-client'},
+					{components: [
 						{name: 'title', kind: 'moon.MarqueeText', classes: 'moon-popup-header-text moon-dialog-title'},
 						{name: 'subTitle', classes: 'moon-dialog-sub-title'}
-					]},
-					{name: 'client', classes: 'moon-dialog-client'}
+					]}
 				]
 			},
 			{kind: 'moon.Divider', classes: 'moon-dialog-divider'},


### PR DESCRIPTION
Issue:
moon.Dialog is layout title and client buttons with Fittable.
If developer dynamically change button showing status, then button will not be aligned on right side because the client width is fixed by fittable on render time.

Fix:
Remove fittable on Dialog and apply float to position client area.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com