### PR TITLE
ENYO-763: Account for transformational rounding issues in scroller thumb.

### DIFF
--- a/source/Thumb.js
+++ b/source/Thumb.js
@@ -66,6 +66,21 @@
 		/**
 		* @private
 		*/
+		rendered: enyo.inherit(function (sup) {
+			return function () {
+				sup.apply(this, arguments);
+
+				// Rounding to the nearest whole pixel in the dimension that will be transformed, to
+				// prevent rounding issues when transforms are applied.
+				var node = this.hasNode(),
+					rect = node && node.getBoundingClientRect();
+				if (rect) this.applyStyle(this.dimension, Math.round(rect[this.dimension]) + 'px');
+			};
+		}),
+
+		/**
+		* @private
+		*/
 		update: function (inStrategy) {
 			if (this.showing && this.scrollBounds) {
 				var d = this.dimension;
@@ -83,11 +98,11 @@
 				}
 				var sbo = inStrategy[this.positionMethod]() - over;
 				// calc size & position
-				var bdc = bd - this.cornerSize;
+				var bdc = bd - moon.riScale(this.cornerSize);
 				var s = Math.floor((bd * bd / sbd) - overs);
-				s = Math.max(this.minSize, s);
+				s = Math.max(moon.riScale(this.minSize), s);
 				var p = Math.floor((bdc * sbo / sbd) + overp);
-				p = Math.max(0, Math.min(bdc - this.minSize, p));
+				p = Math.max(0, Math.min(bdc - moon.riScale(this.minSize), p));
 	
 				p *= ratio;
 				s *= ratio;

--- a/source/Thumb.js
+++ b/source/Thumb.js
@@ -61,6 +61,10 @@
 			this.positionMethod = v ? 'getScrollTop' : 'getScrollLeft';
 			this.sizeDimension = v ? 'clientHeight' : 'clientWidth';
 			this.addClass('enyo-' + this.axis + 'thumb');
+
+			// Pre-calculation of internal, resolution-specific metrics
+			this.cornerSize = moon.riScale(this.cornerSize);
+			this.minSize = moon.riScale(this.minSize);
 		},
 
 		/**
@@ -98,11 +102,11 @@
 				}
 				var sbo = inStrategy[this.positionMethod]() - over;
 				// calc size & position
-				var bdc = bd - moon.riScale(this.cornerSize);
+				var bdc = bd - this.cornerSize;
 				var s = Math.floor((bd * bd / sbd) - overs);
-				s = Math.max(moon.riScale(this.minSize), s);
+				s = Math.max(this.minSize, s);
 				var p = Math.floor((bdc * sbo / sbd) + overp);
-				p = Math.max(0, Math.min(bdc - moon.riScale(this.minSize), p));
+				p = Math.max(0, Math.min(bdc - this.minSize, p));
 	
 				p *= ratio;
 				s *= ratio;


### PR DESCRIPTION
### Issue
The size of the scroller thumb can be incorrectly transformed when its non-transformed measurements consist of fractional pixels. This can cause the visual appearance of the scroller thumb to either appear too small or too large.

### Fix
This is another case of the web engine utilizing the rounded value of an element's measurement when applying transforms. To circumvent this, we set the value of the to-be-transformed dimension (width or height) to its rounded value at render time, so that subsequent computations will align with the value that the transformation will ultimately utilize. Additionally, we preemptively scale several pixel values to their appropriate values via `moon.riScale`. Note that simply retrieving and utilizing the actual, fractional values in the `generateMatrix` function (using `getBoundingClientRect` instead of `offsetHeight` and `offsetWidth`) to generate the transformation matrix is not sufficient as the rounded value will be utilized when the transformation is applied.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>