### PR TITLE
Fixes ENYO-731

### DIFF
--- a/css/Drawers.less
+++ b/css/Drawers.less
@@ -30,6 +30,7 @@
 		background-color: @moon-drawer-bg-color;
 		background-repeat: no-repeat;
 		background-position: center center;
+		background-size: contain;
 		content: @moon-icon-arrowsmalldown;
 		color: @moon-drawer-activator-font-color;
 		text-align: center;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3359,6 +3359,7 @@ html {
   background-color: #404040;
   background-repeat: no-repeat;
   background-position: center center;
+  background-size: contain;
   content: "\0F0006";
   color: #a6a6a6;
   text-align: center;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3359,6 +3359,7 @@ html {
   background-color: #4b4b4b;
   background-repeat: no-repeat;
   background-position: center center;
+  background-size: contain;
   content: "\0F0006";
   color: #a6a6a6;
   text-align: center;


### PR DESCRIPTION
## Issue

Image assets designed for 1080p are too large to display correctly as the activator icon for moon.Drawers.
## Fix

Adding `background-size: contain` to ensure they don't exceed the activator's bounds
