### PR TITLE
ENYO-752: Set position of initial value via transform.

### DIFF
--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -171,6 +171,7 @@
 				this.animateChanged();
 				this.initializeActiveItem();
 				this.disabledChanged();
+				this.selectedIndexChanged();
 				this.updateMarqueeDisable();
 				this.blockChanged();
 				this.showHideNavButtons();


### PR DESCRIPTION
### Issue
We had previously removed the call to `selectedIndexChanged` in `create` to prevent calling this method twice, in making this fix: https://github.com/enyojs/moonstone/commit/1a1ab6. This resulted in any `moon.SimplePicker` being set to an initial value that did not correspond to the first item to display an animation upon initial load.

### Fix
Because we do not yet have a comprehensive fix for the rounding issue with transforms, we re-add the call to `selectedIndexChanged`.

### Notes
For `moon.SimplePicker` controls with a high number of items (i.e. `moon.Calendar`), an animation will still be seen as we are necessarily adjusting the position via the original fix, but this change resolves the issue for the majority of cases.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>