### PR TITLE
ENYO-698: ContextualPopup: Spotlight Does Not Spot Parent upon 'Select Dismiss On' #1849

### DIFF
--- a/samples/ContextualPopupSample.js
+++ b/samples/ContextualPopupSample.js
@@ -25,7 +25,7 @@ enyo.kind({
 		]},
 		{kind: 'moon.ContextualPopupDecorator', style:'position: absolute; right: 0px; top: 13%;', components: [
 			{content:'Nested Radio', small:true},
-				{name:'nestedRadioPopup', kind: 'moon.ContextualPopup', components:[
+				{name:'nestedRadioPopup', kind: 'moon.ContextualPopup', spotActivatorOnClose: true, components:[
 					{name:'nestedRadioGroup', kind: 'moon.RadioItemGroup', components: [
 						{content: 'Creek', selected: true},
 						{content: 'River'},

--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -542,6 +542,10 @@
 			this.inherited(arguments);
 			this.alterDirection();
 			this.showHideScrim(this.showing);
+
+			if(this.spotActivatorOnClose) {
+				enyo.Spotlight.spot(this.activator);
+			}
 		},
 
 		/**

--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -543,7 +543,7 @@
 			this.alterDirection();
 			this.showHideScrim(this.showing);
 
-			if(this.spotActivatorOnClose) {
+			if(this.spotActivatorOnClose && !this.showing) {
 				enyo.Spotlight.spot(this.activator);
 			}
 		},


### PR DESCRIPTION
Issue.

When using Dismiss on Select, the popup activator was not re-spotted because hide was used instead of closePopup

Fix.

Switch the method being used to close popup.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com