### PR TITLE
ENYO-696 (2.5-gordon)

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -815,12 +815,14 @@
 		* @private
 		*/
 		_marquee_calcDistance: function () {
-			if (this._marquee_distance !== null) {
-				return this._marquee_distance;
+			var node, rect;
+
+			if (this._marquee_distance == null) {
+				node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode();
+				rect = node.getBoundingClientRect();
+				this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
 			}
-			var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(),
-				rect = node? node.getBoundingClientRect() : {};
-			this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
+
 			return this._marquee_distance;
 		},
 

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -818,8 +818,9 @@
 			if (this._marquee_distance !== null) {
 				return this._marquee_distance;
 			}
-			var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode();
-			this._marquee_distance = Math.abs(node.scrollWidth - node.clientWidth);
+			var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(),
+				rect = node? node.getBoundingClientRect() : {};
+			this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
 			return this._marquee_distance;
 		},
 


### PR DESCRIPTION
Cherry-picking the changes from https://github.com/enyojs/moonstone/pull/1864 into `2.5-gordon`, creating a PR for tracking purposes.

Note: This change is even more helpful for `2.5-gordon` as the lack of layers results in a number of additional repaints, so we want to minimize any unnecessary animation.