### PR TITLE
ENYO-722: Re-generate CSS with the appropriate amount of measurement precision.

### DIFF
--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -13,7 +13,7 @@ html {
 /* 720p screen size */
 @media only screen and (max-width: 1280px) {
   html {
-    font-size: 0.6666666666666666rem;
+    font-size: 0.66667rem;
     font-size: 16px;
   }
 }
@@ -221,140 +221,140 @@ html {
   width: 2.5rem;
 }
 .moon-2h {
-  width: 5.83333333rem;
+  width: 5.83333rem;
 }
 .moon-3h {
-  width: 9.16666667rem;
+  width: 9.16667rem;
 }
 .moon-4h {
   width: 12.5rem;
 }
 .moon-5h {
-  width: 15.83333333rem;
+  width: 15.83333rem;
 }
 .moon-6h {
-  width: 19.16666667rem;
+  width: 19.16667rem;
 }
 .moon-7h {
   width: 22.5rem;
 }
 .moon-8h {
-  width: 25.83333333rem;
+  width: 25.83333rem;
 }
 .moon-9h {
-  width: 29.16666667rem;
+  width: 29.16667rem;
 }
 .moon-10h {
   width: 32.5rem;
 }
 .moon-11h {
-  width: 35.83333333rem;
+  width: 35.83333rem;
 }
 .moon-12h {
-  width: 39.16666667rem;
+  width: 39.16667rem;
 }
 .moon-13h {
   width: 42.5rem;
 }
 .moon-14h {
-  width: 45.83333333rem;
+  width: 45.83333rem;
 }
 .moon-15h {
-  width: 49.16666667rem;
+  width: 49.16667rem;
 }
 .moon-16h {
   width: 52.5rem;
 }
 .moon-17h {
-  width: 55.83333333rem;
+  width: 55.83333rem;
 }
 .moon-18h {
-  width: 59.16666667rem;
+  width: 59.16667rem;
 }
 .moon-19h {
   width: 62.5rem;
 }
 .moon-20h {
-  width: 65.83333333rem;
+  width: 65.83333rem;
 }
 /* ------- Vertical Dimensioning (columns) ------- */
 .moon-1v {
-  height: 1.66666667rem;
+  height: 1.66667rem;
 }
 .moon-2v {
-  height: 3.33333333rem;
+  height: 3.33333rem;
 }
 .moon-3v {
   height: 5rem;
 }
 .moon-4v {
-  height: 6.66666667rem;
+  height: 6.66667rem;
 }
 .moon-5v {
-  height: 8.33333333rem;
+  height: 8.33333rem;
 }
 .moon-6v {
   height: 10rem;
 }
 .moon-7v {
-  height: 11.66666667rem;
+  height: 11.66667rem;
 }
 .moon-8v {
-  height: 13.33333333rem;
+  height: 13.33333rem;
 }
 .moon-9v {
   height: 15rem;
 }
 .moon-10v {
-  height: 16.66666667rem;
+  height: 16.66667rem;
 }
 .moon-11v {
-  height: 18.33333333rem;
+  height: 18.33333rem;
 }
 .moon-12v {
   height: 20rem;
 }
 .moon-13v {
-  height: 21.66666667rem;
+  height: 21.66667rem;
 }
 .moon-14v {
-  height: 23.33333333rem;
+  height: 23.33333rem;
 }
 .moon-15v {
   height: 25rem;
 }
 .moon-16v {
-  height: 26.66666667rem;
+  height: 26.66667rem;
 }
 .moon-17v {
-  height: 28.33333333rem;
+  height: 28.33333rem;
 }
 .moon-18v {
   height: 30rem;
 }
 .moon-19v {
-  height: 31.66666667rem;
+  height: 31.66667rem;
 }
 .moon-20v {
-  height: 33.33333333rem;
+  height: 33.33333rem;
 }
 .moon-21v {
   height: 35rem;
 }
 .moon-22v {
-  height: 36.66666667rem;
+  height: 36.66667rem;
 }
 .moon-23v {
-  height: 38.33333333rem;
+  height: 38.33333rem;
 }
 .moon-24v {
   height: 40rem;
 }
 .moon-25v {
-  height: 41.66666667rem;
+  height: 41.66667rem;
 }
 .moon-26v {
-  height: 43.33333333rem;
+  height: 43.33333rem;
 }
 /* Prevent browser's default focus treatment (at least in Chrome) */
 :focus {
@@ -367,7 +367,7 @@ html {
   font-weight: normal;
   font-style: normal;
   letter-spacing: normal;
-  padding: 0.83333333rem;
+  padding: 0.83333rem;
   color: #a6a6a6;
   background-color: #000000;
 }
@@ -375,10 +375,10 @@ html {
   direction: rtl;
 }
 .moon-divider-border {
-  border-bottom: 0.08333333rem solid #a6a6a6;
+  border-bottom: 0.08333rem solid #a6a6a6;
 }
 .moon-neutral-divider-border {
-  border-bottom: 0.08333333rem solid #ffffff;
+  border-bottom: 0.08333rem solid #ffffff;
 }
 .moon-composite {
   -webkit-transform: translateZ(0);
@@ -398,7 +398,7 @@ html {
 .moon-superscript {
   font-size: 1rem;
   vertical-align: top;
-  margin: 0 0 0 0.08333333333333333rem;
+  margin: 0 0 0 0.08333rem;
   padding: 0;
 }
 .moon-pre-text {
@@ -406,7 +406,7 @@ html {
   vertical-align: top;
   height: 2rem;
   line-height: 1rem;
-  margin: 0.5rem 0.08333333333333333rem 0.3333333333333333rem 0;
+  margin: 0.5rem 0.08333rem 0.33333rem 0;
   padding: 0rem;
 }
 .moon-large-text {
@@ -429,24 +429,24 @@ html {
 }
 .moon-super-header-text {
   font-family: "Moonstone Miso";
-  font-size: 1.33333333rem;
+  font-size: 1.33333rem;
   -webkit-font-kerning: normal;
 }
 .moon-popup-header-text {
   font-family: "Moonstone Miso";
-  font-size: 3.04166667rem;
+  font-size: 3.04167rem;
   -webkit-font-kerning: normal;
 }
 .moon-divider-text {
   font-family: "MuseoSans 700 Italic";
-  font-size: 0.91666667rem;
+  font-size: 0.91667rem;
   color: #a6a6a6;
 }
 .moon-body-text {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #a6a6a6;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-body-text a:link {
   color: #cf0652;
@@ -465,14 +465,14 @@ html {
   text-decoration: none;
 }
 .moon-body-large-text {
-  font-size: 1.16666667rem;
-  line-height: 1.66666667rem;
+  font-size: 1.16667rem;
+  line-height: 1.66667rem;
 }
 .moon-bold-text {
   font-family: "MuseoSans 900";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #a6a6a6;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-bold-text a:link {
   color: #cf0652;
@@ -491,7 +491,7 @@ html {
   text-decoration: none;
 }
 .moon-body-text-spacing {
-  margin: 0 0.41666667rem 1.66666667rem 0.41666667rem;
+  margin: 0 0.41667rem 1.66667rem 0.41667rem;
 }
 .moon-large-button-text {
   font-family: "Moonstone Miso Bold";
@@ -548,29 +548,29 @@ html {
   line-height: 1.5em;
 }
 .enyo-locale-non-latin .moon-popup-header-text {
-  font-size: 2.70833333rem;
+  font-size: 2.70833rem;
 }
 .enyo-locale-non-latin .moon-sub-header-text {
   font-size: 1.25rem;
 }
 .enyo-locale-non-latin .moon-super-header-text {
-  font-size: 1.33333333rem;
+  font-size: 1.33333rem;
 }
 .enyo-locale-non-latin .moon-divider-text {
-  font-size: 1.16666667rem;
+  font-size: 1.16667rem;
   font-style: normal;
 }
 .enyo-locale-non-latin .moon-body-text {
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 .enyo-locale-non-latin .moon-body-large-text {
-  font-size: 1.16666667rem;
-  line-height: 1.66666667rem;
+  font-size: 1.16667rem;
+  line-height: 1.66667rem;
 }
 .enyo-locale-non-latin .moon-bold-text {
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 .enyo-locale-non-latin .moon-large-button-text {
   font-size: 1.5rem;
@@ -594,7 +594,7 @@ html {
   background-repeat: no-repeat;
   display: inline-block;
   vertical-align: middle;
-  margin: 0.375rem 0.5833333333333334rem;
+  margin: 0.375rem 0.58333rem;
   font-family: "Moonstone", "Moonstone Icons";
   font-size: 3.75rem;
   line-height: 1.875rem;
@@ -605,19 +605,19 @@ html {
 .moon-icon.small,
 .moon-icon-toggle.small {
   background-position: center -0.375rem;
-  background-size: 2.08333333rem 4.16666667rem;
-  width: 1.33333333rem;
-  height: 1.33333333rem;
-  font-size: 2.66666667rem;
-  line-height: 1.33333333rem;
+  background-size: 2.08333rem 4.16667rem;
+  width: 1.33333rem;
+  height: 1.33333rem;
+  font-size: 2.66667rem;
+  line-height: 1.33333rem;
 }
 .moon-icon.small > .small-icon-tap-area,
 .moon-icon-toggle.small > .small-icon-tap-area {
   position: absolute;
-  top: -0.58333333rem;
-  bottom: -0.58333333rem;
-  left: -0.58333333rem;
-  right: -0.58333333rem;
+  top: -0.58333rem;
+  bottom: -0.58333rem;
+  left: -0.58333rem;
+  right: -0.58333rem;
   color: inherit;
   line-height: 2.5rem;
 }
@@ -628,14 +628,14 @@ html {
 }
 .moon-icon.font-lg-icons.small,
 .moon-icon-toggle.font-lg-icons.small {
-  font-size: 1.33333333rem;
+  font-size: 1.33333rem;
 }
 .spotlight .moon-icon {
   color: #ffffff;
   background-position: center -3.75rem;
 }
 .spotlight .moon-icon.small {
-  background-position: center -2.45833333rem;
+  background-position: center -2.45833rem;
 }
 .disabled .moon-icon,
 .moon-icon.disabled {
@@ -647,23 +647,23 @@ html {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   color: #a6a6a6;
-  width: 3.54166667rem;
-  height: 3.54166667rem;
-  border-radius: 1.77083333rem;
+  width: 3.54167rem;
+  height: 3.54167rem;
+  border-radius: 1.77083rem;
   background-color: #404040;
   background-size: 3.125rem 6.25rem;
-  border: 0.20833333rem solid transparent;
+  border: 0.20833rem solid transparent;
   background-position: center 0;
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
   line-height: 3.125rem;
 }
 .moon-icon-button.small {
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 1.25rem;
-  background-size: 2.08333333rem 4.16666667rem;
+  background-size: 2.08333rem 4.16667rem;
   background-position: center 0;
-  line-height: 2.08333333rem;
+  line-height: 2.08333rem;
 }
 .moon-icon-button.small > .small-icon-tap-area {
   line-height: 3.25rem;
@@ -676,7 +676,7 @@ html {
 }
 .moon-icon-button.hover:hover:not(.disabled).small,
 .moon-icon-button.spotlight.small {
-  background-position: center -2.08333333rem;
+  background-position: center -2.08333rem;
 }
 .moon-icon-button.active:not(.spotlight),
 .moon-icon-button:active,
@@ -714,13 +714,13 @@ html {
 }
 .moon-icon-button.active.spotlight:not(.contextual-popup-button):active.small,
 .moon-icon-button.active.spotlight:not(.contextual-popup-button).pressed.small {
-  background-position: center -2.08333333rem;
+  background-position: center -2.08333rem;
 }
 .spotlight .moon-icon-button {
   background-position: center -3.125rem;
 }
 .spotlight .moon-icon-button.small {
-  background-position: center -2.08333333rem;
+  background-position: center -2.08333rem;
 }
 .moon-marquee {
   width: auto;
@@ -759,9 +759,9 @@ html {
 }
 .moon-simple-picker {
   display: inline-block;
-  max-width: 14.583333333333334rem;
+  max-width: 14.58333rem;
   box-sizing: border-box;
-  padding: 0 2.91666667rem;
+  padding: 0 2.91667rem;
   position: relative;
   height: 2.5rem;
   vertical-align: middle;
@@ -893,7 +893,7 @@ html {
 /* Checkbox.css */
 .moon-checkbox {
   cursor: pointer;
-  height: 1.33333333rem;
+  height: 1.33333rem;
 }
 .moon-checkbox .moon-icon {
   visibility: hidden;
@@ -907,12 +907,12 @@ html {
   color: #ffffff;
 }
 .moon-divider {
-  border-bottom: 0.08333333rem solid #a6a6a6;
-  margin: 0 0.41666667rem 0.83333333rem 0.41666667rem;
+  border-bottom: 0.08333rem solid #a6a6a6;
+  margin: 0 0.41667rem 0.83333rem 0.41667rem;
   padding-bottom: 0.125rem;
 }
 .moon-neutral .moon-divider {
-  border-bottom: 0.08333333rem solid #ffffff;
+  border-bottom: 0.08333rem solid #ffffff;
 }
 .moon-checkbox-item {
   position: relative;
@@ -920,19 +920,19 @@ html {
 }
 .moon-checkbox-item .moon-checkbox {
   position: absolute;
-  top: 0.33333333rem;
+  top: 0.33333rem;
   right: 0.25rem;
 }
 .moon-checkbox-item .moon-checkbox-item-label-wrapper {
   height: 1.2em;
-  margin-right: 1.33333333rem;
+  margin-right: 1.33333rem;
 }
 .moon-checkbox-item.left-handed .moon-checkbox {
   left: 0.25rem;
 }
 .moon-checkbox-item.left-handed .moon-checkbox-item-label-wrapper {
   margin-right: 0rem;
-  margin-left: 1.33333333rem;
+  margin-left: 1.33333rem;
 }
 .moon-checkbox-item .moon-icon.small > .small-icon-tap-area {
   left: 0;
@@ -943,19 +943,19 @@ html {
 }
 /* Special treatment inside of ExpandablePicker (checkbox nudged up) */
 .moon-expandable-picker .moon-checkbox-item .moon-checkbox {
-  top: 0.41666667rem;
+  top: 0.41667rem;
 }
 /* this is a fix for TV only - left-side of letter cut off in list-action item drawer*/
 .moon-list-actions-drawer-client .moon-checkbox-item .moon-checkbox-item-label-wrapper {
-  padding-left: 0.08333333333333333rem;
+  padding-left: 0.08333rem;
 }
 /* Right to left */
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox {
-  left: 0.58333333rem;
+  left: 0.58333rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox-item-label-wrapper {
-  margin-left: 1.33333333rem;
+  margin-left: 1.33333rem;
   margin-right: 0rem;
 }
 .enyo-locale-right-to-left .moon-checkbox-item.left-handed .moon-checkbox {
@@ -963,7 +963,7 @@ html {
   right: 0.25rem;
 }
 .enyo-locale-right-to-left .moon-checkbox-item.left-handed .moon-checkbox-item-label-wrapper {
-  margin-right: 1.33333333rem;
+  margin-right: 1.33333rem;
   margin-left: 0rem;
 }
 /* ToggleText.css */
@@ -986,7 +986,7 @@ html {
 .moon-toggle-text-text {
   position: absolute;
   right: 0rem;
-  top: 0.08333333333333333rem;
+  top: 0.08333rem;
   text-align: right;
   color: #a6a6a6;
 }
@@ -1000,12 +1000,12 @@ html {
 /* ToggleSwitch.css */
 .moon-checkbox.moon-toggle-switch {
   border-radius: 0.6875rem;
-  width: 2.70833333rem;
+  width: 2.70833rem;
   height: 1.375rem;
   line-height: 1.375rem;
   background-color: #404040;
   font-family: "Moonstone Icons";
-  font-size: 2.70833333rem;
+  font-size: 2.70833rem;
   overflow: hidden;
   text-align: left;
 }
@@ -1020,7 +1020,7 @@ html {
   background-color: #ffffff;
 }
 .moon-checkbox.moon-toggle-switch[checked] .moon-icon {
-  left: 1.35416667rem;
+  left: 1.35417rem;
   color: #cf0652;
 }
 .moon-checkbox.moon-toggle-switch[disabled] {
@@ -1045,15 +1045,15 @@ html {
   position: relative;
 }
 .moon-toggle-item .moon-checkbox.moon-toggle-switch {
-  top: 0.45833333rem;
+  top: 0.45833rem;
   /* To override top:10px set by .moon-checkbox-item .moon-checkbox so the indicator vertically middle align */
-  right: 0.41666667rem;
+  right: 0.41667rem;
 }
 .moon-toggle-item .moon-toggle-item-label-wrapper {
   margin-right: 3.125rem;
 }
 .enyo-locale-right-to-left .moon-toggle-item .moon-checkbox.moon-toggle-switch {
-  left: 0.41666667rem;
+  left: 0.41667rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-toggle-item .moon-toggle-item-label-wrapper {
@@ -1064,54 +1064,54 @@ html {
 .moon-button.moon-toggle-button {
   text-align: center;
   position: relative;
-  padding-right: 2.58333333rem;
+  padding-right: 2.58333rem;
 }
 .moon-button.moon-toggle-button:after {
   position: absolute;
   content: "";
-  top: 1.14583333rem;
-  right: 0.91666667rem;
-  width: 0.66666667rem;
-  height: 0.66666667rem;
+  top: 1.14583rem;
+  right: 0.91667rem;
+  width: 0.66667rem;
+  height: 0.66667rem;
   border-radius: 416.625rem;
   background-color: #4d4d4d;
-  border: solid 0.08333333rem #ffffff;
+  border: solid 0.08333rem #ffffff;
 }
 .moon-button.moon-toggle-button[disabled] {
-  border: 0.20833333rem solid transparent;
+  border: 0.20833rem solid transparent;
 }
 .moon-button.moon-toggle-button[disabled]:after {
   background-color: #252525;
-  border: solid 0.08333333rem #6d6c6c;
+  border: solid 0.08333rem #6d6c6c;
 }
 .moon-button.moon-toggle-button.moon-toggle-button-on {
-  border: solid 0.20833333rem #cf0652;
+  border: solid 0.20833rem #cf0652;
 }
 .moon-button.moon-toggle-button.moon-toggle-button-on:after {
   background-color: #cf0652;
-  border: solid 0.08333333rem #ffffff;
+  border: solid 0.08333rem #ffffff;
 }
 .moon-button.moon-toggle-button.small {
   padding-right: 2.5rem;
 }
 .moon-button.moon-toggle-button.small:after {
   top: 0.625rem;
-  right: 0.83333333rem;
+  right: 0.83333rem;
 }
 .enyo-locale-right-to-left .moon-button.moon-toggle-button {
-  padding-right: 0.91666667rem;
-  padding-left: 2.58333333rem;
+  padding-right: 0.91667rem;
+  padding-left: 2.58333rem;
 }
 .enyo-locale-right-to-left .moon-button.moon-toggle-button:after {
-  left: 0.91666667rem;
+  left: 0.91667rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-button.moon-toggle-button.small {
-  padding-right: 0.83333333rem;
+  padding-right: 0.83333rem;
   padding-left: 2.5rem;
 }
 .enyo-locale-right-to-left .moon-button.moon-toggle-button.small:after {
-  left: 0.83333333rem;
+  left: 0.83333rem;
   right: auto;
 }
 /* Item.css */
@@ -1120,7 +1120,7 @@ html {
   font-size: 1.25rem;
   color: #a6a6a6;
   line-height: 1.2em;
-  padding: 0.41666667rem;
+  padding: 0.41667rem;
   position: relative;
 }
 .moon-item.spotlight {
@@ -1140,45 +1140,45 @@ html {
 }
 /* SelectableItem.css */
 .moon-selectable-item.selected {
-  padding: 0.41666667rem 0.41666667rem 0.41666667rem 1.75rem;
+  padding: 0.41667rem 0.41667rem 0.41667rem 1.75rem;
 }
 .moon-selectable-item.selected:before {
   content: '';
   position: absolute;
-  left: 0.41666667rem;
-  top: 0.7083333333333334rem;
-  width: 0.83333333rem;
-  height: 0.83333333rem;
-  border-radius: 0.41666667rem;
+  left: 0.41667rem;
+  top: 0.70833rem;
+  width: 0.83333rem;
+  height: 0.83333rem;
+  border-radius: 0.41667rem;
   background-color: #cf0652;
 }
 .moon-selectable-item.selected.spotlight:before {
   background-color: #ffffff;
 }
 .enyo-locale-right-to-left .moon-selectable-item.selected {
-  padding: 0.41666667rem 1.75rem 0.41666667rem 0.41666667rem;
+  padding: 0.41667rem 1.75rem 0.41667rem 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-selectable-item.selected:before {
   left: auto;
-  right: 0.41666667rem;
+  right: 0.41667rem;
 }
 /* Button */
 .moon-button {
   position: relative;
   overflow: visible;
-  height: 3.54166667rem;
+  height: 3.54167rem;
   line-height: 3.125rem;
   border-radius: 416.625rem;
   background-color: #404040;
-  border: 0.20833333rem solid transparent;
+  border: 0.20833rem solid transparent;
   cursor: pointer;
   white-space: nowrap;
   display: inline-block;
   width: auto;
-  min-width: 3.54166667rem;
-  max-width: 12.583333333333334rem;
-  padding: 0 0.91666667rem;
-  margin: 0 0.41666667rem;
+  min-width: 3.54167rem;
+  max-width: 12.58333rem;
+  padding: 0 0.91667rem;
+  margin: 0 0.41667rem;
   color: #a6a6a6;
 }
 .moon-button > * {
@@ -1196,7 +1196,7 @@ html {
 .moon-button.pressed,
 .moon-button.spotlight.pressed,
 .moon-button.spotlight:active {
-  border: 0.20833333rem solid #cf0652;
+  border: 0.20833rem solid #cf0652;
   background-color: #404040;
   color: #a6a6a6;
 }
@@ -1221,28 +1221,28 @@ html {
 .moon-button > .button-tap-area {
   position: absolute;
   border-radius: 416.625rem;
-  top: -0.20833333rem;
-  bottom: -0.20833333rem;
-  left: -0.20833333rem;
-  right: -0.20833333rem;
+  top: -0.20833rem;
+  bottom: -0.20833rem;
+  left: -0.20833rem;
+  right: -0.20833rem;
 }
 .moon-button.small {
   height: 2.5rem;
   min-width: 2.5rem;
-  line-height: 2.08333333rem;
-  padding: 0 0.83333333rem;
+  line-height: 2.08333rem;
+  padding: 0 0.83333rem;
   position: relative;
   overflow: visible;
 }
 .moon-button.small.min-width {
-  min-width: 5.41666667rem;
+  min-width: 5.41667rem;
 }
 .moon-button.small > .button-tap-area {
   border-radius: 0;
-  top: -0.58333333rem;
-  bottom: -0.58333333rem;
-  left: -0.58333333rem;
-  right: -0.58333333rem;
+  top: -0.58333rem;
+  bottom: -0.58333rem;
+  left: -0.58333rem;
+  right: -0.58333rem;
 }
 .moon-neutral .moon-button {
   color: #4b4b4b;
@@ -1261,7 +1261,7 @@ html {
 .moon-neutral .moon-button.pressed,
 .moon-neutral .moon-button.spotlight.pressed,
 .moon-neutral .moon-button.spotlight:active {
-  border: 0.20833333rem solid #cf0652;
+  border: 0.20833rem solid #cf0652;
   background-color: #ffffff;
 }
 .moon-neutral .moon-button.active *,
@@ -1297,17 +1297,17 @@ html {
 /* Caption Decorator - Left/Right Captions */
 .moon-button-caption-decorator .moon-caption.left,
 .moon-button-caption-decorator .moon-caption.right {
-  height: 3.54166667rem;
-  line-height: 3.54166667rem;
+  height: 3.54167rem;
+  line-height: 3.54167rem;
 }
 .moon-button-caption-decorator .moon-caption.left {
   float: left;
-  padding-right: 0.4166666666666667rem;
+  padding-right: 0.41667rem;
   text-align: left;
 }
 .moon-button-caption-decorator .moon-caption.right {
   float: right;
-  padding-left: 0.4166666666666667rem;
+  padding-left: 0.41667rem;
   text-align: right;
 }
 /* Caption Decorator - Top/Bottom Captions */
@@ -1317,10 +1317,10 @@ html {
   text-align: center;
 }
 .moon-button-caption-decorator .moon-caption.top {
-  padding-bottom: 0.16666666666666666rem;
+  padding-bottom: 0.16667rem;
 }
 .moon-button-caption-decorator .moon-caption.bottom {
-  padding-top: 0.16666666666666666rem;
+  padding-top: 0.16667rem;
 }
 /* Caption Decorator - Show On Focus Captions */
 .moon-button-caption-decorator.showOnFocus .moon-caption {
@@ -1336,33 +1336,33 @@ html {
   display: block;
 }
 .moon-button-caption-decorator.showOnFocus .moon-caption.top {
-  margin-bottom: 0.16666666666666666rem;
+  margin-bottom: 0.16667rem;
 }
 .moon-button-caption-decorator.showOnFocus .moon-caption.right {
-  margin-left: 0.4166666666666667rem;
+  margin-left: 0.41667rem;
 }
 .moon-button-caption-decorator.showOnFocus .moon-caption.bottom {
-  margin-top: 0.16666666666666666rem;
+  margin-top: 0.16667rem;
 }
 .moon-button-caption-decorator.showOnFocus .moon-caption.left {
-  margin-right: 0.4166666666666667rem;
+  margin-right: 0.41667rem;
 }
 /* Radio Item */
 .moon-radio-item {
   display: inline-block;
-  max-width: 10.416666666666666rem;
+  max-width: 10.41667rem;
   margin: 0 0.625rem 0 0;
-  padding: 0.41666667rem 0.41666667rem 0.41666667rem 1.75rem;
+  padding: 0.41667rem 0.41667rem 0.41667rem 1.75rem;
 }
 .moon-radio-item:before {
   content: '';
   position: absolute;
-  left: 0.41666667rem;
-  top: 0.7083333333333334rem;
-  width: 0.66666667rem;
-  height: 0.66666667rem;
-  border: solid 0.08333333rem #ffffff;
-  border-radius: 0.41666667rem;
+  left: 0.41667rem;
+  top: 0.70833rem;
+  width: 0.66667rem;
+  height: 0.66667rem;
+  border: solid 0.08333rem #ffffff;
+  border-radius: 0.41667rem;
   background-color: #4d4d4d;
 }
 .moon-radio-item.selected:before {
@@ -1370,16 +1370,16 @@ html {
 }
 .enyo-locale-right-to-left .moon-radio-item {
   margin: 0 0 0 0.625rem;
-  padding: 0.41666667rem 1.75rem 0.41666667rem 0.41666667rem;
+  padding: 0.41667rem 1.75rem 0.41667rem 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-radio-item:before {
   left: auto;
-  right: 0.41666667rem;
+  right: 0.41667rem;
 }
 /* Radio Item */
 .moon-radio-item-group {
   position: relative;
-  margin: 0 0.4166666666666667rem;
+  margin: 0 0.41667rem;
 }
 /* ExpandableListItem Header*/
 .moon-expandable-list-item-header {
@@ -1392,13 +1392,13 @@ html {
 }
 /* Client Items */
 .moon-expandable-list-item.open .moon-expandable-list-item-client {
-  margin-bottom: 0.4166666666666667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-expandable-list-item-client .moon-item {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #a6a6a6;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-expandable-list-item-client .moon-item a:link {
   color: #cf0652;
@@ -1418,8 +1418,8 @@ html {
 }
 .enyo-locale-non-latin .moon-expandable-list-item-client .moon-item {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 .moon-expandable-list-item-client .moon-item.spotlight {
   color: #ffffff;
@@ -1443,12 +1443,12 @@ html {
 }
 .moon-expandable-picker-header:after {
   position: absolute;
-  top: 0.08333333rem;
-  right: 0.45833333rem;
+  top: 0.08333rem;
+  right: 0.45833rem;
   font-family: "Moonstone Icons";
   content: "\0F0001";
   font-size: 2rem;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-expandable-picker-header.spotlight {
   color: #ffffff;
@@ -1458,7 +1458,7 @@ html {
   padding-right: 0;
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header:after {
-  left: 0.45833333rem;
+  left: 0.45833rem;
   right: auto;
 }
 /* Header Open */
@@ -1468,8 +1468,8 @@ html {
 /* Current Value */
 .moon-expandable-picker-current-value {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
   color: #a6a6a6;
   margin: 0rem;
 }
@@ -1497,8 +1497,8 @@ html {
 }
 .enyo-locale-non-latin .moon-expandable-picker-current-value {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 /* Help Text */
 .moon-expandable-picker-help-text {
@@ -1509,18 +1509,18 @@ html {
   -moz-box-sizing: border-box;
   color: #a6a6a6;
   height: 15rem;
-  border-top: 0.08333333rem solid #505050;
+  border-top: 0.08333rem solid #505050;
   border-bottom: 0.25rem solid #404040;
   position: relative;
   max-width: 100%;
-  padding: 0 0 0.41666667rem 0;
+  padding: 0 0 0.41667rem 0;
   background-color: transparent;
   background-repeat: no-repeat;
   background-position: top left;
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
 }
 .moon-header .moon-header-title-above {
-  margin-top: 0.20833333333333334rem;
+  margin-top: 0.20833rem;
   height: 1.2em;
   white-space: nowrap;
   overflow: hidden;
@@ -1531,22 +1531,22 @@ html {
 }
 .moon-header .moon-header-title {
   line-height: normal;
-  height: 6.458333333333333rem;
+  height: 6.45833rem;
 }
 .moon-header .moon-header-title .moon-marquee-text {
   white-space: nowrap;
 }
 .moon-header .moon-header-title-below,
 .moon-header .moon-header-sub-title-below {
-  height: 1.8333333333333333rem;
+  height: 1.83333rem;
 }
 .moon-header.full-bleed {
-  padding: 0 0.83333333rem 0.41666667rem 0.83333333rem;
+  padding: 0 0.83333rem 0.41667rem 0.83333rem;
   border: 0;
 }
 .moon-header.full-bleed .moon-header-client {
-  left: 0.83333333rem;
-  right: 0.83333333rem;
+  left: 0.83333rem;
+  right: 0.83333rem;
 }
 .moon-header .moon-hspacing > * {
   vertical-align: bottom;
@@ -1562,7 +1562,7 @@ html {
 }
 .moon-header.moon-medium-header .moon-header-title-below,
 .moon-header.moon-medium-header .moon-header-sub-title-below {
-  height: 1.6666666666666667rem;
+  height: 1.66667rem;
 }
 .moon-header.moon-small-header {
   height: 5rem;
@@ -1573,7 +1573,7 @@ html {
   display: none;
 }
 .moon-header.moon-small-header .moon-header-title {
-  padding: 1.0833333333333333rem 0 0 0;
+  padding: 1.08333rem 0 0 0;
   line-height: normal;
   font-size: 2.5rem;
   height: 3.5rem;
@@ -1583,7 +1583,7 @@ html {
 }
 .moon-header .moon-header-client {
   position: absolute;
-  bottom: 0.5833333333333334rem;
+  bottom: 0.58333rem;
   left: 0;
   right: 0;
   text-align: right;
@@ -1602,7 +1602,7 @@ html {
   line-height: 2.5rem;
 }
 .moon-neutral .moon-header {
-  border-top: 0.08333333rem solid #ffffff;
+  border-top: 0.08333rem solid #ffffff;
   border-bottom: 0.25rem solid #ffffff;
 }
 .enyo-locale-non-latin .moon-header .moon-header-title {
@@ -1639,7 +1639,7 @@ html {
 .moon-gridlist-imageitem {
   display: inline-block;
   overflow: hidden;
-  border: 0.20833333333333334rem solid transparent;
+  border: 0.20833rem solid transparent;
 }
 .moon-gridlist-imageitem .caption {
   font-family: "MuseoSans 700";
@@ -1648,9 +1648,9 @@ html {
 }
 .moon-gridlist-imageitem .sub-caption {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #a6a6a6;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-gridlist-imageitem .sub-caption a:link {
   color: #cf0652;
@@ -1669,11 +1669,11 @@ html {
   text-decoration: none;
 }
 .moon-gridlist-imageitem.selected {
-  border: 0.20833333rem solid #404040;
+  border: 0.20833rem solid #404040;
   background-color: #404040;
 }
 .moon-gridlist-imageitem.spotlight {
-  border: 0.20833333rem solid #cf0652;
+  border: 0.20833rem solid #cf0652;
   background-color: #cf0652;
 }
 .moon-gridlist-imageitem.selected .caption,
@@ -1684,7 +1684,7 @@ html {
 }
 .moon-gridlist-imageitem.sized-image.use-caption,
 .moon-gridlist-imageitem.sized-image.use-subcaption {
-  padding-bottom: 1.6666666666666667rem;
+  padding-bottom: 1.66667rem;
 }
 .moon-gridlist-imageitem.sized-image > .caption,
 .moon-gridlist-imageitem.sized-image > .sub-caption {
@@ -1692,11 +1692,11 @@ html {
   bottom: 0;
 }
 .moon-gridlist-imageitem.sized-image.use-caption.use-subcaption {
-  padding-bottom: 3.3333333333333335rem;
+  padding-bottom: 3.33333rem;
 }
 .moon-gridlist-imageitem.sized-image.use-caption.use-subcaption > .caption {
   position: absolute;
-  bottom: 1.4583333333333333rem;
+  bottom: 1.45833rem;
 }
 .enyo-locale-non-latin .moon-gridlist-imageitem .caption {
   font-family: "Moonstone LG Display Bold";
@@ -1704,8 +1704,8 @@ html {
 }
 .enyo-locale-non-latin .moon-gridlist-imageitem .sub-caption {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 /* Scroller Page Controls */
 .moon-icon-button.moon-paging-button {
@@ -1742,7 +1742,7 @@ html {
 }
 .moon-scroll-picker {
   direction: ltr;
-  height: 3.91666667rem;
+  height: 3.91667rem;
   border-top: solid 1.25rem transparent;
   border-bottom: solid 1.25rem transparent;
   border-radius: 1.875rem;
@@ -1754,16 +1754,16 @@ html {
 }
 .moon-scroll-picker-item {
   white-space: nowrap;
-  padding: 0 0.20833333rem 0.08333333rem 0.20833333rem;
-  min-width: 2.0833333333333335rem;
-  height: 3.91666667rem;
-  line-height: 3.91666667rem;
+  padding: 0 0.20833rem 0.08333rem 0.20833rem;
+  min-width: 2.08333rem;
+  height: 3.91667rem;
+  line-height: 3.91667rem;
   text-align: center;
   background: transparent;
 }
 .moon-scroll-picker-buffer {
   white-space: nowrap;
-  padding: 0 0.20833333rem 0.08333333rem 0.20833333rem;
+  padding: 0 0.20833rem 0.08333rem 0.20833rem;
   height: 0;
   opacity: 0;
 }
@@ -1779,16 +1779,16 @@ html {
 }
 .moon-scroll-picker-overlay-container.next:after {
   content: "\0F0005";
-  font-size: 2.83333333rem;
-  line-height: 1.58333333rem;
+  font-size: 2.83333rem;
+  line-height: 1.58333rem;
 }
 .moon-scroll-picker-overlay-container.previous {
   bottom: 0;
 }
 .moon-scroll-picker-overlay-container.previous:after {
   content: "\0F0006";
-  font-size: 2.83333333rem;
-  line-height: 1.08333333rem;
+  font-size: 2.83333rem;
+  line-height: 1.08333rem;
 }
 .spotlight .moon-scroll-picker-overlay-container {
   color: #ffffff;
@@ -1799,11 +1799,11 @@ html {
 }
 .spotlight .moon-scroll-picker-overlay-container.previous:after {
   content: "\0F0001";
-  line-height: 0.91666667rem;
+  line-height: 0.91667rem;
 }
 .selected .moon-scroll-picker-overlay {
   position: absolute;
-  height: 1.45833333rem;
+  height: 1.45833rem;
   width: 100%;
   background-color: #cf0652;
 }
@@ -1817,7 +1817,7 @@ html {
 }
 .selected .moon-scroll-picker-overlay.next:after {
   content: "\0F0005";
-  font-size: 2.83333333rem;
+  font-size: 2.83333rem;
   line-height: 1.25rem;
 }
 .selected .moon-scroll-picker-overlay.previous {
@@ -1830,7 +1830,7 @@ html {
 }
 .selected .moon-scroll-picker-overlay.previous:after {
   content: "\0F0006";
-  font-size: 2.83333333rem;
+  font-size: 2.83333rem;
   line-height: 1.75rem;
 }
 .moon-scroll-picker-taparea {
@@ -1842,9 +1842,9 @@ html {
 }
 /* DatePicker.css */
 .moon-date-picker-wrap {
-  min-width: 4.166666666666667rem;
+  min-width: 4.16667rem;
   text-align: center;
-  margin: 0.4166666666666667rem 0;
+  margin: 0.41667rem 0;
   vertical-align: top;
 }
 .moon-date-picker-wrap.year {
@@ -1852,7 +1852,7 @@ html {
 }
 .moon-date-picker-label {
   text-align: center;
-  padding: 0.83333333rem 0.41666667rem;
+  padding: 0.83333rem 0.41667rem;
   white-space: nowrap;
 }
 .moon-date-picker-client {
@@ -1921,8 +1921,8 @@ html {
 /* InputDecorator.css */
 .moon-input-decorator:not(.moon-input-header-input-decorator),
 .moon-textarea-decorator {
-  margin: 0.20833333333333334rem;
-  border: 0.20833333rem solid transparent;
+  margin: 0.20833rem;
+  border: 0.20833rem solid transparent;
   background-color: #ffffff;
   box-sizing: border-box;
 }
@@ -1938,7 +1938,7 @@ html {
 .moon-textarea-decorator .moon-icon.small,
 .moon-input-decorator:not(.moon-input-header-input-decorator) .spotlight .moon-icon.small,
 .moon-textarea-decorator .spotlight .moon-icon.small {
-  width: 0.8333333333333334rem;
+  width: 0.83333rem;
   margin: 0;
   color: #4b4b4b;
 }
@@ -1948,17 +1948,17 @@ html {
 }
 .moon-input-decorator:not(.moon-input-header-input-decorator) {
   padding: 0.375rem 1.25rem;
-  border-radius: 1.4166666666666667rem;
+  border-radius: 1.41667rem;
 }
 .moon-textarea-decorator {
-  padding: 0.375rem 0.5833333333333334rem;
-  border-radius: 0.4166666666666667rem;
+  padding: 0.375rem 0.58333rem;
+  border-radius: 0.41667rem;
 }
 .moon-expandable-input .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  margin: 0.20833333333333334rem 0;
+  margin: 0.20833rem 0;
 }
 .enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  padding: 0.20833333333333334rem 1.25rem 0.375rem;
+  padding: 0.20833rem 1.25rem 0.375rem;
 }
 .enyo-locale-non-latin.enyo-locale-th .moon-input-decorator:not(.moon-input-header-input-decorator),
 .enyo-locale-non-latin.enyo-locale-ar .moon-input-decorator:not(.moon-input-header-input-decorator),
@@ -1979,10 +1979,10 @@ html {
 /* ProgressBar.css */
 .moon-progress-bar {
   position: relative;
-  margin: 2.0833333333333335rem 0.8333333333333334rem;
-  height: 0.4166666666666667rem;
+  margin: 2.08333rem 0.83333rem;
+  height: 0.41667rem;
   background-color: #262626;
-  min-width: 5.333333333333333rem;
+  min-width: 5.33333rem;
   direction: ltr;
 }
 .moon-progress-bg-bar,
@@ -2001,14 +2001,14 @@ html {
 .moon-progress-button {
   position: relative;
   overflow: hidden;
-  border: 0.20833333rem solid transparent;
+  border: 0.20833rem solid transparent;
   transform: translateZ(0);
   -webkit-transform: translateZ(0);
 }
 .moon-progress-button.in-progress:active:hover:not([disabled]),
 .moon-progress-button.in-progress {
   color: #ffffff;
-  padding: 0.20833333rem 1.125rem;
+  padding: 0.20833rem 1.125rem;
   border-width: 0;
 }
 .moon-progress-button.completed .moon-progress-button-bar {
@@ -2052,7 +2052,7 @@ html {
 }
 .moon-slider.spotlight > .moon-slider-knob.spotselect {
   background-color: #4d4d4d;
-  border: 0.20833333rem solid #cf0652;
+  border: 0.20833rem solid #cf0652;
 }
 .moon-slider.disabled {
   cursor: default;
@@ -2066,24 +2066,24 @@ html {
   border-radius: 2.5rem;
   margin: -1.25rem;
   background-color: #4d4d4d;
-  top: 0.20833333rem;
-  border: solid 0.20833333rem transparent;
+  top: 0.20833rem;
+  border: solid 0.20833rem transparent;
   box-sizing: border-box;
 }
 .moon-slider-knob:not(.spotselect).active,
 .moon-slider-knob:not(.spotselect).spotselect,
 .moon-slider-knob:not(.spotselect):active:not(.disabled) {
-  width: 3.58333333rem;
-  height: 3.58333333rem;
-  border-radius: 1.79166667rem;
-  margin: -1.79166667rem;
-  border: solid 0.20833333rem transparent;
+  width: 3.58333rem;
+  height: 3.58333rem;
+  border-radius: 1.79167rem;
+  margin: -1.79167rem;
+  border: solid 0.20833rem transparent;
   box-sizing: border-box;
 }
 .moon-slider-taparea {
   position: absolute;
-  top: -0.58333333rem;
-  height: 1.33333333rem;
+  top: -0.58333rem;
+  height: 1.33333rem;
   width: 100%;
 }
 /* Slider Popup */
@@ -2133,20 +2133,20 @@ html {
 }
 /* ContextualPopupButton.css */
 .moon-button.contextual-popup-button {
-  padding-right: 2.08333333rem;
+  padding-right: 2.08333rem;
   position: relative;
 }
 .moon-button.contextual-popup-button:after {
   position: absolute;
-  right: 0.41666667rem;
+  right: 0.41667rem;
   font-family: "Moonstone Icons";
   content: "\0F0008";
-  font-size: 2.41666667rem;
+  font-size: 2.41667rem;
   line-height: 3.125rem;
   color: #cf0652;
 }
 .moon-button.contextual-popup-button.small:after {
-  line-height: 2.08333333rem;
+  line-height: 2.08333rem;
 }
 .moon-button.contextual-popup-button.spotlight {
   color: #ffffff;
@@ -2169,16 +2169,16 @@ html {
   color: #4d4d4d;
 }
 .enyo-locale-right-to-left .moon-button.contextual-popup-button {
-  padding-left: 2.08333333rem;
-  padding-right: 0.91666667rem;
+  padding-left: 2.08333rem;
+  padding-right: 0.91667rem;
 }
 .enyo-locale-right-to-left .moon-button.contextual-popup-button:after {
-  left: 0.41666667rem;
+  left: 0.41667rem;
   right: auto;
   content: "\0F0007";
 }
 .enyo-locale-right-to-left .moon-button.contextual-popup-button.small {
-  padding-right: 0.83333333rem;
+  padding-right: 0.83333rem;
 }
 /* ContextualPopupDecorator.css */
 .moon-contextual-popup-decorator {
@@ -2190,12 +2190,12 @@ html {
 }
 /* ContextualPopup */
 .moon-contextual-popup {
-  min-height: 4.166666666666667rem;
-  min-width: 4.166666666666667rem;
-  border-radius: 0.66666667rem;
-  border: 0.20833333rem solid rgba(0, 0, 0, 0.5);
+  min-height: 4.16667rem;
+  min-width: 4.16667rem;
+  border-radius: 0.66667rem;
+  border: 0.20833rem solid rgba(0, 0, 0, 0.5);
   color: #ffffff;
-  padding: 0.83333333rem;
+  padding: 0.83333rem;
   background-clip: padding-box;
   -webkit-background-clip: padding-box;
   -moz-background-clip: padding-box;
@@ -2205,7 +2205,7 @@ html {
   background-color: #686868;
 }
 .moon-contextual-popup.reserve-close {
-  padding-right: 2.91666667rem;
+  padding-right: 2.91667rem;
 }
 .moon-contextual-popup:before,
 .moon-contextual-popup:after {
@@ -2227,12 +2227,12 @@ html {
 }
 .moon-contextual-popup.high:before,
 .moon-contextual-popup.high:after {
-  top: 1.77083333rem;
+  top: 1.77083rem;
 }
 .moon-contextual-popup.low:before,
 .moon-contextual-popup.low:after {
   top: auto;
-  bottom: 1.77083333rem;
+  bottom: 1.77083rem;
 }
 .moon-contextual-popup.left:before,
 .moon-contextual-popup.right:before {
@@ -2252,38 +2252,38 @@ html {
   height: 0;
 }
 .moon-contextual-popup.left {
-  margin: 0 0 0 1.45833333rem;
+  margin: 0 0 0 1.45833rem;
 }
 .moon-contextual-popup.left:before,
 .moon-contextual-popup.left:after {
   left: 0;
 }
 .moon-contextual-popup.left:before {
-  margin: -0.79166667rem auto auto -1rem;
-  border-top: 0.66666667rem solid transparent;
-  border-bottom: 0.66666667rem solid transparent;
-  border-right: 0.79166667rem solid rgba(0, 0, 0, 0.5);
+  margin: -0.79167rem auto auto -1rem;
+  border-top: 0.66667rem solid transparent;
+  border-bottom: 0.66667rem solid transparent;
+  border-right: 0.79167rem solid rgba(0, 0, 0, 0.5);
 }
 .moon-contextual-popup.left:after {
-  margin: -0.66666667rem auto auto -0.79166667rem;
-  border-top: 0.66666667rem solid transparent;
-  border-bottom: 0.66666667rem solid transparent;
-  border-right: 0.79166667rem solid #686868;
+  margin: -0.66667rem auto auto -0.79167rem;
+  border-top: 0.66667rem solid transparent;
+  border-bottom: 0.66667rem solid transparent;
+  border-right: 0.79167rem solid #686868;
 }
 .moon-contextual-popup.left.high:before {
-  margin: -1.04166667rem auto auto -1rem;
+  margin: -1.04167rem auto auto -1rem;
 }
 .moon-contextual-popup.left.high:after {
-  margin: -0.91666667rem auto auto -0.79166667rem;
+  margin: -0.91667rem auto auto -0.79167rem;
 }
 .moon-contextual-popup.left.low:before {
-  margin: auto auto -1.04166667rem -1rem;
+  margin: auto auto -1.04167rem -1rem;
 }
 .moon-contextual-popup.left.low:after {
-  margin: auto auto -0.91666667rem -0.79166667rem;
+  margin: auto auto -0.91667rem -0.79167rem;
 }
 .moon-contextual-popup.right {
-  margin: 0 0 0 -1.45833333rem;
+  margin: 0 0 0 -1.45833rem;
 }
 .moon-contextual-popup.right:before,
 .moon-contextual-popup.right:after {
@@ -2291,28 +2291,28 @@ html {
   right: auto;
 }
 .moon-contextual-popup.right:before {
-  margin: -0.79166667rem auto auto 0.20833333rem;
-  border-top: 0.66666667rem solid transparent;
-  border-bottom: 0.66666667rem solid transparent;
-  border-left: 0.79166667rem solid rgba(0, 0, 0, 0.5);
+  margin: -0.79167rem auto auto 0.20833rem;
+  border-top: 0.66667rem solid transparent;
+  border-bottom: 0.66667rem solid transparent;
+  border-left: 0.79167rem solid rgba(0, 0, 0, 0.5);
 }
 .moon-contextual-popup.right:after {
-  margin: -0.66666667rem auto auto 0;
-  border-top: 0.66666667rem solid transparent;
-  border-bottom: 0.66666667rem solid transparent;
-  border-left: 0.79166667rem solid #686868;
+  margin: -0.66667rem auto auto 0;
+  border-top: 0.66667rem solid transparent;
+  border-bottom: 0.66667rem solid transparent;
+  border-left: 0.79167rem solid #686868;
 }
 .moon-contextual-popup.right.high:before {
-  margin: -1.04166667rem auto auto 0.20833333rem;
+  margin: -1.04167rem auto auto 0.20833rem;
 }
 .moon-contextual-popup.right.high:after {
-  margin: -0.91666667rem auto auto 0;
+  margin: -0.91667rem auto auto 0;
 }
 .moon-contextual-popup.right.low:before {
-  margin: auto auto -1.04166667rem 0.20833333rem;
+  margin: auto auto -1.04167rem 0.20833rem;
 }
 .moon-contextual-popup.right.low:after {
-  margin: auto auto -0.91666667rem 0;
+  margin: auto auto -0.91667rem 0;
 }
 .moon-contextual-popup.below.right:before,
 .moon-contextual-popup.above.right:before,
@@ -2328,73 +2328,73 @@ html {
   right: 10%;
 }
 .moon-contextual-popup.below {
-  margin: 1.45833333rem 0 0 0;
+  margin: 1.45833rem 0 0 0;
 }
 .moon-contextual-popup.below:before,
 .moon-contextual-popup.below:after {
   top: 0;
 }
 .moon-contextual-popup.below:before {
-  margin: -1rem auto auto -0.79166667rem;
-  border-right: 0.66666667rem solid transparent;
-  border-left: 0.66666667rem solid transparent;
-  border-bottom: 0.79166667rem solid rgba(0, 0, 0, 0.5);
+  margin: -1rem auto auto -0.79167rem;
+  border-right: 0.66667rem solid transparent;
+  border-left: 0.66667rem solid transparent;
+  border-bottom: 0.79167rem solid rgba(0, 0, 0, 0.5);
 }
 .moon-contextual-popup.below:after {
-  margin: -0.79166667rem auto auto -0.66666667rem;
-  border-right: 0.66666667rem solid transparent;
-  border-left: 0.66666667rem solid transparent;
-  border-bottom: 0.79166667rem solid #686868;
+  margin: -0.79167rem auto auto -0.66667rem;
+  border-right: 0.66667rem solid transparent;
+  border-left: 0.66667rem solid transparent;
+  border-bottom: 0.79167rem solid #686868;
 }
 .moon-contextual-popup.below.right:before {
-  margin: -1.66666667rem auto auto -0.79166667rem;
+  margin: -1.66667rem auto auto -0.79167rem;
 }
 .moon-contextual-popup.below.right:after {
-  margin: -1.45833333rem auto auto -0.66666667rem;
+  margin: -1.45833rem auto auto -0.66667rem;
 }
 .moon-contextual-popup.below.left:before {
-  margin: -1.66666667rem -0.79166667rem auto auto;
+  margin: -1.66667rem -0.79167rem auto auto;
 }
 .moon-contextual-popup.below.left:after {
-  margin: -1.45833333rem -0.66666667rem auto auto;
+  margin: -1.45833rem -0.66667rem auto auto;
 }
 .moon-contextual-popup.above {
-  margin: -1.45833333rem 0 0 0;
+  margin: -1.45833rem 0 0 0;
 }
 .moon-contextual-popup.above:before,
 .moon-contextual-popup.above:after {
   top: 100%;
 }
 .moon-contextual-popup.above:before {
-  margin: 0.20833333rem auto auto -0.79166667rem;
-  border-right: 0.66666667rem solid transparent;
-  border-left: 0.66666667rem solid transparent;
-  border-top: 0.79166667rem solid rgba(0, 0, 0, 0.5);
+  margin: 0.20833rem auto auto -0.79167rem;
+  border-right: 0.66667rem solid transparent;
+  border-left: 0.66667rem solid transparent;
+  border-top: 0.79167rem solid rgba(0, 0, 0, 0.5);
 }
 .moon-contextual-popup.above:after {
-  margin: 0 auto auto -0.66666667rem;
-  border-right: 0.66666667rem solid transparent;
-  border-left: 0.66666667rem solid transparent;
-  border-top: 0.79166667rem solid #686868;
+  margin: 0 auto auto -0.66667rem;
+  border-right: 0.66667rem solid transparent;
+  border-left: 0.66667rem solid transparent;
+  border-top: 0.79167rem solid #686868;
 }
 .moon-contextual-popup.above.right:before {
-  margin: 0.20833333rem auto auto -0.79166667rem;
+  margin: 0.20833rem auto auto -0.79167rem;
 }
 .moon-contextual-popup.above.right:after {
-  margin: 0 auto auto -0.66666667rem;
+  margin: 0 auto auto -0.66667rem;
 }
 .moon-contextual-popup.above.left:before {
-  margin: 0.20833333rem -0.79166667rem auto auto;
+  margin: 0.20833rem -0.79167rem auto auto;
 }
 .moon-contextual-popup.above.left:after {
-  margin: 0 -0.66666667rem auto auto;
+  margin: 0 -0.66667rem auto auto;
 }
 .enyo-locale-right-to-left .moon-contextual-popup {
   direction: rtl;
 }
 .enyo-locale-right-to-left .moon-contextual-popup.reserve-close {
-  padding-right: 0.8333333333333334rem;
-  padding-left: 2.91666667rem;
+  padding-right: 0.83333rem;
+  padding-left: 2.91667rem;
 }
 .moon-contextual-popup-client {
   height: 100%;
@@ -2420,16 +2420,16 @@ html {
 }
 .moon-textarea::-webkit-scrollbar,
 .moon-richtext::-webkit-scrollbar {
-  width: 0.16666666666666666rem;
+  width: 0.16667rem;
 }
 .moon-textarea::-webkit-scrollbar-track-piece,
 .moon-richtext::-webkit-scrollbar-track-piece {
-  border-radius: 0.4166666666666667rem;
+  border-radius: 0.41667rem;
 }
 .moon-textarea::-webkit-scrollbar-thumb:vertical,
 .moon-richtext::-webkit-scrollbar-thumb:vertical {
   background-color: #a6a6a6;
-  border-radius: 0.4166666666666667rem;
+  border-radius: 0.41667rem;
 }
 .moon-textarea-decorator.moon-focused .moon-textarea,
 .moon-textarea-decorator .moon-focused .moon-richtext {
@@ -2459,30 +2459,30 @@ html {
   right: 0;
 }
 .moon-header .list-actions-drawer {
-  top: -0.08333333rem;
+  top: -0.08333rem;
   bottom: -0.25rem;
 }
 /* Close button */
 .moon-icon-button.moon-list-actions-close {
   position: absolute;
-  right: 0.4166666666666667rem;
-  top: 0.4166666666666667rem;
+  right: 0.41667rem;
+  top: 0.41667rem;
   z-index: 2;
 }
 .enyo-locale-right-to-left .moon-icon-button.moon-list-actions-close {
   right: auto;
-  left: 0.4166666666666667rem;
+  left: 0.41667rem;
 }
 /* Scroller */
 .moon-list-actions-scroller {
-  margin: 0.8333333333333334rem;
-  margin-right: 3.33333333rem;
+  margin: 0.83333rem;
+  margin-right: 3.33333rem;
   padding: 0rem;
   z-index: 1;
 }
 .enyo-locale-right-to-left .moon-list-actions-scroller {
-  margin-right: 0.4166666666666667rem;
-  margin-left: 3.33333333rem;
+  margin-right: 0.41667rem;
+  margin-left: 3.33333rem;
 }
 /* Action menu */
 .moon-list-actions-menu {
@@ -2502,7 +2502,7 @@ html {
   width: 100% !important;
 }
 .moon-list-actions-drawer.stacked .moon-list-actions-menu {
-  margin-bottom: 0.8333333333333334rem;
+  margin-bottom: 0.83333rem;
   clear: both;
 }
 .moon-list-actions-menu .enyo-scroller {
@@ -2549,7 +2549,7 @@ html {
 /* Labeled Text Item */
 .moon-labeledtextitem {
   min-width: 14rem;
-  height: 8.083333333333334rem;
+  height: 8.08333rem;
   overflow: hidden;
   margin: 0rem;
 }
@@ -2558,7 +2558,7 @@ html {
   font-family: "MuseoSans 700";
   font-size: 1.25rem;
   color: #a6a6a6;
-  border-top: 0.08333333rem solid #a6a6a6;
+  border-top: 0.08333rem solid #a6a6a6;
   margin: 0rem 0rem 0.125rem 0rem;
   padding: 0.25rem 0rem 0rem 0rem;
 }
@@ -2574,9 +2574,9 @@ html {
 /* Text */
 .moon-labeledtextitem .text {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #a6a6a6;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
   text-transform: none;
   margin: 0rem;
   padding: 0rem;
@@ -2599,8 +2599,8 @@ html {
 }
 .enyo-locale-non-latin .moon-labeledtextitem .text {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 .spotlight.moon-labeledtextitem .text,
 .spotlight .moon-labeledtextitem .text {
@@ -2612,24 +2612,24 @@ html {
 .moon-imageitem {
   display: block;
   clear: both;
-  min-width: 22.333333333333332rem;
+  min-width: 22.33333rem;
   margin-top: 0rem;
   padding-top: 0rem;
   height: 8.5rem;
   overflow: hidden;
 }
 .moon-imageitem img {
-  width: 5.666666666666667rem;
-  height: 8.083333333333334rem;
+  width: 5.66667rem;
+  height: 8.08333rem;
   padding: 0rem;
-  margin: 0.4166666666666667rem 2.6666666666666665rem 0.4166666666666667rem 0rem;
+  margin: 0.41667rem 2.66667rem 0.41667rem 0rem;
   display: inline-block;
   float: left;
 }
 .moon-imageitem.align-right img {
   float: right;
   margin-right: 0rem;
-  margin-left: 2.6666666666666665rem;
+  margin-left: 2.66667rem;
 }
 /* Spinner.css */
 @-webkit-keyframes spinBall {
@@ -2757,15 +2757,15 @@ html {
   }
 }
 .moon-spinner {
-  min-height: 3.04166667rem;
-  min-width: 3.04166667rem;
-  line-height: 3.04166667rem;
+  min-height: 3.04167rem;
+  min-width: 3.04167rem;
+  line-height: 3.04167rem;
   position: relative;
   display: inline-block;
   color: #ffffff;
   background-color: #4d4d4d;
-  border-radius: 1.77083333rem;
-  margin: 0 0.41666667rem;
+  border-radius: 1.77083rem;
+  margin: 0 0.41667rem;
 }
 .moon-spinner > * {
   display: inline-block;
@@ -2789,15 +2789,15 @@ html {
   padding: 0.25rem;
 }
 .moon-spinner.content .moon-spinner-client {
-  max-width: 16.666666666666668rem;
+  max-width: 16.66667rem;
 }
 .moon-spinner.running .moon-spinner-ball {
   -webkit-animation-play-state: running;
 }
 .moon-spinner .moon-spinner-ball-decorator {
   position: relative;
-  width: 3.04166667rem;
-  height: 3.04166667rem;
+  width: 3.04167rem;
+  height: 3.04167rem;
   float: left;
 }
 .moon-spinner .moon-spinner-ball {
@@ -2834,7 +2834,7 @@ html {
 }
 .moon-spinner .moon-spinner-client {
   float: left;
-  line-height: 3.04166667rem;
+  line-height: 3.04167rem;
   margin: 0 2.6ex 0 0;
 }
 .enyo-locale-right-to-left .moon-spinner .moon-spinner-ball-decorator {
@@ -2858,7 +2858,7 @@ html {
 .moon-panel {
   overflow: hidden;
   padding: 0;
-  padding: 0.8333333333333334rem 0.4166666666666667rem;
+  padding: 0.83333rem 0.41667rem;
   height: 100%;
 }
 .moon-panel.enyo-fit {
@@ -2885,13 +2885,13 @@ html {
 .moon-panel-body {
   overflow: hidden;
   position: relative;
-  padding-top: 0.4166666666666667rem;
+  padding-top: 0.41667rem;
   z-index: 1;
 }
 /* Breadcrumb */
 .moon-panel-breadcrumb {
-  width: 9.58333333rem;
-  height: 15.41666667rem;
+  width: 9.58333rem;
+  height: 15.41667rem;
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -2905,17 +2905,17 @@ html {
   overflow: hidden;
 }
 .moon-panel-small-header-wrapper {
-  margin: 0.41666667rem 0 0 0;
+  margin: 0.41667rem 0 0 0;
   position: absolute;
-  bottom: 0.4166666666666667rem;
+  bottom: 0.41667rem;
   left: 0;
   height: 15rem;
   width: 100%;
-  padding: 0 0.41666667rem 0.41666667rem 0.41666667rem;
+  padding: 0 0.41667rem 0.41667rem 0.41667rem;
   box-sizing: border-box;
 }
 .moon-panel-small-header {
-  margin-top: 1.0416666666666667rem;
+  margin-top: 1.04167rem;
   color: #a6a6a6;
   display: block;
   overflow: hidden;
@@ -2926,8 +2926,8 @@ html {
 }
 .moon-panel-small-header-title-above {
   color: #a6a6a6;
-  border-top: 0.08333333rem solid #ffffff;
-  padding-top: 0.20833333333333334rem;
+  border-top: 0.08333rem solid #ffffff;
+  padding-top: 0.20833rem;
 }
 .spotlight .moon-panel-small-header-title-above {
   color: #ffffff;
@@ -2937,14 +2937,14 @@ html {
   color: #ffffff;
 }
 .moon-panel .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header-title-above {
-  border-top: 0.08333333333333333rem solid transparent;
+  border-top: 0.08333rem solid transparent;
 }
 /* Activity Panels Overrides */
 .moon-panels.activity .moon-panel {
   padding: 0;
 }
 .moon-panels.activity .moon-panel-small-header-title-above {
-  border-top: 0.08333333rem solid #505050;
+  border-top: 0.08333rem solid #505050;
 }
 .moon-panels.activity .moon-panel-small-header,
 .moon-panels.activity .moon-panel-small-header-title-above {
@@ -3064,7 +3064,7 @@ html {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  padding: 0.8333333333333334rem 0.4166666666666667rem;
+  padding: 0.83333rem 0.41667rem;
   overflow: visible;
   pointer-events: none;
 }
@@ -3113,10 +3113,10 @@ html {
 }
 .moon-panels.activity .moon-panels-panel-scrim .moon-panels-branding {
   position: absolute;
-  top: 15.83333333rem;
+  top: 15.83333rem;
   width: 8.75rem;
-  bottom: 0.8333333333333334rem;
-  left: 0.8333333333333334rem;
+  bottom: 0.83333rem;
+  left: 0.83333rem;
   background-position: bottom center;
 }
 .moon-panels.always-viewing .moon-panels-panel-scrim {
@@ -3129,9 +3129,9 @@ html {
   position: absolute;
   top: 0;
   left: auto;
-  right: -5.41666667rem;
+  right: -5.41667rem;
   height: 100%;
-  width: 5.41666667rem;
+  width: 5.41667rem;
   z-index: 100;
 }
 .moon-panels-handle:before {
@@ -3140,8 +3140,8 @@ html {
   height: 100%;
   width: 100%;
   line-height: 100vh;
-  margin-left: -0.41666667rem;
-  margin-right: 0.4166666666666667rem;
+  margin-left: -0.41667rem;
+  margin-right: 0.41667rem;
   background-color: #4b4b4b;
   font-family: "Moonstone Icons";
   font-size: 6rem;
@@ -3181,17 +3181,17 @@ html {
 .moon-calendar-picker {
   display: inline-block;
   text-align: center;
-  width: 25.66666667rem;
+  width: 25.66667rem;
   background-color: #686868;
-  border-radius: 0.66666667rem;
-  margin: 0 0.8333333333333334rem;
-  padding: 0.8333333333333334rem 0;
+  border-radius: 0.66667rem;
+  margin: 0 0.83333rem;
+  padding: 0.83333rem 0;
 }
 .moon-calendar-picker > * {
   display: inline-block;
 }
 .moon-calendar-picker .moon-simple-picker {
-  max-width: 10.416666666666666rem;
+  max-width: 10.41667rem;
 }
 .moon-calendar-picker .moon-simple-picker .moon-simple-picker-client > * {
   color: #ffffff;
@@ -3216,12 +3216,12 @@ html {
   display: inline-block;
 }
 .moon-calendar-picker .moon-calendar-picker-day.small {
-  font-size: 0.91666667rem;
+  font-size: 0.91667rem;
 }
 .moon-calendar-picker .moon-neutral .moon-calendar-picker-day-base {
   width: 2.5rem;
   color: #a2a2a2;
-  margin: 0.4166666666666667rem;
+  margin: 0.41667rem;
   border-color: #a2a2a2;
   display: inline-block;
 }
@@ -3240,13 +3240,13 @@ html {
   width: 2.5rem;
   line-height: 2.5rem;
   border-radius: 416.625rem;
-  border: solid 0.4166666666666667rem transparent;
+  border: solid 0.41667rem transparent;
   display: inline-block;
 }
 .moon-calendar-picker-date.spotlight,
 .moon-calendar-picker-date.active {
   background-color: #cf0652;
-  border: solid 0.41666667rem #686868;
+  border: solid 0.41667rem #686868;
 }
 .moon-calendar-picker-date.moon-calendar-picker-date-shadow {
   color: #a2a2a2;
@@ -3268,7 +3268,7 @@ html {
   color: #ffffff;
 }
 .moon-table-row .moon-table-cell {
-  padding: 0.41666667rem;
+  padding: 0.41667rem;
   white-space: nowrap;
 }
 .moon-input-header-input-decorator {
@@ -3324,10 +3324,10 @@ html {
   color: #333333;
 }
 .moon-drawer-partial-client {
-  padding: 1.6666666666666667rem 0.8333333333333334rem 0.8333333333333334rem;
+  padding: 1.66667rem 0.83333rem 0.83333rem;
 }
 .moon-drawer-client {
-  padding: 0.8333333333333334rem;
+  padding: 0.83333rem;
 }
 /* Drawers.css */
 .moon-drawers {
@@ -3336,8 +3336,8 @@ html {
 .moon-drawers-activator {
   z-index: 100;
   font-family: "Moonstone Icons";
-  font-size: 1.7916666666666667rem;
-  line-height: 1.33333333rem;
+  font-size: 1.79167rem;
+  line-height: 1.33333rem;
   height: 0rem;
   position: absolute;
   width: 100%;
@@ -3347,7 +3347,7 @@ html {
 .moon-drawers-activator:before {
   content: '';
   display: block;
-  height: 0.91666667rem;
+  height: 0.91667rem;
   background-color: #404040;
 }
 .moon-drawers-activator .moon-drawers-activator-icon {
@@ -3385,12 +3385,12 @@ html {
 }
 .moon-drawers-handle-container .moon-drawers-handles {
   text-align: center;
-  padding: 2.0833333333333335rem 0 0.4166666666666667rem;
+  padding: 2.08333rem 0 0.41667rem;
 }
 .moon-drawers-handle-container .moon-drawers-handle {
   display: inline-block;
   text-align: start;
-  width: 10.416666666666666rem;
+  width: 10.41667rem;
 }
 .moon-drawers-container {
   position: relative;
@@ -3438,7 +3438,7 @@ html {
   position: absolute;
   bottom: 0;
   width: 100%;
-  padding: 1.66666667rem;
+  padding: 1.66667rem;
   box-sizing: border-box;
   overflow: hidden;
   -webkit-transform: translateY(100%) translateZ(0);
@@ -3455,12 +3455,12 @@ html {
   transform: translateY(0) translateZ(0);
 }
 .moon-popup.reserve-close {
-  padding-right: 2.91666667rem;
+  padding-right: 2.91667rem;
 }
 .moon-popup-close {
   position: absolute;
-  right: 0.41666667rem;
-  top: 0.41666667rem;
+  right: 0.41667rem;
+  top: 0.41667rem;
   margin: 0;
   background-color: transparent;
   background-repeat: no-repeat;
@@ -3473,19 +3473,19 @@ html {
   color: #ffffff;
 }
 .enyo-locale-right-to-left .moon-popup.reserve-close {
-  padding-right: 1.66666667rem;
-  padding-left: 2.91666667rem;
+  padding-right: 1.66667rem;
+  padding-left: 2.91667rem;
 }
 .enyo-locale-right-to-left .moon-popup-close {
   right: auto;
-  left: 0.41666667rem;
+  left: 0.41667rem;
 }
 /* Dialog.css */
 .moon-dialog {
-  padding: 1rem 1.6666666666666667rem 1.6666666666666667rem;
+  padding: 1rem 1.66667rem 1.66667rem;
 }
 .moon-dialog-title {
-  margin-bottom: 0.4166666666666667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-dialog-sub-title {
   font-size: 1rem;
@@ -3495,18 +3495,18 @@ html {
 }
 .moon-dialog-divider {
   padding-bottom: 0;
-  border-bottom-width: 0.08333333333333333rem;
-  margin: 0.8333333333333334rem 0 0.8333333333333334rem;
+  border-bottom-width: 0.08333rem;
+  margin: 0.83333rem 0 0.83333rem;
 }
 .moon-dialog-client {
   padding: 1.5rem 0 0;
 }
 .moon-dialog-client > * {
-  margin-left: 0.83333333rem;
+  margin-left: 0.83333rem;
 }
 .moon-tooltip {
   z-index: 20;
-  height: 2.83333333rem;
+  height: 2.83333rem;
   -webkit-transform: translateZ(0);
   transform: translateZ(0);
   pointer-events: none;
@@ -3515,8 +3515,8 @@ html {
   font-family: "Moonstone Miso Bold";
   font-size: 1.125rem;
   -webkit-font-kerning: normal;
-  height: 2.45833333rem;
-  line-height: 2.45833333rem;
+  height: 2.45833rem;
+  line-height: 2.45833rem;
   white-space: nowrap;
   color: #ffffff;
   text-align: center;
@@ -3542,46 +3542,46 @@ html {
 }
 /* .above .left-arrow nub shape */
 .moon-tooltip.above.left-arrow .moon-tooltip-label {
-  border-radius: 1.41666667rem 1.41666667rem 1.41666667rem 0rem;
+  border-radius: 1.41667rem 1.41667rem 1.41667rem 0rem;
 }
 .moon-tooltip.above.left-arrow .moon-tooltip-label:before {
-  top: 1.2083333333333333rem;
-  left: -0.08333333rem;
-  border-top: 1.20833333rem solid #4d4d4d;
-  clip: rect(1.25rem, 1rem, 1.58333333rem, 0.08333333rem);
+  top: 1.20833rem;
+  left: -0.08333rem;
+  border-top: 1.20833rem solid #4d4d4d;
+  clip: rect(1.25rem, 1rem, 1.58333rem, 0.08333rem);
   border-radius: 416.625rem;
 }
 /* .above .right-arrow nub shape */
 .moon-tooltip.above.right-arrow .moon-tooltip-label {
-  border-radius: 1.41666667rem 1.41666667rem 0rem 1.41666667rem;
+  border-radius: 1.41667rem 1.41667rem 0rem 1.41667rem;
 }
 .moon-tooltip.above.right-arrow .moon-tooltip-label:before {
-  top: 1.2083333333333333rem;
-  right: -0.08333333rem;
-  border-top: 1.20833333rem solid #4d4d4d;
-  clip: rect(1.25rem, 3.41666667rem, 1.58333333rem, 2.33333333rem);
+  top: 1.20833rem;
+  right: -0.08333rem;
+  border-top: 1.20833rem solid #4d4d4d;
+  clip: rect(1.25rem, 3.41667rem, 1.58333rem, 2.33333rem);
   border-radius: 416.625rem;
 }
 /* .below .left-arrow nub shape */
 .moon-tooltip.below.left-arrow .moon-tooltip-label {
-  border-radius: 0 1.41666667rem 1.41666667rem 1.41666667rem;
+  border-radius: 0 1.41667rem 1.41667rem 1.41667rem;
 }
 .moon-tooltip.below.left-arrow .moon-tooltip-label:before {
-  top: -2.08333333rem;
-  left: -0.08333333rem;
-  border-bottom: 1.20833333rem solid #4d4d4d;
-  clip: rect(0.08333333rem, 1rem, 2.5rem, 0.08333333rem);
+  top: -2.08333rem;
+  left: -0.08333rem;
+  border-bottom: 1.20833rem solid #4d4d4d;
+  clip: rect(0.08333rem, 1rem, 2.5rem, 0.08333rem);
   border-radius: 416.625rem;
 }
 /* .below .right-arrow nub shape */
 .moon-tooltip.below.right-arrow .moon-tooltip-label {
-  border-radius: 1.41666667rem 0rem 1.41666667rem 1.41666667rem;
+  border-radius: 1.41667rem 0rem 1.41667rem 1.41667rem;
 }
 .moon-tooltip.below.right-arrow .moon-tooltip-label:before {
-  top: -2.08333333rem;
-  right: -0.08333333rem;
-  border-bottom: 1.20833333rem solid #4d4d4d;
-  clip: rect(0.08333333rem, 3.41666667rem, 2.5rem, 2.33333333rem);
+  top: -2.08333rem;
+  right: -0.08333rem;
+  border-bottom: 1.20833rem solid #4d4d4d;
+  clip: rect(0.08333rem, 3.41667rem, 2.5rem, 2.33333rem);
   border-radius: 416.625rem;
 }
 /* AudioPlayback.css */
@@ -3592,14 +3592,14 @@ html {
 .moon-audio-playback-track-icon {
   position: relative;
   top: 0.25rem;
-  left: 0.16666666666666666rem;
-  width: 5.333333333333333rem;
-  height: 5.333333333333333rem;
+  left: 0.16667rem;
+  width: 5.33333rem;
+  height: 5.33333rem;
   background: transparent url() no-repeat 0rem 0rem;
   display: inline-block;
 }
 .moon-audio-playback-playtime {
-  font-size: 0.8333333333333334rem;
+  font-size: 0.83333rem;
 }
 .moon-audio-track-info,
 .moon-audio-control-buttons > * {
@@ -3607,8 +3607,8 @@ html {
   top: 0.25rem;
 }
 .moon-audio-play-time {
-  width: 3.3333333333333335rem;
-  font-size: 0.8333333333333334rem;
+  width: 3.33333rem;
+  font-size: 0.83333rem;
   padding-top: 3rem;
 }
 .moon-audio-play-time.left {
@@ -3622,20 +3622,20 @@ html {
 }
 .moon-audio-track-info {
   width: 40%;
-  padding: 0 0.4166666666666667rem;
+  padding: 0 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-audio-track-info {
   text-align: right;
   direction: rtl;
 }
 .moon-audio-top {
-  height: 2.7083333333333335rem;
+  height: 2.70833rem;
   padding-top: 0.625rem;
 }
 /* AudioPlayback styles for IconButton */
 .moon-audio-icon-button {
   background-color: #808080;
-  margin: 0.3333333333333333rem 0.16666666666666666rem;
+  margin: 0.33333rem 0.16667rem;
 }
 .moon-audio-icon-button.left {
   float: left;
@@ -3645,7 +3645,7 @@ html {
 }
 /* AudioPlayback styles for Slider */
 .moon-audio-slider-container {
-  padding-top: 0.4166666666666667rem;
+  padding-top: 0.41667rem;
 }
 .moon-audio-slider.spotlight > .moon-slider-knob {
   background-color: #cf0652;
@@ -3655,34 +3655,34 @@ html {
   height: 1.25rem;
   width: 1.25rem;
   border-radius: 0.625rem;
-  margin: -0.54166667rem -0.66666667rem;
+  margin: -0.54167rem -0.66667rem;
   background-color: #808080;
 }
 .moon-audio-slider > .moon-slider-knob.active,
 .moon-audio-slider > .moon-slider-knob.spotselect,
 .moon-audio-slider > .moon-slider-knob:active:hover {
-  height: 1.4166666666666667rem;
-  width: 1.4166666666666667rem;
-  border-radius: 0.7083333333333334rem;
+  height: 1.41667rem;
+  width: 1.41667rem;
+  border-radius: 0.70833rem;
   margin: -0.625rem -0.75rem;
   background-color: #808080;
 }
 .moon-audio-slider.moon-progress-bar {
   background-color: #cccccc;
   margin: 0rem;
-  top: 0.4166666666666667rem;
+  top: 0.41667rem;
 }
 .moon-audio-slider > .moon-progress-bar-bar {
   background-color: #666666;
 }
 /* AudioPlayback styles for queue */
 .moon-audio-playback-queue {
-  margin: 0rem 1.6666666666666667rem;
+  margin: 0rem 1.66667rem;
 }
 /* AudioPlayback styles for queue list items */
 .moon-audio-queue-list {
-  height: 4.166666666666667rem;
-  padding: 0.5rem 0.6666666666666666rem;
+  height: 4.16667rem;
+  padding: 0.5rem 0.66667rem;
   border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
 }
@@ -3695,17 +3695,17 @@ html {
   vertical-align: middle;
 }
 .moon-audio-queue-album-art {
-  width: 3.3333333333333335rem;
-  height: 3.3333333333333335rem;
+  width: 3.33333rem;
+  height: 3.33333rem;
   background: transparent none no-repeat 0rem 0rem;
-  padding-right: 0.4166666666666667rem;
+  padding-right: 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-audio-queue-album-art {
   padding-right: 0;
-  padding-left: 0.4166666666666667rem;
+  padding-left: 0.41667rem;
 }
 .moon-video-transport-slider {
-  height: 3.33333333rem;
+  height: 3.33333rem;
   background-color: #323232;
 }
 .moon-video-transport-slider .moon-slider-popup.above {
@@ -3722,7 +3722,7 @@ html {
   width: 0.25rem;
   border-radius: 0.125rem;
   margin: -0.125rem;
-  top: 0.83333333rem;
+  top: 0.83333rem;
   pointer-events: none;
 }
 .moon-video-transport-slider-knob {
@@ -3768,7 +3768,7 @@ html {
   display: inline-block;
 }
 .moon-video-transport-slider-indicator-wrapper {
-  height: 3.4166666666666665rem;
+  height: 3.41667rem;
   top: 0;
   position: absolute;
 }
@@ -3781,16 +3781,16 @@ html {
 .moon-video-transport-slider-indicator-bar-left {
   position: absolute;
   left: 49.5%;
-  top: 1.0416666666666667rem;
-  width: 0.08333333333333333rem;
+  top: 1.04167rem;
+  width: 0.08333rem;
   height: 1.25rem;
   background-color: #ffffff;
 }
 .moon-video-transport-slider-indicator-bar-right {
   position: absolute;
   left: 49.5%;
-  top: 1.0416666666666667rem;
-  width: 0.08333333333333333rem;
+  top: 1.04167rem;
+  width: 0.08333rem;
   height: 1.25rem;
   background-color: #ffffff;
 }
@@ -3798,7 +3798,7 @@ html {
   position: absolute;
   width: 100%;
   height: 1.25rem;
-  top: 0.9583333333333334rem;
+  top: 0.95833rem;
   font-size: 1.25rem;
   font-family: "Moonstone Miso";
   font-weight: bold;
@@ -3818,7 +3818,7 @@ html {
   background-color: #000000;
 }
 .moon-video-player:not(.enyo-fullscreen) {
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
 }
 .moon-video-player-container {
   display: block;
@@ -3837,8 +3837,8 @@ html {
   position: absolute;
   top: 50%;
   left: 50%;
-  margin-top: -1.52083333rem;
-  margin-left: -1.52083333rem;
+  margin-top: -1.52083rem;
+  margin-left: -1.52083rem;
 }
 /* Fullscreen CSS */
 :-webkit-full-screen.moon-video-player {
@@ -3882,32 +3882,32 @@ html {
   position: static;
 }
 .moon-video-inline {
-  padding-bottom: 3.3333333333333335rem;
+  padding-bottom: 3.33333rem;
 }
 .moon-video-inline-control {
   position: relative;
   width: 100%;
-  height: 3.3333333333333335rem;
+  height: 3.33333rem;
   background-color: #252525;
 }
 .moon-video-inline-control .moon-video-inline-control-play-pause {
   position: absolute;
-  bottom: 0.4166666666666667rem;
-  left: 0.4166666666666667rem;
+  bottom: 0.41667rem;
+  left: 0.41667rem;
 }
 .moon-video-inline-control .moon-video-inline-control-fullscreen {
   position: absolute;
-  bottom: 0.4166666666666667rem;
-  right: 0.4166666666666667rem;
+  bottom: 0.41667rem;
+  right: 0.41667rem;
 }
 .moon-video-inline-control-text {
   font-family: "Moonstone Miso";
   position: absolute;
-  bottom: 0.8333333333333334rem;
-  left: 4.166666666666667rem;
+  bottom: 0.83333rem;
+  left: 4.16667rem;
   background-color: transparent;
   color: #ffffff;
-  font-size: 1.3333333333333333rem;
+  font-size: 1.33333rem;
 }
 .moon-video-inline-control-text > * {
   display: inline;
@@ -3917,7 +3917,7 @@ html {
   bottom: 0rem;
   left: 0rem;
   width: 0%;
-  height: 3.3333333333333335rem;
+  height: 3.33333rem;
   background-color: #cf0652;
   transition: width 0.1s linear;
   -webkit-transition: width 0.1s linear;
@@ -3928,7 +3928,7 @@ html {
   bottom: 0rem;
   left: 0rem;
   width: 0%;
-  height: 3.3333333333333335rem;
+  height: 3.33333rem;
   background-color: #393939;
   transition: width 0.1s linear;
   -webkit-transition: width 0.1s linear;
@@ -3944,12 +3944,12 @@ html {
 .moon-video-inline-control .moon-icon-button.spotlight:active {
   color: #393939;
   background-color: #ffffff;
-  background-position: 0rem -2.08333333rem;
+  background-position: 0rem -2.08333rem;
 }
 .moon-video-inline-control .moon-icon-button.spotlight {
   color: #393939;
   background-color: #ffffff;
-  background-position: 0rem -2.08333333rem;
+  background-position: 0rem -2.08333rem;
 }
 /* --- Fullscreen control --- */
 .moon-video-fullscreen-control {
@@ -3998,7 +3998,7 @@ html {
   direction: ltr;
 }
 .moon-video-player-controls {
-  height: 3.54166667rem;
+  height: 3.54167rem;
   margin-bottom: 1.25rem;
 }
 .enyo-fittable-columns-layout.moon-video-player-controls {
@@ -4009,8 +4009,8 @@ html {
   width: 100%;
 }
 .moon-video-player-more-controls {
-  border-left: 0.08333333333333333rem solid white;
-  padding-left: 0.20833333333333334rem;
+  border-left: 0.08333rem solid white;
+  padding-left: 0.20833rem;
 }
 .moon-video-player-more-controls > * {
   vertical-align: middle;
@@ -4020,31 +4020,31 @@ html {
 }
 .moon-video-player-premium-placeholder-left {
   width: 8.75rem;
-  height: 3.54166667rem;
+  height: 3.54167rem;
   padding-left: 3.75rem;
 }
 .moon-video-player-premium-placeholder-right {
   width: 8.75rem;
-  height: 3.54166667rem;
-  padding-left: 0.20833333333333334rem;
+  height: 3.54167rem;
+  padding-left: 0.20833rem;
 }
 /* --- Buttons --- */
 .moon-video-fullscreen-control .moon-icon-button {
-  width: 3.54166667rem;
-  height: 3.54166667rem;
+  width: 3.54167rem;
+  height: 3.54167rem;
   border-radius: 0;
   border: 0rem;
   background-color: transparent;
   background-position: 0rem 0rem;
-  background-size: 3.54166667rem 7.08333333rem;
+  background-size: 3.54167rem 7.08333rem;
   color: #ffffff;
-  line-height: 3.54166667rem;
+  line-height: 3.54167rem;
 }
 .moon-icon-playpause-font-style {
-  font-size: 9.16666667rem;
+  font-size: 9.16667rem;
 }
 .moon-icon-video-main-control-font-style {
-  font-size: 7.91666667rem;
+  font-size: 7.91667rem;
 }
 /* this style is used for the two side controls and placeholders */
 .moon-icon-button.moon-icon-video-round-controls-style {
@@ -4053,7 +4053,7 @@ html {
   border-radius: 416.625rem;
 }
 .moon-icon-button.moon-icon-video-more-controls-font-style {
-  font-size: 4.66666667rem;
+  font-size: 4.66667rem;
 }
 .moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
 .moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
@@ -4061,7 +4061,7 @@ html {
 .moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
 .moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
 .moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
-  background-position: 0 -3.54166667rem;
+  background-position: 0 -3.54167rem;
   border: 0rem;
   background-color: transparent;
   color: #cf0652;
@@ -4084,7 +4084,7 @@ html {
   text-align: center;
 }
 .moon-video-fullscreen-control .moon-video-player-control-buttons > * {
-  margin: 0 1.6666666666666667rem;
+  margin: 0 1.66667rem;
 }
 .moon-video-fullscreen-control .moon-video-player-control-buttons > :first-child {
   margin-left: 0;
@@ -4095,7 +4095,7 @@ html {
 /* ---- Slider container styling ---- */
 .moon-video-player-slider-container {
   padding: 3.75rem 0 0 0;
-  height: 3.3333333333333335rem;
+  height: 3.33333rem;
 }
 .moon-video-player-slider-container .moon-slider {
   margin: 0 0 0 !important;
@@ -4115,12 +4115,12 @@ html {
 .moon-icon.moon-video-feedback-icon-left,
 .moon-icon.moon-video-feedback-icon-right {
   display: inline-block;
-  width: 1.33333333rem;
+  width: 1.33333rem;
   margin: 0 0 0 0.625rem;
   /* margin-right is inherited from moon-video-player-feedback */
   color: #cf0652;
-  font-size: 5.16666667rem;
-  line-height: 1.08333333rem;
+  font-size: 5.16667rem;
+  line-height: 1.08333rem;
   /* use line-height to middle align the icon, the defaut 32px from moon-icon will make it too low */
 }
 .moon-icon.moon-video-feedback-icon-left .small-icon-tap-area,
@@ -4135,18 +4135,18 @@ html {
   margin-right: 0.625rem;
 }
 .moon-icon.moon-video-feedback-icon-left.moon-icon-pausejumpbackward {
-  width: 1.54166667rem;
+  width: 1.54167rem;
 }
 .moon-icon.moon-video-feedback-icon-right.moon-icon-play {
   font-size: 3rem;
-  width: 0.91666667rem;
+  width: 0.91667rem;
 }
 .moon-icon.moon-video-feedback-icon-right.moon-icon-pause {
   font-size: 3rem;
-  width: 0.91666667rem;
+  width: 0.91667rem;
 }
 .moon-icon.moon-video-feedback-icon-right.moon-icon-pausejumpforward {
-  width: 1.54166667rem;
+  width: 1.54167rem;
 }
 .moon-video-player-feedback .moon-icon.small > .small-icon-tap-area {
   top: 0;
@@ -4156,7 +4156,7 @@ html {
 }
 .enyo-locale-non-latin .moon-video-feedback-icon-left,
 .enyo-locale-non-latin .moon-video-feedback-icon-right {
-  margin-bottom: 0.08333333333333333rem;
+  margin-bottom: 0.08333rem;
 }
 .enyo-locale-right-to-left .moon-video-player-feedback {
   margin: 0 0 0 0.625rem;
@@ -4170,11 +4170,11 @@ html {
 .moon-video-info-header {
   display: inline-block;
   vertical-align: top;
-  max-width: 45.833333333333336rem;
+  max-width: 45.83333rem;
 }
 .moon-video-player-info-datetime {
-  font-size: 1.33333333rem;
-  margin-bottom: 1.3333333333333333rem;
+  font-size: 1.33333rem;
+  margin-bottom: 1.33333rem;
   white-space: nowrap;
 }
 .moon-video-player-info-title {
@@ -4193,7 +4193,7 @@ html {
   font-family: "MuseoSans 700";
   font-size: 1.25rem;
   color: #ffffff;
-  margin-bottom: 0.9166666666666666rem;
+  margin-bottom: 0.91667rem;
   white-space: nowrap;
 }
 .enyo-locale-non-latin .moon-video-player-info-subtitle {
@@ -4203,15 +4203,15 @@ html {
 }
 .moon-video-player-info-subsubtitle {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #a6a6a6;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
   font-style: italic;
   color: #ffffff;
   display: inline-block;
   white-space: normal;
   max-width: 50rem;
-  margin-bottom: 0.4166666666666667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-video-player-info-subsubtitle a:link {
   color: #cf0652;
@@ -4231,18 +4231,18 @@ html {
 }
 .enyo-locale-non-latin .moon-video-player-info-subsubtitle {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
   color: #ffffff;
 }
 .moon-video-player-info-description {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #a6a6a6;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
   color: #ffffff;
   white-space: normal;
-  margin-bottom: 1.0416666666666667rem;
+  margin-bottom: 1.04167rem;
   -webkit-line-clamp: 3;
   display: -webkit-inline-box;
   overflow: hidden;
@@ -4267,33 +4267,33 @@ html {
 }
 .enyo-locale-non-latin .moon-video-player-info-description {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
   color: #ffffff;
 }
 .moon-video-player-info-client {
   display: inline-block;
-  margin: 0 0 0.4166666666666667rem 0.8333333333333334rem;
+  margin: 0 0 0.41667rem 0.83333rem;
 }
 .enyo-locale-right-to-left .moon-video-player-info-client {
-  margin: 0 0.8333333333333334rem 0.4166666666666667rem 0;
+  margin: 0 0.83333rem 0.41667rem 0;
 }
 .moon-video-player-info-client > * {
   display: inline-block;
-  margin: 0 0.20833333333333334rem;
+  margin: 0 0.20833rem;
 }
 .moon-channelinfo {
   display: inline-block;
   vertical-align: top;
   text-align: right;
   white-space: normal;
-  max-width: 33.333333333333336rem;
+  max-width: 33.33333rem;
 }
 .moon-channelinfo .moon-marquee {
   text-align: right;
 }
 .moon-video-player-channel-info-badges > * {
-  margin: 0.125rem 0 0.125rem 0.8333333333333334rem;
+  margin: 0.125rem 0 0.125rem 0.83333rem;
 }
 .moon-video-player-channel-info-no {
   font-family: "Moonstone Miso";
@@ -4311,7 +4311,7 @@ html {
   font-family: "MuseoSans 700";
   font-size: 1.25rem;
   color: #ffffff;
-  margin-bottom: 0.9166666666666666rem;
+  margin-bottom: 0.91667rem;
   white-space: nowrap;
 }
 .enyo-locale-non-latin .moon-video-player-channel-info-name {
@@ -4319,10 +4319,10 @@ html {
 }
 .moon-video-player-info-icon {
   font-family: "MuseoSans 700";
-  font-size: 0.83333333rem;
+  font-size: 0.83333rem;
   color: #000000;
   background-color: #ffffff;
-  border-radius: 0.20833333333333334rem;
+  border-radius: 0.20833rem;
   text-align: center;
   white-space: nowrap;
   padding: 0.125rem 0.375rem;
@@ -4334,7 +4334,7 @@ html {
 .moon-video-player-info-redicon {
   background-color: #fe4a4b;
   color: #ffffff;
-  margin-top: 0.5416666666666666rem;
+  margin-top: 0.54167rem;
 }
 .moon-background-wrapper {
   position: absolute;
@@ -4356,14 +4356,14 @@ html {
   height: 0;
 }
 .moon-background-wrapper-client-content.left {
-  padding: 0 1.25rem 0 2.9166666666666665rem;
+  padding: 0 1.25rem 0 2.91667rem;
   float: left;
 }
 .moon-background-wrapper-client-content.left:after {
   left: 100%;
   bottom: 0;
-  border-bottom: solid 41.666666666666664rem transparent;
-  border-left: solid 7.08333333rem #000000;
+  border-bottom: solid 41.66667rem transparent;
+  border-left: solid 7.08333rem #000000;
 }
 .moon-background-wrapper-client-content.right {
   padding: 0 1.25rem 0 0;
@@ -4372,8 +4372,8 @@ html {
 .moon-background-wrapper-client-content.right:after {
   right: 100%;
   top: 0;
-  border-top: solid 41.666666666666664rem transparent;
-  border-right: solid 7.08333333rem #000000;
+  border-top: solid 41.66667rem transparent;
+  border-right: solid 7.08333rem #000000;
 }
 .moon-background-wrapper-client-content > * {
   display: inline-block;
@@ -4383,7 +4383,7 @@ html {
   direction: rtl;
 }
 .moon-clock {
-  margin: 1.25rem 0.8333333333333334rem 1.25rem 1.6666666666666667rem;
+  margin: 1.25rem 0.83333rem 1.25rem 1.66667rem;
 }
 .moon-clock .moon-bold-text {
   font-size: 2.25rem;
@@ -4416,11 +4416,11 @@ html {
   -webkit-user-select: none;
 }
 .moon-scroller-client-wrapper.v-scroll-enabled {
-  padding-right: 2.91666667rem;
+  padding-right: 2.91667rem;
 }
 .enyo-locale-right-to-left .moon-scroller-client-wrapper.v-scroll-enabled {
   padding-right: 0;
-  padding-left: 2.91666667rem;
+  padding-left: 2.91667rem;
 }
 .moon-scroller-client-wrapper.h-scroll-enabled {
   padding-bottom: 2.5rem;
@@ -4458,12 +4458,12 @@ html {
 .moon-scroller-v-column {
   top: 0rem;
   bottom: 0rem;
-  right: 0.41666667rem;
+  right: 0.41667rem;
   width: 2.5rem;
 }
 .enyo-locale-right-to-left .moon-scroller-v-column {
   right: auto;
-  left: 0.41666667rem;
+  left: 0.41667rem;
 }
 /* Default position for horizontal scrollbar */
 .moon-scroller-h-column {
@@ -4502,8 +4502,8 @@ html {
 .moon-expandable-input .moon-input-decorator {
   width: 100%;
   box-sizing: border-box;
-  margin-top: 0.41666667rem;
-  margin-bottom: 0.41666667rem;
+  margin-top: 0.41667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-expandable-input .moon-input {
   width: 100%;
@@ -4525,7 +4525,7 @@ html {
 .moon-objaction.vertical .moon-objaction-actions {
   opacity: 0;
   text-align: center;
-  padding: 0 0.41666667rem;
+  padding: 0 0.41667rem;
   box-sizing: border-box;
 }
 .moon-objaction.vertical .moon-objaction-actions.stretch > * {
@@ -4537,24 +4537,24 @@ html {
 .moon-objaction.horizontal .moon-objaction-client {
   display: table-cell;
   width: 100%;
-  padding-right: 0.41666667rem;
+  padding-right: 0.41667rem;
 }
 .moon-objaction.horizontal .moon-objaction-actions {
   display: table-cell;
   opacity: 0;
   white-space: nowrap;
   vertical-align: middle;
-  padding-right: 0.41666667rem;
+  padding-right: 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-objaction-client.horizontal .moon-objaction-client {
   padding-right: auto;
-  padding-left: 0.41666667rem;
+  padding-left: 0.41667rem;
 }
 .moon-objaction.vertical .moon-objaction-client .moon-item.spotlight {
   background-color: transparent;
 }
 .moon-objaction.vertical .moon-objaction-client .moon-item > img {
-  padding: 0.41666667rem;
+  padding: 0.41667rem;
 }
 .moon-objaction.vertical .moon-objaction-client .moon-item.spotlight > img {
   background-color: #cf0652;
@@ -4562,13 +4562,13 @@ html {
 /* FormCheckbox.css */
 .moon-item.moon-formcheckbox-item {
   background: none;
-  padding: 0 0 0 0.41666667rem;
-  margin-bottom: 0.41666667rem;
+  padding: 0 0 0 0.41667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-item.moon-formcheckbox-item .moon-checkbox {
   position: absolute;
-  top: 0.20833333333333334rem;
-  left: 0.41666667rem;
+  top: 0.20833rem;
+  left: 0.41667rem;
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 416.625rem;
@@ -4577,21 +4577,21 @@ html {
   text-align: center;
 }
 .moon-item.moon-formcheckbox-item .moon-checkbox .moon-icon {
-  padding-bottom: 0.08333333333333333rem;
+  padding-bottom: 0.08333rem;
 }
 .moon-item.moon-formcheckbox-item .moon-checkbox-item-label-wrapper {
-  padding: 0.3333333333333333rem 0.4166666666666667rem;
+  padding: 0.33333rem 0.41667rem;
   margin-left: 1.75rem;
 }
 .enyo-locale-right-to-left .moon-item.moon-formcheckbox-item {
-  padding: 0 0.41666667rem 0 0;
+  padding: 0 0.41667rem 0 0;
 }
 .enyo-locale-right-to-left .moon-item.moon-formcheckbox-item .moon-checkbox-item-label-wrapper {
   margin-left: auto;
-  margin-right: 2.16666667rem;
+  margin-right: 2.16667rem;
 }
 .enyo-locale-right-to-left .moon-item.moon-formcheckbox-item .moon-checkbox {
-  right: 0.41666667rem;
+  right: 0.41667rem;
 }
 .moon-formcheckbox-item.spotlight .moon-checkbox {
   background-color: #cf0652;
@@ -4613,7 +4613,7 @@ html {
   margin: -1.25rem 0 0 -1.25rem;
   background-color: #ffffff;
   border-radius: 1.25rem;
-  background-position: center 0.20833333rem;
+  background-position: center 0.20833rem;
 }
 .moon-selection-overlay-support-scrim {
   display: none;
@@ -4626,8 +4626,8 @@ html {
   -webkit-transform-origin: 0rem 0rem;
   border: none;
   background: #a6a6a6;
-  width: 0.16666666666666666rem;
-  height: 0.16666666666666666rem;
+  width: 0.16667rem;
+  height: 0.16667rem;
   border-radius: 0;
 }
 .moon-neutral .moon-thumb {
@@ -4640,10 +4640,10 @@ html {
   -webkit-transition: opacity 0.1s linear;
 }
 .moon-scroller-hthumb {
-  bottom: 1.16666667rem;
+  bottom: 1.16667rem;
 }
 .moon-scroller-vthumb {
-  right: 1.16666667rem;
+  right: 1.16667rem;
 }
 .moon-scroller-hthumb.hidden,
 .moon-scroller-vthumb.hidden {
@@ -4651,7 +4651,7 @@ html {
 }
 .moon-image {
   display: inline-block;
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
 }
 .moon-image.has-children {
   position: relative;
@@ -4670,7 +4670,7 @@ html {
   left: 0;
   right: 0;
   background: #6d6d6d;
-  padding: 0.3333333333333333rem;
+  padding: 0.33333rem;
   overflow: hidden;
   display: block;
 }
@@ -4696,7 +4696,7 @@ html {
   overflow: hidden;
 }
 .moon-expandable-text .moon-expandable-text-content {
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
   display: -webkit-inline-box;
   overflow: hidden;
   -webkit-box-orient: vertical;
@@ -4704,13 +4704,13 @@ html {
 .moon-expandable-text .moon-expandable-text-button {
   float: right;
   display: inline-block;
-  padding: 0.41666667rem 1.75rem 0.41666667rem 0.41666667rem;
+  padding: 0.41667rem 1.75rem 0.41667rem 0.41667rem;
   position: relative;
 }
 .moon-expandable-text .moon-expandable-text-button:after {
   position: absolute;
-  top: 0.41666667rem;
-  right: 0.45833333rem;
+  top: 0.41667rem;
+  right: 0.45833rem;
   font-family: "Moonstone Icons";
   content: "\0F0002";
   font-size: 2rem;
@@ -4726,14 +4726,14 @@ html {
   display: none;
 }
 .enyo-locale-non-latin .moon-expandable-text .moon-expandable-text-button:after {
-  top: 0.45833333rem;
+  top: 0.45833rem;
 }
 .enyo-locale-right-to-left .moon-expandable-text .moon-expandable-text-button {
   float: left;
-  padding: 0.41666667rem 0.41666667rem 0.41666667rem 1.75rem;
+  padding: 0.41667rem 0.41667rem 0.41667rem 1.75rem;
 }
 .enyo-locale-right-to-left .moon-expandable-text .moon-expandable-text-button:after {
-  left: 0.45833333rem;
+  left: 0.45833rem;
   right: auto;
 }
 .moon-body-text-control {
@@ -4743,7 +4743,7 @@ html {
   text-align: right;
 }
 .moon-icon-exitfullscreen.moon-icon-exitfullscreen-font-style {
-  font-size: 4.16666667rem;
+  font-size: 4.16667rem;
 }
 /* Put this at the end because we want these to take precedence over others */
 .moon-neutral {
@@ -4769,7 +4769,7 @@ html {
 .moon-hspacing > * {
   display: inline-block;
   vertical-align: middle;
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
 }
 .moon-hspacing.top > * {
   vertical-align: top;
@@ -4779,7 +4779,7 @@ html {
   margin-left: 0;
 }
 .enyo-locale-right-to-left .moon-hspacing > :first-child {
-  margin-left: 0.41666667rem;
+  margin-left: 0.41667rem;
   margin-right: 0;
 }
 .moon-hspacing > :last-child,
@@ -4787,7 +4787,7 @@ html {
   margin-right: 0;
 }
 .enyo-locale-right-to-left .moon-hspacing > :last-child {
-  margin-right: 0.41666667rem;
+  margin-right: 0.41667rem;
   margin-left: 0;
 }
 /* -------------------------- */
@@ -4795,7 +4795,7 @@ html {
 /* -------------------------- */
 .moon-vspacing > * {
   display: block;
-  margin: 0.41666667rem 0;
+  margin: 0.41667rem 0;
 }
 .moon-vspacing > :first-child {
   margin-top: 0;
@@ -4809,33 +4809,33 @@ html {
 .moon-vspacing-s > .moon-item:not(.moon-formcheckbox-item),
 .moon-vspacing-s > .moon-expandable-list-item:not(.open) .moon-item,
 .moon-vspacing-s > .moon-expandable-list-item.open {
-  padding-bottom: 0.41666667rem;
+  padding-bottom: 0.41667rem;
 }
 .moon-vspacing-s > .moon-button,
 .moon-vspacing-s > .moon-input-decorator,
 .moon-vspacing-s > .moon-formcheckbox-item {
-  margin-top: 0.20833333rem;
-  margin-bottom: 0.41666667rem;
+  margin-top: 0.20833rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-vspacing-m > .moon-item:not(.moon-formcheckbox-item),
 .moon-vspacing-m > .moon-expandable-list-item:not(.open) .moon-item,
 .moon-vspacing-m > .moon-expandable-list-item.open {
-  padding-bottom: 0.83333333rem;
+  padding-bottom: 0.83333rem;
 }
 .moon-vspacing-m > .moon-button,
 .moon-vspacing-m > .moon-input-decorator,
 .moon-vspacing-m > .moon-formcheckbox-item {
-  margin-top: 0.41666667rem;
-  margin-bottom: 0.83333333rem;
+  margin-top: 0.41667rem;
+  margin-bottom: 0.83333rem;
 }
 .moon-vspacing-l > .moon-item:not(.moon-formcheckbox-item),
 .moon-vspacing-l > .moon-expandable-list-item:not(.open) .moon-item,
 .moon-vspacing-l > .moon-expandable-list-item.open {
-  padding-bottom: 1.66666667rem;
+  padding-bottom: 1.66667rem;
 }
 .moon-vspacing-l > .moon-button,
 .moon-vspacing-l > .moon-input-decorator,
 .moon-vspacing-l > .moon-formcheckbox-item {
-  margin-top: 0.83333333rem;
-  margin-bottom: 1.66666667rem;
+  margin-top: 0.83333rem;
+  margin-bottom: 1.66667rem;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -13,7 +13,7 @@ html {
 /* 720p screen size */
 @media only screen and (max-width: 1280px) {
   html {
-    font-size: 0.6666666666666666rem;
+    font-size: 0.66667rem;
     font-size: 16px;
   }
 }
@@ -221,140 +221,140 @@ html {
   width: 2.5rem;
 }
 .moon-2h {
-  width: 5.83333333rem;
+  width: 5.83333rem;
 }
 .moon-3h {
-  width: 9.16666667rem;
+  width: 9.16667rem;
 }
 .moon-4h {
   width: 12.5rem;
 }
 .moon-5h {
-  width: 15.83333333rem;
+  width: 15.83333rem;
 }
 .moon-6h {
-  width: 19.16666667rem;
+  width: 19.16667rem;
 }
 .moon-7h {
   width: 22.5rem;
 }
 .moon-8h {
-  width: 25.83333333rem;
+  width: 25.83333rem;
 }
 .moon-9h {
-  width: 29.16666667rem;
+  width: 29.16667rem;
 }
 .moon-10h {
   width: 32.5rem;
 }
 .moon-11h {
-  width: 35.83333333rem;
+  width: 35.83333rem;
 }
 .moon-12h {
-  width: 39.16666667rem;
+  width: 39.16667rem;
 }
 .moon-13h {
   width: 42.5rem;
 }
 .moon-14h {
-  width: 45.83333333rem;
+  width: 45.83333rem;
 }
 .moon-15h {
-  width: 49.16666667rem;
+  width: 49.16667rem;
 }
 .moon-16h {
   width: 52.5rem;
 }
 .moon-17h {
-  width: 55.83333333rem;
+  width: 55.83333rem;
 }
 .moon-18h {
-  width: 59.16666667rem;
+  width: 59.16667rem;
 }
 .moon-19h {
   width: 62.5rem;
 }
 .moon-20h {
-  width: 65.83333333rem;
+  width: 65.83333rem;
 }
 /* ------- Vertical Dimensioning (columns) ------- */
 .moon-1v {
-  height: 1.66666667rem;
+  height: 1.66667rem;
 }
 .moon-2v {
-  height: 3.33333333rem;
+  height: 3.33333rem;
 }
 .moon-3v {
   height: 5rem;
 }
 .moon-4v {
-  height: 6.66666667rem;
+  height: 6.66667rem;
 }
 .moon-5v {
-  height: 8.33333333rem;
+  height: 8.33333rem;
 }
 .moon-6v {
   height: 10rem;
 }
 .moon-7v {
-  height: 11.66666667rem;
+  height: 11.66667rem;
 }
 .moon-8v {
-  height: 13.33333333rem;
+  height: 13.33333rem;
 }
 .moon-9v {
   height: 15rem;
 }
 .moon-10v {
-  height: 16.66666667rem;
+  height: 16.66667rem;
 }
 .moon-11v {
-  height: 18.33333333rem;
+  height: 18.33333rem;
 }
 .moon-12v {
   height: 20rem;
 }
 .moon-13v {
-  height: 21.66666667rem;
+  height: 21.66667rem;
 }
 .moon-14v {
-  height: 23.33333333rem;
+  height: 23.33333rem;
 }
 .moon-15v {
   height: 25rem;
 }
 .moon-16v {
-  height: 26.66666667rem;
+  height: 26.66667rem;
 }
 .moon-17v {
-  height: 28.33333333rem;
+  height: 28.33333rem;
 }
 .moon-18v {
   height: 30rem;
 }
 .moon-19v {
-  height: 31.66666667rem;
+  height: 31.66667rem;
 }
 .moon-20v {
-  height: 33.33333333rem;
+  height: 33.33333rem;
 }
 .moon-21v {
   height: 35rem;
 }
 .moon-22v {
-  height: 36.66666667rem;
+  height: 36.66667rem;
 }
 .moon-23v {
-  height: 38.33333333rem;
+  height: 38.33333rem;
 }
 .moon-24v {
   height: 40rem;
 }
 .moon-25v {
-  height: 41.66666667rem;
+  height: 41.66667rem;
 }
 .moon-26v {
-  height: 43.33333333rem;
+  height: 43.33333rem;
 }
 /* Prevent browser's default focus treatment (at least in Chrome) */
 :focus {
@@ -367,7 +367,7 @@ html {
   font-weight: normal;
   font-style: normal;
   letter-spacing: normal;
-  padding: 0.83333333rem;
+  padding: 0.83333rem;
   color: #4b4b4b;
   background-color: #ededed;
 }
@@ -375,10 +375,10 @@ html {
   direction: rtl;
 }
 .moon-divider-border {
-  border-bottom: 0.08333333rem solid #4b4b4b;
+  border-bottom: 0.08333rem solid #4b4b4b;
 }
 .moon-neutral-divider-border {
-  border-bottom: 0.08333333rem solid #ffffff;
+  border-bottom: 0.08333rem solid #ffffff;
 }
 .moon-composite {
   -webkit-transform: translateZ(0);
@@ -398,7 +398,7 @@ html {
 .moon-superscript {
   font-size: 1rem;
   vertical-align: top;
-  margin: 0 0 0 0.08333333333333333rem;
+  margin: 0 0 0 0.08333rem;
   padding: 0;
 }
 .moon-pre-text {
@@ -406,7 +406,7 @@ html {
   vertical-align: top;
   height: 2rem;
   line-height: 1rem;
-  margin: 0.5rem 0.08333333333333333rem 0.3333333333333333rem 0;
+  margin: 0.5rem 0.08333rem 0.33333rem 0;
   padding: 0rem;
 }
 .moon-large-text {
@@ -429,24 +429,24 @@ html {
 }
 .moon-super-header-text {
   font-family: "Moonstone Miso";
-  font-size: 1.33333333rem;
+  font-size: 1.33333rem;
   -webkit-font-kerning: normal;
 }
 .moon-popup-header-text {
   font-family: "Moonstone Miso";
-  font-size: 3.04166667rem;
+  font-size: 3.04167rem;
   -webkit-font-kerning: normal;
 }
 .moon-divider-text {
   font-family: "MuseoSans 700 Italic";
-  font-size: 0.91666667rem;
+  font-size: 0.91667rem;
   color: #4b4b4b;
 }
 .moon-body-text {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #4b4b4b;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-body-text a:link {
   color: #cf0652;
@@ -465,14 +465,14 @@ html {
   text-decoration: none;
 }
 .moon-body-large-text {
-  font-size: 1.16666667rem;
-  line-height: 1.66666667rem;
+  font-size: 1.16667rem;
+  line-height: 1.66667rem;
 }
 .moon-bold-text {
   font-family: "MuseoSans 900";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #4b4b4b;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-bold-text a:link {
   color: #cf0652;
@@ -491,7 +491,7 @@ html {
   text-decoration: none;
 }
 .moon-body-text-spacing {
-  margin: 0 0.41666667rem 1.66666667rem 0.41666667rem;
+  margin: 0 0.41667rem 1.66667rem 0.41667rem;
 }
 .moon-large-button-text {
   font-family: "Moonstone Miso Bold";
@@ -548,29 +548,29 @@ html {
   line-height: 1.5em;
 }
 .enyo-locale-non-latin .moon-popup-header-text {
-  font-size: 2.70833333rem;
+  font-size: 2.70833rem;
 }
 .enyo-locale-non-latin .moon-sub-header-text {
   font-size: 1.25rem;
 }
 .enyo-locale-non-latin .moon-super-header-text {
-  font-size: 1.33333333rem;
+  font-size: 1.33333rem;
 }
 .enyo-locale-non-latin .moon-divider-text {
-  font-size: 1.16666667rem;
+  font-size: 1.16667rem;
   font-style: normal;
 }
 .enyo-locale-non-latin .moon-body-text {
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 .enyo-locale-non-latin .moon-body-large-text {
-  font-size: 1.16666667rem;
-  line-height: 1.66666667rem;
+  font-size: 1.16667rem;
+  line-height: 1.66667rem;
 }
 .enyo-locale-non-latin .moon-bold-text {
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 .enyo-locale-non-latin .moon-large-button-text {
   font-size: 1.5rem;
@@ -594,7 +594,7 @@ html {
   background-repeat: no-repeat;
   display: inline-block;
   vertical-align: middle;
-  margin: 0.375rem 0.5833333333333334rem;
+  margin: 0.375rem 0.58333rem;
   font-family: "Moonstone", "Moonstone Icons";
   font-size: 3.75rem;
   line-height: 1.875rem;
@@ -605,19 +605,19 @@ html {
 .moon-icon.small,
 .moon-icon-toggle.small {
   background-position: center -0.375rem;
-  background-size: 2.08333333rem 4.16666667rem;
-  width: 1.33333333rem;
-  height: 1.33333333rem;
-  font-size: 2.66666667rem;
-  line-height: 1.33333333rem;
+  background-size: 2.08333rem 4.16667rem;
+  width: 1.33333rem;
+  height: 1.33333rem;
+  font-size: 2.66667rem;
+  line-height: 1.33333rem;
 }
 .moon-icon.small > .small-icon-tap-area,
 .moon-icon-toggle.small > .small-icon-tap-area {
   position: absolute;
-  top: -0.58333333rem;
-  bottom: -0.58333333rem;
-  left: -0.58333333rem;
-  right: -0.58333333rem;
+  top: -0.58333rem;
+  bottom: -0.58333rem;
+  left: -0.58333rem;
+  right: -0.58333rem;
   color: inherit;
   line-height: 2.5rem;
 }
@@ -628,14 +628,14 @@ html {
 }
 .moon-icon.font-lg-icons.small,
 .moon-icon-toggle.font-lg-icons.small {
-  font-size: 1.33333333rem;
+  font-size: 1.33333rem;
 }
 .spotlight .moon-icon {
   color: #ffffff;
   background-position: center -3.75rem;
 }
 .spotlight .moon-icon.small {
-  background-position: center -2.45833333rem;
+  background-position: center -2.45833rem;
 }
 .disabled .moon-icon,
 .moon-icon.disabled {
@@ -647,23 +647,23 @@ html {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   color: #999999;
-  width: 3.54166667rem;
-  height: 3.54166667rem;
-  border-radius: 1.77083333rem;
+  width: 3.54167rem;
+  height: 3.54167rem;
+  border-radius: 1.77083rem;
   background-color: #ffffff;
   background-size: 3.125rem 6.25rem;
-  border: 0.20833333rem solid transparent;
+  border: 0.20833rem solid transparent;
   background-position: center 0;
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
   line-height: 3.125rem;
 }
 .moon-icon-button.small {
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 1.25rem;
-  background-size: 2.08333333rem 4.16666667rem;
+  background-size: 2.08333rem 4.16667rem;
   background-position: center 0;
-  line-height: 2.08333333rem;
+  line-height: 2.08333rem;
 }
 .moon-icon-button.small > .small-icon-tap-area {
   line-height: 3.25rem;
@@ -676,7 +676,7 @@ html {
 }
 .moon-icon-button.hover:hover:not(.disabled).small,
 .moon-icon-button.spotlight.small {
-  background-position: center -2.08333333rem;
+  background-position: center -2.08333rem;
 }
 .moon-icon-button.active:not(.spotlight),
 .moon-icon-button:active,
@@ -714,13 +714,13 @@ html {
 }
 .moon-icon-button.active.spotlight:not(.contextual-popup-button):active.small,
 .moon-icon-button.active.spotlight:not(.contextual-popup-button).pressed.small {
-  background-position: center -2.08333333rem;
+  background-position: center -2.08333rem;
 }
 .spotlight .moon-icon-button {
   background-position: center -3.125rem;
 }
 .spotlight .moon-icon-button.small {
-  background-position: center -2.08333333rem;
+  background-position: center -2.08333rem;
 }
 .moon-marquee {
   width: auto;
@@ -759,9 +759,9 @@ html {
 }
 .moon-simple-picker {
   display: inline-block;
-  max-width: 14.583333333333334rem;
+  max-width: 14.58333rem;
   box-sizing: border-box;
-  padding: 0 2.91666667rem;
+  padding: 0 2.91667rem;
   position: relative;
   height: 2.5rem;
   vertical-align: middle;
@@ -893,7 +893,7 @@ html {
 /* Checkbox.css */
 .moon-checkbox {
   cursor: pointer;
-  height: 1.33333333rem;
+  height: 1.33333rem;
 }
 .moon-checkbox .moon-icon {
   visibility: hidden;
@@ -907,12 +907,12 @@ html {
   color: #ffffff;
 }
 .moon-divider {
-  border-bottom: 0.08333333rem solid #4b4b4b;
-  margin: 0 0.41666667rem 0.83333333rem 0.41666667rem;
+  border-bottom: 0.08333rem solid #4b4b4b;
+  margin: 0 0.41667rem 0.83333rem 0.41667rem;
   padding-bottom: 0.125rem;
 }
 .moon-neutral .moon-divider {
-  border-bottom: 0.08333333rem solid #ffffff;
+  border-bottom: 0.08333rem solid #ffffff;
 }
 .moon-checkbox-item {
   position: relative;
@@ -920,19 +920,19 @@ html {
 }
 .moon-checkbox-item .moon-checkbox {
   position: absolute;
-  top: 0.33333333rem;
+  top: 0.33333rem;
   right: 0.25rem;
 }
 .moon-checkbox-item .moon-checkbox-item-label-wrapper {
   height: 1.2em;
-  margin-right: 1.33333333rem;
+  margin-right: 1.33333rem;
 }
 .moon-checkbox-item.left-handed .moon-checkbox {
   left: 0.25rem;
 }
 .moon-checkbox-item.left-handed .moon-checkbox-item-label-wrapper {
   margin-right: 0rem;
-  margin-left: 1.33333333rem;
+  margin-left: 1.33333rem;
 }
 .moon-checkbox-item .moon-icon.small > .small-icon-tap-area {
   left: 0;
@@ -943,19 +943,19 @@ html {
 }
 /* Special treatment inside of ExpandablePicker (checkbox nudged up) */
 .moon-expandable-picker .moon-checkbox-item .moon-checkbox {
-  top: 0.41666667rem;
+  top: 0.41667rem;
 }
 /* this is a fix for TV only - left-side of letter cut off in list-action item drawer*/
 .moon-list-actions-drawer-client .moon-checkbox-item .moon-checkbox-item-label-wrapper {
-  padding-left: 0.08333333333333333rem;
+  padding-left: 0.08333rem;
 }
 /* Right to left */
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox {
-  left: 0.58333333rem;
+  left: 0.58333rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox-item-label-wrapper {
-  margin-left: 1.33333333rem;
+  margin-left: 1.33333rem;
   margin-right: 0rem;
 }
 .enyo-locale-right-to-left .moon-checkbox-item.left-handed .moon-checkbox {
@@ -963,7 +963,7 @@ html {
   right: 0.25rem;
 }
 .enyo-locale-right-to-left .moon-checkbox-item.left-handed .moon-checkbox-item-label-wrapper {
-  margin-right: 1.33333333rem;
+  margin-right: 1.33333rem;
   margin-left: 0rem;
 }
 /* ToggleText.css */
@@ -986,7 +986,7 @@ html {
 .moon-toggle-text-text {
   position: absolute;
   right: 0rem;
-  top: 0.08333333333333333rem;
+  top: 0.08333rem;
   text-align: right;
   color: #4b4b4b;
 }
@@ -1000,12 +1000,12 @@ html {
 /* ToggleSwitch.css */
 .moon-checkbox.moon-toggle-switch {
   border-radius: 0.6875rem;
-  width: 2.70833333rem;
+  width: 2.70833rem;
   height: 1.375rem;
   line-height: 1.375rem;
   background-color: #ffffff;
   font-family: "Moonstone Icons";
-  font-size: 2.70833333rem;
+  font-size: 2.70833rem;
   overflow: hidden;
   text-align: left;
 }
@@ -1020,7 +1020,7 @@ html {
   background-color: #ffffff;
 }
 .moon-checkbox.moon-toggle-switch[checked] .moon-icon {
-  left: 1.35416667rem;
+  left: 1.35417rem;
   color: #cf0652;
 }
 .moon-checkbox.moon-toggle-switch[disabled] {
@@ -1045,15 +1045,15 @@ html {
   position: relative;
 }
 .moon-toggle-item .moon-checkbox.moon-toggle-switch {
-  top: 0.45833333rem;
+  top: 0.45833rem;
   /* To override top:10px set by .moon-checkbox-item .moon-checkbox so the indicator vertically middle align */
-  right: 0.41666667rem;
+  right: 0.41667rem;
 }
 .moon-toggle-item .moon-toggle-item-label-wrapper {
   margin-right: 3.125rem;
 }
 .enyo-locale-right-to-left .moon-toggle-item .moon-checkbox.moon-toggle-switch {
-  left: 0.41666667rem;
+  left: 0.41667rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-toggle-item .moon-toggle-item-label-wrapper {
@@ -1064,54 +1064,54 @@ html {
 .moon-button.moon-toggle-button {
   text-align: center;
   position: relative;
-  padding-right: 2.58333333rem;
+  padding-right: 2.58333rem;
 }
 .moon-button.moon-toggle-button:after {
   position: absolute;
   content: "";
-  top: 1.14583333rem;
-  right: 0.91666667rem;
-  width: 0.66666667rem;
-  height: 0.66666667rem;
+  top: 1.14583rem;
+  right: 0.91667rem;
+  width: 0.66667rem;
+  height: 0.66667rem;
   border-radius: 416.625rem;
   background-color: #b3b3b3;
-  border: solid 0.08333333rem #ffffff;
+  border: solid 0.08333rem #ffffff;
 }
 .moon-button.moon-toggle-button[disabled] {
-  border: 0.20833333rem solid transparent;
+  border: 0.20833rem solid transparent;
 }
 .moon-button.moon-toggle-button[disabled]:after {
   background-color: #b3b3b3;
-  border: solid 0.08333333rem #ffffff;
+  border: solid 0.08333rem #ffffff;
 }
 .moon-button.moon-toggle-button.moon-toggle-button-on {
-  border: solid 0.20833333rem #cf0652;
+  border: solid 0.20833rem #cf0652;
 }
 .moon-button.moon-toggle-button.moon-toggle-button-on:after {
   background-color: #cf0652;
-  border: solid 0.08333333rem #ffffff;
+  border: solid 0.08333rem #ffffff;
 }
 .moon-button.moon-toggle-button.small {
   padding-right: 2.5rem;
 }
 .moon-button.moon-toggle-button.small:after {
   top: 0.625rem;
-  right: 0.83333333rem;
+  right: 0.83333rem;
 }
 .enyo-locale-right-to-left .moon-button.moon-toggle-button {
-  padding-right: 0.91666667rem;
-  padding-left: 2.58333333rem;
+  padding-right: 0.91667rem;
+  padding-left: 2.58333rem;
 }
 .enyo-locale-right-to-left .moon-button.moon-toggle-button:after {
-  left: 0.91666667rem;
+  left: 0.91667rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-button.moon-toggle-button.small {
-  padding-right: 0.83333333rem;
+  padding-right: 0.83333rem;
   padding-left: 2.5rem;
 }
 .enyo-locale-right-to-left .moon-button.moon-toggle-button.small:after {
-  left: 0.83333333rem;
+  left: 0.83333rem;
   right: auto;
 }
 /* Item.css */
@@ -1120,7 +1120,7 @@ html {
   font-size: 1.25rem;
   color: #4b4b4b;
   line-height: 1.2em;
-  padding: 0.41666667rem;
+  padding: 0.41667rem;
   position: relative;
 }
 .moon-item.spotlight {
@@ -1140,45 +1140,45 @@ html {
 }
 /* SelectableItem.css */
 .moon-selectable-item.selected {
-  padding: 0.41666667rem 0.41666667rem 0.41666667rem 1.75rem;
+  padding: 0.41667rem 0.41667rem 0.41667rem 1.75rem;
 }
 .moon-selectable-item.selected:before {
   content: '';
   position: absolute;
-  left: 0.41666667rem;
-  top: 0.7083333333333334rem;
-  width: 0.83333333rem;
-  height: 0.83333333rem;
-  border-radius: 0.41666667rem;
+  left: 0.41667rem;
+  top: 0.70833rem;
+  width: 0.83333rem;
+  height: 0.83333rem;
+  border-radius: 0.41667rem;
   background-color: #cf0652;
 }
 .moon-selectable-item.selected.spotlight:before {
   background-color: #ffffff;
 }
 .enyo-locale-right-to-left .moon-selectable-item.selected {
-  padding: 0.41666667rem 1.75rem 0.41666667rem 0.41666667rem;
+  padding: 0.41667rem 1.75rem 0.41667rem 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-selectable-item.selected:before {
   left: auto;
-  right: 0.41666667rem;
+  right: 0.41667rem;
 }
 /* Button */
 .moon-button {
   position: relative;
   overflow: visible;
-  height: 3.54166667rem;
+  height: 3.54167rem;
   line-height: 3.125rem;
   border-radius: 416.625rem;
   background-color: #ffffff;
-  border: 0.20833333rem solid transparent;
+  border: 0.20833rem solid transparent;
   cursor: pointer;
   white-space: nowrap;
   display: inline-block;
   width: auto;
-  min-width: 3.54166667rem;
-  max-width: 12.583333333333334rem;
-  padding: 0 0.91666667rem;
-  margin: 0 0.41666667rem;
+  min-width: 3.54167rem;
+  max-width: 12.58333rem;
+  padding: 0 0.91667rem;
+  margin: 0 0.41667rem;
   color: #4b4b4b;
 }
 .moon-button > * {
@@ -1196,7 +1196,7 @@ html {
 .moon-button.pressed,
 .moon-button.spotlight.pressed,
 .moon-button.spotlight:active {
-  border: 0.20833333rem solid #cf0652;
+  border: 0.20833rem solid #cf0652;
   background-color: #ffffff;
   color: #4b4b4b;
 }
@@ -1221,28 +1221,28 @@ html {
 .moon-button > .button-tap-area {
   position: absolute;
   border-radius: 416.625rem;
-  top: -0.20833333rem;
-  bottom: -0.20833333rem;
-  left: -0.20833333rem;
-  right: -0.20833333rem;
+  top: -0.20833rem;
+  bottom: -0.20833rem;
+  left: -0.20833rem;
+  right: -0.20833rem;
 }
 .moon-button.small {
   height: 2.5rem;
   min-width: 2.5rem;
-  line-height: 2.08333333rem;
-  padding: 0 0.83333333rem;
+  line-height: 2.08333rem;
+  padding: 0 0.83333rem;
   position: relative;
   overflow: visible;
 }
 .moon-button.small.min-width {
-  min-width: 5.41666667rem;
+  min-width: 5.41667rem;
 }
 .moon-button.small > .button-tap-area {
   border-radius: 0;
-  top: -0.58333333rem;
-  bottom: -0.58333333rem;
-  left: -0.58333333rem;
-  right: -0.58333333rem;
+  top: -0.58333rem;
+  bottom: -0.58333rem;
+  left: -0.58333rem;
+  right: -0.58333rem;
 }
 .moon-neutral .moon-button {
   color: #4b4b4b;
@@ -1261,7 +1261,7 @@ html {
 .moon-neutral .moon-button.pressed,
 .moon-neutral .moon-button.spotlight.pressed,
 .moon-neutral .moon-button.spotlight:active {
-  border: 0.20833333rem solid #cf0652;
+  border: 0.20833rem solid #cf0652;
   background-color: #ffffff;
 }
 .moon-neutral .moon-button.active *,
@@ -1297,17 +1297,17 @@ html {
 /* Caption Decorator - Left/Right Captions */
 .moon-button-caption-decorator .moon-caption.left,
 .moon-button-caption-decorator .moon-caption.right {
-  height: 3.54166667rem;
-  line-height: 3.54166667rem;
+  height: 3.54167rem;
+  line-height: 3.54167rem;
 }
 .moon-button-caption-decorator .moon-caption.left {
   float: left;
-  padding-right: 0.4166666666666667rem;
+  padding-right: 0.41667rem;
   text-align: left;
 }
 .moon-button-caption-decorator .moon-caption.right {
   float: right;
-  padding-left: 0.4166666666666667rem;
+  padding-left: 0.41667rem;
   text-align: right;
 }
 /* Caption Decorator - Top/Bottom Captions */
@@ -1317,10 +1317,10 @@ html {
   text-align: center;
 }
 .moon-button-caption-decorator .moon-caption.top {
-  padding-bottom: 0.16666666666666666rem;
+  padding-bottom: 0.16667rem;
 }
 .moon-button-caption-decorator .moon-caption.bottom {
-  padding-top: 0.16666666666666666rem;
+  padding-top: 0.16667rem;
 }
 /* Caption Decorator - Show On Focus Captions */
 .moon-button-caption-decorator.showOnFocus .moon-caption {
@@ -1336,33 +1336,33 @@ html {
   display: block;
 }
 .moon-button-caption-decorator.showOnFocus .moon-caption.top {
-  margin-bottom: 0.16666666666666666rem;
+  margin-bottom: 0.16667rem;
 }
 .moon-button-caption-decorator.showOnFocus .moon-caption.right {
-  margin-left: 0.4166666666666667rem;
+  margin-left: 0.41667rem;
 }
 .moon-button-caption-decorator.showOnFocus .moon-caption.bottom {
-  margin-top: 0.16666666666666666rem;
+  margin-top: 0.16667rem;
 }
 .moon-button-caption-decorator.showOnFocus .moon-caption.left {
-  margin-right: 0.4166666666666667rem;
+  margin-right: 0.41667rem;
 }
 /* Radio Item */
 .moon-radio-item {
   display: inline-block;
-  max-width: 10.416666666666666rem;
+  max-width: 10.41667rem;
   margin: 0 0.625rem 0 0;
-  padding: 0.41666667rem 0.41666667rem 0.41666667rem 1.75rem;
+  padding: 0.41667rem 0.41667rem 0.41667rem 1.75rem;
 }
 .moon-radio-item:before {
   content: '';
   position: absolute;
-  left: 0.41666667rem;
-  top: 0.7083333333333334rem;
-  width: 0.66666667rem;
-  height: 0.66666667rem;
-  border: solid 0.08333333rem #ffffff;
-  border-radius: 0.41666667rem;
+  left: 0.41667rem;
+  top: 0.70833rem;
+  width: 0.66667rem;
+  height: 0.66667rem;
+  border: solid 0.08333rem #ffffff;
+  border-radius: 0.41667rem;
   background-color: #b3b3b3;
 }
 .moon-radio-item.selected:before {
@@ -1370,16 +1370,16 @@ html {
 }
 .enyo-locale-right-to-left .moon-radio-item {
   margin: 0 0 0 0.625rem;
-  padding: 0.41666667rem 1.75rem 0.41666667rem 0.41666667rem;
+  padding: 0.41667rem 1.75rem 0.41667rem 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-radio-item:before {
   left: auto;
-  right: 0.41666667rem;
+  right: 0.41667rem;
 }
 /* Radio Item */
 .moon-radio-item-group {
   position: relative;
-  margin: 0 0.4166666666666667rem;
+  margin: 0 0.41667rem;
 }
 /* ExpandableListItem Header*/
 .moon-expandable-list-item-header {
@@ -1392,13 +1392,13 @@ html {
 }
 /* Client Items */
 .moon-expandable-list-item.open .moon-expandable-list-item-client {
-  margin-bottom: 0.4166666666666667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-expandable-list-item-client .moon-item {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #4b4b4b;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-expandable-list-item-client .moon-item a:link {
   color: #cf0652;
@@ -1418,8 +1418,8 @@ html {
 }
 .enyo-locale-non-latin .moon-expandable-list-item-client .moon-item {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 .moon-expandable-list-item-client .moon-item.spotlight {
   color: #ffffff;
@@ -1443,12 +1443,12 @@ html {
 }
 .moon-expandable-picker-header:after {
   position: absolute;
-  top: 0.08333333rem;
-  right: 0.45833333rem;
+  top: 0.08333rem;
+  right: 0.45833rem;
   font-family: "Moonstone Icons";
   content: "\0F0001";
   font-size: 2rem;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-expandable-picker-header.spotlight {
   color: #ffffff;
@@ -1458,7 +1458,7 @@ html {
   padding-right: 0;
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header:after {
-  left: 0.45833333rem;
+  left: 0.45833rem;
   right: auto;
 }
 /* Header Open */
@@ -1468,8 +1468,8 @@ html {
 /* Current Value */
 .moon-expandable-picker-current-value {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
   color: #4b4b4b;
   margin: 0rem;
 }
@@ -1497,8 +1497,8 @@ html {
 }
 .enyo-locale-non-latin .moon-expandable-picker-current-value {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 /* Help Text */
 .moon-expandable-picker-help-text {
@@ -1509,18 +1509,18 @@ html {
   -moz-box-sizing: border-box;
   color: #4b4b4b;
   height: 15rem;
-  border-top: 0.08333333rem solid #4b4b4b;
+  border-top: 0.08333rem solid #4b4b4b;
   border-bottom: 0.25rem solid #4b4b4b;
   position: relative;
   max-width: 100%;
-  padding: 0 0 0.41666667rem 0;
+  padding: 0 0 0.41667rem 0;
   background-color: transparent;
   background-repeat: no-repeat;
   background-position: top left;
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
 }
 .moon-header .moon-header-title-above {
-  margin-top: 0.20833333333333334rem;
+  margin-top: 0.20833rem;
   height: 1.2em;
   white-space: nowrap;
   overflow: hidden;
@@ -1531,22 +1531,22 @@ html {
 }
 .moon-header .moon-header-title {
   line-height: normal;
-  height: 6.458333333333333rem;
+  height: 6.45833rem;
 }
 .moon-header .moon-header-title .moon-marquee-text {
   white-space: nowrap;
 }
 .moon-header .moon-header-title-below,
 .moon-header .moon-header-sub-title-below {
-  height: 1.8333333333333333rem;
+  height: 1.83333rem;
 }
 .moon-header.full-bleed {
-  padding: 0 0.83333333rem 0.41666667rem 0.83333333rem;
+  padding: 0 0.83333rem 0.41667rem 0.83333rem;
   border: 0;
 }
 .moon-header.full-bleed .moon-header-client {
-  left: 0.83333333rem;
-  right: 0.83333333rem;
+  left: 0.83333rem;
+  right: 0.83333rem;
 }
 .moon-header .moon-hspacing > * {
   vertical-align: bottom;
@@ -1562,7 +1562,7 @@ html {
 }
 .moon-header.moon-medium-header .moon-header-title-below,
 .moon-header.moon-medium-header .moon-header-sub-title-below {
-  height: 1.6666666666666667rem;
+  height: 1.66667rem;
 }
 .moon-header.moon-small-header {
   height: 5rem;
@@ -1573,7 +1573,7 @@ html {
   display: none;
 }
 .moon-header.moon-small-header .moon-header-title {
-  padding: 1.0833333333333333rem 0 0 0;
+  padding: 1.08333rem 0 0 0;
   line-height: normal;
   font-size: 2.5rem;
   height: 3.5rem;
@@ -1583,7 +1583,7 @@ html {
 }
 .moon-header .moon-header-client {
   position: absolute;
-  bottom: 0.5833333333333334rem;
+  bottom: 0.58333rem;
   left: 0;
   right: 0;
   text-align: right;
@@ -1602,7 +1602,7 @@ html {
   line-height: 2.5rem;
 }
 .moon-neutral .moon-header {
-  border-top: 0.08333333rem solid #ffffff;
+  border-top: 0.08333rem solid #ffffff;
   border-bottom: 0.25rem solid #ffffff;
 }
 .enyo-locale-non-latin .moon-header .moon-header-title {
@@ -1639,7 +1639,7 @@ html {
 .moon-gridlist-imageitem {
   display: inline-block;
   overflow: hidden;
-  border: 0.20833333333333334rem solid transparent;
+  border: 0.20833rem solid transparent;
 }
 .moon-gridlist-imageitem .caption {
   font-family: "MuseoSans 700";
@@ -1648,9 +1648,9 @@ html {
 }
 .moon-gridlist-imageitem .sub-caption {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #4b4b4b;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
 }
 .moon-gridlist-imageitem .sub-caption a:link {
   color: #cf0652;
@@ -1669,11 +1669,11 @@ html {
   text-decoration: none;
 }
 .moon-gridlist-imageitem.selected {
-  border: 0.20833333rem solid #404040;
+  border: 0.20833rem solid #404040;
   background-color: #404040;
 }
 .moon-gridlist-imageitem.spotlight {
-  border: 0.20833333rem solid #cf0652;
+  border: 0.20833rem solid #cf0652;
   background-color: #cf0652;
 }
 .moon-gridlist-imageitem.selected .caption,
@@ -1684,7 +1684,7 @@ html {
 }
 .moon-gridlist-imageitem.sized-image.use-caption,
 .moon-gridlist-imageitem.sized-image.use-subcaption {
-  padding-bottom: 1.6666666666666667rem;
+  padding-bottom: 1.66667rem;
 }
 .moon-gridlist-imageitem.sized-image > .caption,
 .moon-gridlist-imageitem.sized-image > .sub-caption {
@@ -1692,11 +1692,11 @@ html {
   bottom: 0;
 }
 .moon-gridlist-imageitem.sized-image.use-caption.use-subcaption {
-  padding-bottom: 3.3333333333333335rem;
+  padding-bottom: 3.33333rem;
 }
 .moon-gridlist-imageitem.sized-image.use-caption.use-subcaption > .caption {
   position: absolute;
-  bottom: 1.4583333333333333rem;
+  bottom: 1.45833rem;
 }
 .enyo-locale-non-latin .moon-gridlist-imageitem .caption {
   font-family: "Moonstone LG Display Bold";
@@ -1704,8 +1704,8 @@ html {
 }
 .enyo-locale-non-latin .moon-gridlist-imageitem .sub-caption {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 /* Scroller Page Controls */
 .moon-icon-button.moon-paging-button {
@@ -1742,7 +1742,7 @@ html {
 }
 .moon-scroll-picker {
   direction: ltr;
-  height: 3.91666667rem;
+  height: 3.91667rem;
   border-top: solid 1.25rem transparent;
   border-bottom: solid 1.25rem transparent;
   border-radius: 1.875rem;
@@ -1754,16 +1754,16 @@ html {
 }
 .moon-scroll-picker-item {
   white-space: nowrap;
-  padding: 0 0.20833333rem 0.08333333rem 0.20833333rem;
-  min-width: 2.0833333333333335rem;
-  height: 3.91666667rem;
-  line-height: 3.91666667rem;
+  padding: 0 0.20833rem 0.08333rem 0.20833rem;
+  min-width: 2.08333rem;
+  height: 3.91667rem;
+  line-height: 3.91667rem;
   text-align: center;
   background: transparent;
 }
 .moon-scroll-picker-buffer {
   white-space: nowrap;
-  padding: 0 0.20833333rem 0.08333333rem 0.20833333rem;
+  padding: 0 0.20833rem 0.08333rem 0.20833rem;
   height: 0;
   opacity: 0;
 }
@@ -1779,16 +1779,16 @@ html {
 }
 .moon-scroll-picker-overlay-container.next:after {
   content: "\0F0005";
-  font-size: 2.83333333rem;
-  line-height: 1.58333333rem;
+  font-size: 2.83333rem;
+  line-height: 1.58333rem;
 }
 .moon-scroll-picker-overlay-container.previous {
   bottom: 0;
 }
 .moon-scroll-picker-overlay-container.previous:after {
   content: "\0F0006";
-  font-size: 2.83333333rem;
-  line-height: 1.08333333rem;
+  font-size: 2.83333rem;
+  line-height: 1.08333rem;
 }
 .spotlight .moon-scroll-picker-overlay-container {
   color: #ffffff;
@@ -1799,11 +1799,11 @@ html {
 }
 .spotlight .moon-scroll-picker-overlay-container.previous:after {
   content: "\0F0001";
-  line-height: 0.91666667rem;
+  line-height: 0.91667rem;
 }
 .selected .moon-scroll-picker-overlay {
   position: absolute;
-  height: 1.45833333rem;
+  height: 1.45833rem;
   width: 100%;
   background-color: #cf0652;
 }
@@ -1817,7 +1817,7 @@ html {
 }
 .selected .moon-scroll-picker-overlay.next:after {
   content: "\0F0005";
-  font-size: 2.83333333rem;
+  font-size: 2.83333rem;
   line-height: 1.25rem;
 }
 .selected .moon-scroll-picker-overlay.previous {
@@ -1830,7 +1830,7 @@ html {
 }
 .selected .moon-scroll-picker-overlay.previous:after {
   content: "\0F0006";
-  font-size: 2.83333333rem;
+  font-size: 2.83333rem;
   line-height: 1.75rem;
 }
 .moon-scroll-picker-taparea {
@@ -1842,9 +1842,9 @@ html {
 }
 /* DatePicker.css */
 .moon-date-picker-wrap {
-  min-width: 4.166666666666667rem;
+  min-width: 4.16667rem;
   text-align: center;
-  margin: 0.4166666666666667rem 0;
+  margin: 0.41667rem 0;
   vertical-align: top;
 }
 .moon-date-picker-wrap.year {
@@ -1852,7 +1852,7 @@ html {
 }
 .moon-date-picker-label {
   text-align: center;
-  padding: 0.83333333rem 0.41666667rem;
+  padding: 0.83333rem 0.41667rem;
   white-space: nowrap;
 }
 .moon-date-picker-client {
@@ -1921,8 +1921,8 @@ html {
 /* InputDecorator.css */
 .moon-input-decorator:not(.moon-input-header-input-decorator),
 .moon-textarea-decorator {
-  margin: 0.20833333333333334rem;
-  border: 0.20833333rem solid transparent;
+  margin: 0.20833rem;
+  border: 0.20833rem solid transparent;
   background-color: #ffffff;
   box-sizing: border-box;
 }
@@ -1938,7 +1938,7 @@ html {
 .moon-textarea-decorator .moon-icon.small,
 .moon-input-decorator:not(.moon-input-header-input-decorator) .spotlight .moon-icon.small,
 .moon-textarea-decorator .spotlight .moon-icon.small {
-  width: 0.8333333333333334rem;
+  width: 0.83333rem;
   margin: 0;
   color: #4b4b4b;
 }
@@ -1948,17 +1948,17 @@ html {
 }
 .moon-input-decorator:not(.moon-input-header-input-decorator) {
   padding: 0.375rem 1.25rem;
-  border-radius: 1.4166666666666667rem;
+  border-radius: 1.41667rem;
 }
 .moon-textarea-decorator {
-  padding: 0.375rem 0.5833333333333334rem;
-  border-radius: 0.4166666666666667rem;
+  padding: 0.375rem 0.58333rem;
+  border-radius: 0.41667rem;
 }
 .moon-expandable-input .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  margin: 0.20833333333333334rem 0;
+  margin: 0.20833rem 0;
 }
 .enyo-locale-non-latin .moon-input-decorator:not(.moon-input-header-input-decorator) {
-  padding: 0.20833333333333334rem 1.25rem 0.375rem;
+  padding: 0.20833rem 1.25rem 0.375rem;
 }
 .enyo-locale-non-latin.enyo-locale-th .moon-input-decorator:not(.moon-input-header-input-decorator),
 .enyo-locale-non-latin.enyo-locale-ar .moon-input-decorator:not(.moon-input-header-input-decorator),
@@ -1979,10 +1979,10 @@ html {
 /* ProgressBar.css */
 .moon-progress-bar {
   position: relative;
-  margin: 2.0833333333333335rem 0.8333333333333334rem;
-  height: 0.4166666666666667rem;
+  margin: 2.08333rem 0.83333rem;
+  height: 0.41667rem;
   background-color: #323232;
-  min-width: 5.333333333333333rem;
+  min-width: 5.33333rem;
   direction: ltr;
 }
 .moon-progress-bg-bar,
@@ -2001,14 +2001,14 @@ html {
 .moon-progress-button {
   position: relative;
   overflow: hidden;
-  border: 0.20833333rem solid transparent;
+  border: 0.20833rem solid transparent;
   transform: translateZ(0);
   -webkit-transform: translateZ(0);
 }
 .moon-progress-button.in-progress:active:hover:not([disabled]),
 .moon-progress-button.in-progress {
   color: #ffffff;
-  padding: 0.20833333rem 1.125rem;
+  padding: 0.20833rem 1.125rem;
   border-width: 0;
 }
 .moon-progress-button.completed .moon-progress-button-bar {
@@ -2052,7 +2052,7 @@ html {
 }
 .moon-slider.spotlight > .moon-slider-knob.spotselect {
   background-color: #ffffff;
-  border: 0.20833333rem solid #cf0652;
+  border: 0.20833rem solid #cf0652;
 }
 .moon-slider.disabled {
   cursor: default;
@@ -2066,24 +2066,24 @@ html {
   border-radius: 2.5rem;
   margin: -1.25rem;
   background-color: #ffffff;
-  top: 0.20833333rem;
-  border: solid 0.20833333rem transparent;
+  top: 0.20833rem;
+  border: solid 0.20833rem transparent;
   box-sizing: border-box;
 }
 .moon-slider-knob:not(.spotselect).active,
 .moon-slider-knob:not(.spotselect).spotselect,
 .moon-slider-knob:not(.spotselect):active:not(.disabled) {
-  width: 3.58333333rem;
-  height: 3.58333333rem;
-  border-radius: 1.79166667rem;
-  margin: -1.79166667rem;
-  border: solid 0.20833333rem transparent;
+  width: 3.58333rem;
+  height: 3.58333rem;
+  border-radius: 1.79167rem;
+  margin: -1.79167rem;
+  border: solid 0.20833rem transparent;
   box-sizing: border-box;
 }
 .moon-slider-taparea {
   position: absolute;
-  top: -0.58333333rem;
-  height: 1.33333333rem;
+  top: -0.58333rem;
+  height: 1.33333rem;
   width: 100%;
 }
 /* Slider Popup */
@@ -2133,20 +2133,20 @@ html {
 }
 /* ContextualPopupButton.css */
 .moon-button.contextual-popup-button {
-  padding-right: 2.08333333rem;
+  padding-right: 2.08333rem;
   position: relative;
 }
 .moon-button.contextual-popup-button:after {
   position: absolute;
-  right: 0.41666667rem;
+  right: 0.41667rem;
   font-family: "Moonstone Icons";
   content: "\0F0008";
-  font-size: 2.41666667rem;
+  font-size: 2.41667rem;
   line-height: 3.125rem;
   color: #cf0652;
 }
 .moon-button.contextual-popup-button.small:after {
-  line-height: 2.08333333rem;
+  line-height: 2.08333rem;
 }
 .moon-button.contextual-popup-button.spotlight {
   color: #ffffff;
@@ -2169,16 +2169,16 @@ html {
   color: #b3b3b3;
 }
 .enyo-locale-right-to-left .moon-button.contextual-popup-button {
-  padding-left: 2.08333333rem;
-  padding-right: 0.91666667rem;
+  padding-left: 2.08333rem;
+  padding-right: 0.91667rem;
 }
 .enyo-locale-right-to-left .moon-button.contextual-popup-button:after {
-  left: 0.41666667rem;
+  left: 0.41667rem;
   right: auto;
   content: "\0F0007";
 }
 .enyo-locale-right-to-left .moon-button.contextual-popup-button.small {
-  padding-right: 0.83333333rem;
+  padding-right: 0.83333rem;
 }
 /* ContextualPopupDecorator.css */
 .moon-contextual-popup-decorator {
@@ -2190,12 +2190,12 @@ html {
 }
 /* ContextualPopup */
 .moon-contextual-popup {
-  min-height: 4.166666666666667rem;
-  min-width: 4.166666666666667rem;
-  border-radius: 0.66666667rem;
-  border: 0.20833333rem solid rgba(0, 0, 0, 0.5);
+  min-height: 4.16667rem;
+  min-width: 4.16667rem;
+  border-radius: 0.66667rem;
+  border: 0.20833rem solid rgba(0, 0, 0, 0.5);
   color: #ffffff;
-  padding: 0.83333333rem;
+  padding: 0.83333rem;
   background-clip: padding-box;
   -webkit-background-clip: padding-box;
   -moz-background-clip: padding-box;
@@ -2205,7 +2205,7 @@ html {
   background-color: #686868;
 }
 .moon-contextual-popup.reserve-close {
-  padding-right: 2.91666667rem;
+  padding-right: 2.91667rem;
 }
 .moon-contextual-popup:before,
 .moon-contextual-popup:after {
@@ -2227,12 +2227,12 @@ html {
 }
 .moon-contextual-popup.high:before,
 .moon-contextual-popup.high:after {
-  top: 1.77083333rem;
+  top: 1.77083rem;
 }
 .moon-contextual-popup.low:before,
 .moon-contextual-popup.low:after {
   top: auto;
-  bottom: 1.77083333rem;
+  bottom: 1.77083rem;
 }
 .moon-contextual-popup.left:before,
 .moon-contextual-popup.right:before {
@@ -2252,38 +2252,38 @@ html {
   height: 0;
 }
 .moon-contextual-popup.left {
-  margin: 0 0 0 1.45833333rem;
+  margin: 0 0 0 1.45833rem;
 }
 .moon-contextual-popup.left:before,
 .moon-contextual-popup.left:after {
   left: 0;
 }
 .moon-contextual-popup.left:before {
-  margin: -0.79166667rem auto auto -1rem;
-  border-top: 0.66666667rem solid transparent;
-  border-bottom: 0.66666667rem solid transparent;
-  border-right: 0.79166667rem solid rgba(0, 0, 0, 0.5);
+  margin: -0.79167rem auto auto -1rem;
+  border-top: 0.66667rem solid transparent;
+  border-bottom: 0.66667rem solid transparent;
+  border-right: 0.79167rem solid rgba(0, 0, 0, 0.5);
 }
 .moon-contextual-popup.left:after {
-  margin: -0.66666667rem auto auto -0.79166667rem;
-  border-top: 0.66666667rem solid transparent;
-  border-bottom: 0.66666667rem solid transparent;
-  border-right: 0.79166667rem solid #686868;
+  margin: -0.66667rem auto auto -0.79167rem;
+  border-top: 0.66667rem solid transparent;
+  border-bottom: 0.66667rem solid transparent;
+  border-right: 0.79167rem solid #686868;
 }
 .moon-contextual-popup.left.high:before {
-  margin: -1.04166667rem auto auto -1rem;
+  margin: -1.04167rem auto auto -1rem;
 }
 .moon-contextual-popup.left.high:after {
-  margin: -0.91666667rem auto auto -0.79166667rem;
+  margin: -0.91667rem auto auto -0.79167rem;
 }
 .moon-contextual-popup.left.low:before {
-  margin: auto auto -1.04166667rem -1rem;
+  margin: auto auto -1.04167rem -1rem;
 }
 .moon-contextual-popup.left.low:after {
-  margin: auto auto -0.91666667rem -0.79166667rem;
+  margin: auto auto -0.91667rem -0.79167rem;
 }
 .moon-contextual-popup.right {
-  margin: 0 0 0 -1.45833333rem;
+  margin: 0 0 0 -1.45833rem;
 }
 .moon-contextual-popup.right:before,
 .moon-contextual-popup.right:after {
@@ -2291,28 +2291,28 @@ html {
   right: auto;
 }
 .moon-contextual-popup.right:before {
-  margin: -0.79166667rem auto auto 0.20833333rem;
-  border-top: 0.66666667rem solid transparent;
-  border-bottom: 0.66666667rem solid transparent;
-  border-left: 0.79166667rem solid rgba(0, 0, 0, 0.5);
+  margin: -0.79167rem auto auto 0.20833rem;
+  border-top: 0.66667rem solid transparent;
+  border-bottom: 0.66667rem solid transparent;
+  border-left: 0.79167rem solid rgba(0, 0, 0, 0.5);
 }
 .moon-contextual-popup.right:after {
-  margin: -0.66666667rem auto auto 0;
-  border-top: 0.66666667rem solid transparent;
-  border-bottom: 0.66666667rem solid transparent;
-  border-left: 0.79166667rem solid #686868;
+  margin: -0.66667rem auto auto 0;
+  border-top: 0.66667rem solid transparent;
+  border-bottom: 0.66667rem solid transparent;
+  border-left: 0.79167rem solid #686868;
 }
 .moon-contextual-popup.right.high:before {
-  margin: -1.04166667rem auto auto 0.20833333rem;
+  margin: -1.04167rem auto auto 0.20833rem;
 }
 .moon-contextual-popup.right.high:after {
-  margin: -0.91666667rem auto auto 0;
+  margin: -0.91667rem auto auto 0;
 }
 .moon-contextual-popup.right.low:before {
-  margin: auto auto -1.04166667rem 0.20833333rem;
+  margin: auto auto -1.04167rem 0.20833rem;
 }
 .moon-contextual-popup.right.low:after {
-  margin: auto auto -0.91666667rem 0;
+  margin: auto auto -0.91667rem 0;
 }
 .moon-contextual-popup.below.right:before,
 .moon-contextual-popup.above.right:before,
@@ -2328,73 +2328,73 @@ html {
   right: 10%;
 }
 .moon-contextual-popup.below {
-  margin: 1.45833333rem 0 0 0;
+  margin: 1.45833rem 0 0 0;
 }
 .moon-contextual-popup.below:before,
 .moon-contextual-popup.below:after {
   top: 0;
 }
 .moon-contextual-popup.below:before {
-  margin: -1rem auto auto -0.79166667rem;
-  border-right: 0.66666667rem solid transparent;
-  border-left: 0.66666667rem solid transparent;
-  border-bottom: 0.79166667rem solid rgba(0, 0, 0, 0.5);
+  margin: -1rem auto auto -0.79167rem;
+  border-right: 0.66667rem solid transparent;
+  border-left: 0.66667rem solid transparent;
+  border-bottom: 0.79167rem solid rgba(0, 0, 0, 0.5);
 }
 .moon-contextual-popup.below:after {
-  margin: -0.79166667rem auto auto -0.66666667rem;
-  border-right: 0.66666667rem solid transparent;
-  border-left: 0.66666667rem solid transparent;
-  border-bottom: 0.79166667rem solid #686868;
+  margin: -0.79167rem auto auto -0.66667rem;
+  border-right: 0.66667rem solid transparent;
+  border-left: 0.66667rem solid transparent;
+  border-bottom: 0.79167rem solid #686868;
 }
 .moon-contextual-popup.below.right:before {
-  margin: -1.66666667rem auto auto -0.79166667rem;
+  margin: -1.66667rem auto auto -0.79167rem;
 }
 .moon-contextual-popup.below.right:after {
-  margin: -1.45833333rem auto auto -0.66666667rem;
+  margin: -1.45833rem auto auto -0.66667rem;
 }
 .moon-contextual-popup.below.left:before {
-  margin: -1.66666667rem -0.79166667rem auto auto;
+  margin: -1.66667rem -0.79167rem auto auto;
 }
 .moon-contextual-popup.below.left:after {
-  margin: -1.45833333rem -0.66666667rem auto auto;
+  margin: -1.45833rem -0.66667rem auto auto;
 }
 .moon-contextual-popup.above {
-  margin: -1.45833333rem 0 0 0;
+  margin: -1.45833rem 0 0 0;
 }
 .moon-contextual-popup.above:before,
 .moon-contextual-popup.above:after {
   top: 100%;
 }
 .moon-contextual-popup.above:before {
-  margin: 0.20833333rem auto auto -0.79166667rem;
-  border-right: 0.66666667rem solid transparent;
-  border-left: 0.66666667rem solid transparent;
-  border-top: 0.79166667rem solid rgba(0, 0, 0, 0.5);
+  margin: 0.20833rem auto auto -0.79167rem;
+  border-right: 0.66667rem solid transparent;
+  border-left: 0.66667rem solid transparent;
+  border-top: 0.79167rem solid rgba(0, 0, 0, 0.5);
 }
 .moon-contextual-popup.above:after {
-  margin: 0 auto auto -0.66666667rem;
-  border-right: 0.66666667rem solid transparent;
-  border-left: 0.66666667rem solid transparent;
-  border-top: 0.79166667rem solid #686868;
+  margin: 0 auto auto -0.66667rem;
+  border-right: 0.66667rem solid transparent;
+  border-left: 0.66667rem solid transparent;
+  border-top: 0.79167rem solid #686868;
 }
 .moon-contextual-popup.above.right:before {
-  margin: 0.20833333rem auto auto -0.79166667rem;
+  margin: 0.20833rem auto auto -0.79167rem;
 }
 .moon-contextual-popup.above.right:after {
-  margin: 0 auto auto -0.66666667rem;
+  margin: 0 auto auto -0.66667rem;
 }
 .moon-contextual-popup.above.left:before {
-  margin: 0.20833333rem -0.79166667rem auto auto;
+  margin: 0.20833rem -0.79167rem auto auto;
 }
 .moon-contextual-popup.above.left:after {
-  margin: 0 -0.66666667rem auto auto;
+  margin: 0 -0.66667rem auto auto;
 }
 .enyo-locale-right-to-left .moon-contextual-popup {
   direction: rtl;
 }
 .enyo-locale-right-to-left .moon-contextual-popup.reserve-close {
-  padding-right: 0.8333333333333334rem;
-  padding-left: 2.91666667rem;
+  padding-right: 0.83333rem;
+  padding-left: 2.91667rem;
 }
 .moon-contextual-popup-client {
   height: 100%;
@@ -2420,16 +2420,16 @@ html {
 }
 .moon-textarea::-webkit-scrollbar,
 .moon-richtext::-webkit-scrollbar {
-  width: 0.16666666666666666rem;
+  width: 0.16667rem;
 }
 .moon-textarea::-webkit-scrollbar-track-piece,
 .moon-richtext::-webkit-scrollbar-track-piece {
-  border-radius: 0.4166666666666667rem;
+  border-radius: 0.41667rem;
 }
 .moon-textarea::-webkit-scrollbar-thumb:vertical,
 .moon-richtext::-webkit-scrollbar-thumb:vertical {
   background-color: #a6a6a6;
-  border-radius: 0.4166666666666667rem;
+  border-radius: 0.41667rem;
 }
 .moon-textarea-decorator.moon-focused .moon-textarea,
 .moon-textarea-decorator .moon-focused .moon-richtext {
@@ -2459,30 +2459,30 @@ html {
   right: 0;
 }
 .moon-header .list-actions-drawer {
-  top: -0.08333333rem;
+  top: -0.08333rem;
   bottom: -0.25rem;
 }
 /* Close button */
 .moon-icon-button.moon-list-actions-close {
   position: absolute;
-  right: 0.4166666666666667rem;
-  top: 0.4166666666666667rem;
+  right: 0.41667rem;
+  top: 0.41667rem;
   z-index: 2;
 }
 .enyo-locale-right-to-left .moon-icon-button.moon-list-actions-close {
   right: auto;
-  left: 0.4166666666666667rem;
+  left: 0.41667rem;
 }
 /* Scroller */
 .moon-list-actions-scroller {
-  margin: 0.8333333333333334rem;
-  margin-right: 3.33333333rem;
+  margin: 0.83333rem;
+  margin-right: 3.33333rem;
   padding: 0rem;
   z-index: 1;
 }
 .enyo-locale-right-to-left .moon-list-actions-scroller {
-  margin-right: 0.4166666666666667rem;
-  margin-left: 3.33333333rem;
+  margin-right: 0.41667rem;
+  margin-left: 3.33333rem;
 }
 /* Action menu */
 .moon-list-actions-menu {
@@ -2502,7 +2502,7 @@ html {
   width: 100% !important;
 }
 .moon-list-actions-drawer.stacked .moon-list-actions-menu {
-  margin-bottom: 0.8333333333333334rem;
+  margin-bottom: 0.83333rem;
   clear: both;
 }
 .moon-list-actions-menu .enyo-scroller {
@@ -2549,7 +2549,7 @@ html {
 /* Labeled Text Item */
 .moon-labeledtextitem {
   min-width: 14rem;
-  height: 8.083333333333334rem;
+  height: 8.08333rem;
   overflow: hidden;
   margin: 0rem;
 }
@@ -2558,7 +2558,7 @@ html {
   font-family: "MuseoSans 700";
   font-size: 1.25rem;
   color: #4b4b4b;
-  border-top: 0.08333333rem solid #4b4b4b;
+  border-top: 0.08333rem solid #4b4b4b;
   margin: 0rem 0rem 0.125rem 0rem;
   padding: 0.25rem 0rem 0rem 0rem;
 }
@@ -2574,9 +2574,9 @@ html {
 /* Text */
 .moon-labeledtextitem .text {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #4b4b4b;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
   text-transform: none;
   margin: 0rem;
   padding: 0rem;
@@ -2599,8 +2599,8 @@ html {
 }
 .enyo-locale-non-latin .moon-labeledtextitem .text {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
 }
 .spotlight.moon-labeledtextitem .text,
 .spotlight .moon-labeledtextitem .text {
@@ -2612,24 +2612,24 @@ html {
 .moon-imageitem {
   display: block;
   clear: both;
-  min-width: 22.333333333333332rem;
+  min-width: 22.33333rem;
   margin-top: 0rem;
   padding-top: 0rem;
   height: 8.5rem;
   overflow: hidden;
 }
 .moon-imageitem img {
-  width: 5.666666666666667rem;
-  height: 8.083333333333334rem;
+  width: 5.66667rem;
+  height: 8.08333rem;
   padding: 0rem;
-  margin: 0.4166666666666667rem 2.6666666666666665rem 0.4166666666666667rem 0rem;
+  margin: 0.41667rem 2.66667rem 0.41667rem 0rem;
   display: inline-block;
   float: left;
 }
 .moon-imageitem.align-right img {
   float: right;
   margin-right: 0rem;
-  margin-left: 2.6666666666666665rem;
+  margin-left: 2.66667rem;
 }
 /* Spinner.css */
 @-webkit-keyframes spinBall {
@@ -2757,15 +2757,15 @@ html {
   }
 }
 .moon-spinner {
-  min-height: 3.04166667rem;
-  min-width: 3.04166667rem;
-  line-height: 3.04166667rem;
+  min-height: 3.04167rem;
+  min-width: 3.04167rem;
+  line-height: 3.04167rem;
   position: relative;
   display: inline-block;
   color: #ffffff;
   background-color: #4d4d4d;
-  border-radius: 1.77083333rem;
-  margin: 0 0.41666667rem;
+  border-radius: 1.77083rem;
+  margin: 0 0.41667rem;
 }
 .moon-spinner > * {
   display: inline-block;
@@ -2789,15 +2789,15 @@ html {
   padding: 0.25rem;
 }
 .moon-spinner.content .moon-spinner-client {
-  max-width: 16.666666666666668rem;
+  max-width: 16.66667rem;
 }
 .moon-spinner.running .moon-spinner-ball {
   -webkit-animation-play-state: running;
 }
 .moon-spinner .moon-spinner-ball-decorator {
   position: relative;
-  width: 3.04166667rem;
-  height: 3.04166667rem;
+  width: 3.04167rem;
+  height: 3.04167rem;
   float: left;
 }
 .moon-spinner .moon-spinner-ball {
@@ -2834,7 +2834,7 @@ html {
 }
 .moon-spinner .moon-spinner-client {
   float: left;
-  line-height: 3.04166667rem;
+  line-height: 3.04167rem;
   margin: 0 2.6ex 0 0;
 }
 .enyo-locale-right-to-left .moon-spinner .moon-spinner-ball-decorator {
@@ -2858,7 +2858,7 @@ html {
 .moon-panel {
   overflow: hidden;
   padding: 0;
-  padding: 0.8333333333333334rem 0.4166666666666667rem;
+  padding: 0.83333rem 0.41667rem;
   height: 100%;
 }
 .moon-panel.enyo-fit {
@@ -2885,13 +2885,13 @@ html {
 .moon-panel-body {
   overflow: hidden;
   position: relative;
-  padding-top: 0.4166666666666667rem;
+  padding-top: 0.41667rem;
   z-index: 1;
 }
 /* Breadcrumb */
 .moon-panel-breadcrumb {
-  width: 9.58333333rem;
-  height: 15.41666667rem;
+  width: 9.58333rem;
+  height: 15.41667rem;
   position: absolute;
   top: 0rem;
   left: 0rem;
@@ -2905,17 +2905,17 @@ html {
   overflow: hidden;
 }
 .moon-panel-small-header-wrapper {
-  margin: 0.41666667rem 0 0 0;
+  margin: 0.41667rem 0 0 0;
   position: absolute;
-  bottom: 0.4166666666666667rem;
+  bottom: 0.41667rem;
   left: 0;
   height: 15rem;
   width: 100%;
-  padding: 0 0.41666667rem 0.41666667rem 0.41666667rem;
+  padding: 0 0.41667rem 0.41667rem 0.41667rem;
   box-sizing: border-box;
 }
 .moon-panel-small-header {
-  margin-top: 1.0416666666666667rem;
+  margin-top: 1.04167rem;
   color: #4b4b4b;
   display: block;
   overflow: hidden;
@@ -2926,8 +2926,8 @@ html {
 }
 .moon-panel-small-header-title-above {
   color: #4b4b4b;
-  border-top: 0.08333333rem solid #ffffff;
-  padding-top: 0.20833333333333334rem;
+  border-top: 0.08333rem solid #ffffff;
+  padding-top: 0.20833rem;
 }
 .spotlight .moon-panel-small-header-title-above {
   color: #ffffff;
@@ -2937,14 +2937,14 @@ html {
   color: #ffffff;
 }
 .moon-panel .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header-title-above {
-  border-top: 0.08333333333333333rem solid transparent;
+  border-top: 0.08333rem solid transparent;
 }
 /* Activity Panels Overrides */
 .moon-panels.activity .moon-panel {
   padding: 0;
 }
 .moon-panels.activity .moon-panel-small-header-title-above {
-  border-top: 0.08333333rem solid #4b4b4b;
+  border-top: 0.08333rem solid #4b4b4b;
 }
 .moon-panels.activity .moon-panel-small-header,
 .moon-panels.activity .moon-panel-small-header-title-above {
@@ -3064,7 +3064,7 @@ html {
   width: 100%;
   height: 100%;
   box-sizing: border-box;
-  padding: 0.8333333333333334rem 0.4166666666666667rem;
+  padding: 0.83333rem 0.41667rem;
   overflow: visible;
   pointer-events: none;
 }
@@ -3113,10 +3113,10 @@ html {
 }
 .moon-panels.activity .moon-panels-panel-scrim .moon-panels-branding {
   position: absolute;
-  top: 15.83333333rem;
+  top: 15.83333rem;
   width: 8.75rem;
-  bottom: 0.8333333333333334rem;
-  left: 0.8333333333333334rem;
+  bottom: 0.83333rem;
+  left: 0.83333rem;
   background-position: bottom center;
 }
 .moon-panels.always-viewing .moon-panels-panel-scrim {
@@ -3129,9 +3129,9 @@ html {
   position: absolute;
   top: 0;
   left: auto;
-  right: -5.41666667rem;
+  right: -5.41667rem;
   height: 100%;
-  width: 5.41666667rem;
+  width: 5.41667rem;
   z-index: 100;
 }
 .moon-panels-handle:before {
@@ -3140,8 +3140,8 @@ html {
   height: 100%;
   width: 100%;
   line-height: 100vh;
-  margin-left: -0.41666667rem;
-  margin-right: 0.4166666666666667rem;
+  margin-left: -0.41667rem;
+  margin-right: 0.41667rem;
   background-color: #4b4b4b;
   font-family: "Moonstone Icons";
   font-size: 6rem;
@@ -3181,17 +3181,17 @@ html {
 .moon-calendar-picker {
   display: inline-block;
   text-align: center;
-  width: 25.66666667rem;
+  width: 25.66667rem;
   background-color: #686868;
-  border-radius: 0.66666667rem;
-  margin: 0 0.8333333333333334rem;
-  padding: 0.8333333333333334rem 0;
+  border-radius: 0.66667rem;
+  margin: 0 0.83333rem;
+  padding: 0.83333rem 0;
 }
 .moon-calendar-picker > * {
   display: inline-block;
 }
 .moon-calendar-picker .moon-simple-picker {
-  max-width: 10.416666666666666rem;
+  max-width: 10.41667rem;
 }
 .moon-calendar-picker .moon-simple-picker .moon-simple-picker-client > * {
   color: #ffffff;
@@ -3216,12 +3216,12 @@ html {
   display: inline-block;
 }
 .moon-calendar-picker .moon-calendar-picker-day.small {
-  font-size: 0.91666667rem;
+  font-size: 0.91667rem;
 }
 .moon-calendar-picker .moon-neutral .moon-calendar-picker-day-base {
   width: 2.5rem;
   color: #a2a2a2;
-  margin: 0.4166666666666667rem;
+  margin: 0.41667rem;
   border-color: #a2a2a2;
   display: inline-block;
 }
@@ -3240,13 +3240,13 @@ html {
   width: 2.5rem;
   line-height: 2.5rem;
   border-radius: 416.625rem;
-  border: solid 0.4166666666666667rem transparent;
+  border: solid 0.41667rem transparent;
   display: inline-block;
 }
 .moon-calendar-picker-date.spotlight,
 .moon-calendar-picker-date.active {
   background-color: #cf0652;
-  border: solid 0.41666667rem #686868;
+  border: solid 0.41667rem #686868;
 }
 .moon-calendar-picker-date.moon-calendar-picker-date-shadow {
   color: #a2a2a2;
@@ -3268,7 +3268,7 @@ html {
   color: #ffffff;
 }
 .moon-table-row .moon-table-cell {
-  padding: 0.41666667rem;
+  padding: 0.41667rem;
   white-space: nowrap;
 }
 .moon-input-header-input-decorator {
@@ -3324,10 +3324,10 @@ html {
   color: #b1b1b1;
 }
 .moon-drawer-partial-client {
-  padding: 1.6666666666666667rem 0.8333333333333334rem 0.8333333333333334rem;
+  padding: 1.66667rem 0.83333rem 0.83333rem;
 }
 .moon-drawer-client {
-  padding: 0.8333333333333334rem;
+  padding: 0.83333rem;
 }
 /* Drawers.css */
 .moon-drawers {
@@ -3336,8 +3336,8 @@ html {
 .moon-drawers-activator {
   z-index: 100;
   font-family: "Moonstone Icons";
-  font-size: 1.7916666666666667rem;
-  line-height: 1.33333333rem;
+  font-size: 1.79167rem;
+  line-height: 1.33333rem;
   height: 0rem;
   position: absolute;
   width: 100%;
@@ -3347,7 +3347,7 @@ html {
 .moon-drawers-activator:before {
   content: '';
   display: block;
-  height: 0.91666667rem;
+  height: 0.91667rem;
   background-color: #4b4b4b;
 }
 .moon-drawers-activator .moon-drawers-activator-icon {
@@ -3385,12 +3385,12 @@ html {
 }
 .moon-drawers-handle-container .moon-drawers-handles {
   text-align: center;
-  padding: 2.0833333333333335rem 0 0.4166666666666667rem;
+  padding: 2.08333rem 0 0.41667rem;
 }
 .moon-drawers-handle-container .moon-drawers-handle {
   display: inline-block;
   text-align: start;
-  width: 10.416666666666666rem;
+  width: 10.41667rem;
 }
 .moon-drawers-container {
   position: relative;
@@ -3438,7 +3438,7 @@ html {
   position: absolute;
   bottom: 0;
   width: 100%;
-  padding: 1.66666667rem;
+  padding: 1.66667rem;
   box-sizing: border-box;
   overflow: hidden;
   -webkit-transform: translateY(100%) translateZ(0);
@@ -3455,12 +3455,12 @@ html {
   transform: translateY(0) translateZ(0);
 }
 .moon-popup.reserve-close {
-  padding-right: 2.91666667rem;
+  padding-right: 2.91667rem;
 }
 .moon-popup-close {
   position: absolute;
-  right: 0.41666667rem;
-  top: 0.41666667rem;
+  right: 0.41667rem;
+  top: 0.41667rem;
   margin: 0;
   background-color: transparent;
   background-repeat: no-repeat;
@@ -3473,19 +3473,19 @@ html {
   color: #ffffff;
 }
 .enyo-locale-right-to-left .moon-popup.reserve-close {
-  padding-right: 1.66666667rem;
-  padding-left: 2.91666667rem;
+  padding-right: 1.66667rem;
+  padding-left: 2.91667rem;
 }
 .enyo-locale-right-to-left .moon-popup-close {
   right: auto;
-  left: 0.41666667rem;
+  left: 0.41667rem;
 }
 /* Dialog.css */
 .moon-dialog {
-  padding: 1rem 1.6666666666666667rem 1.6666666666666667rem;
+  padding: 1rem 1.66667rem 1.66667rem;
 }
 .moon-dialog-title {
-  margin-bottom: 0.4166666666666667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-dialog-sub-title {
   font-size: 1rem;
@@ -3495,18 +3495,18 @@ html {
 }
 .moon-dialog-divider {
   padding-bottom: 0;
-  border-bottom-width: 0.08333333333333333rem;
-  margin: 0.8333333333333334rem 0 0.8333333333333334rem;
+  border-bottom-width: 0.08333rem;
+  margin: 0.83333rem 0 0.83333rem;
 }
 .moon-dialog-client {
   padding: 1.5rem 0 0;
 }
 .moon-dialog-client > * {
-  margin-left: 0.83333333rem;
+  margin-left: 0.83333rem;
 }
 .moon-tooltip {
   z-index: 20;
-  height: 2.83333333rem;
+  height: 2.83333rem;
   -webkit-transform: translateZ(0);
   transform: translateZ(0);
   pointer-events: none;
@@ -3515,8 +3515,8 @@ html {
   font-family: "Moonstone Miso Bold";
   font-size: 1.125rem;
   -webkit-font-kerning: normal;
-  height: 2.45833333rem;
-  line-height: 2.45833333rem;
+  height: 2.45833rem;
+  line-height: 2.45833rem;
   white-space: nowrap;
   color: #ffffff;
   text-align: center;
@@ -3542,46 +3542,46 @@ html {
 }
 /* .above .left-arrow nub shape */
 .moon-tooltip.above.left-arrow .moon-tooltip-label {
-  border-radius: 1.41666667rem 1.41666667rem 1.41666667rem 0rem;
+  border-radius: 1.41667rem 1.41667rem 1.41667rem 0rem;
 }
 .moon-tooltip.above.left-arrow .moon-tooltip-label:before {
-  top: 1.2083333333333333rem;
-  left: -0.08333333rem;
-  border-top: 1.20833333rem solid #4d4d4d;
-  clip: rect(1.25rem, 1rem, 1.58333333rem, 0.08333333rem);
+  top: 1.20833rem;
+  left: -0.08333rem;
+  border-top: 1.20833rem solid #4d4d4d;
+  clip: rect(1.25rem, 1rem, 1.58333rem, 0.08333rem);
   border-radius: 416.625rem;
 }
 /* .above .right-arrow nub shape */
 .moon-tooltip.above.right-arrow .moon-tooltip-label {
-  border-radius: 1.41666667rem 1.41666667rem 0rem 1.41666667rem;
+  border-radius: 1.41667rem 1.41667rem 0rem 1.41667rem;
 }
 .moon-tooltip.above.right-arrow .moon-tooltip-label:before {
-  top: 1.2083333333333333rem;
-  right: -0.08333333rem;
-  border-top: 1.20833333rem solid #4d4d4d;
-  clip: rect(1.25rem, 3.41666667rem, 1.58333333rem, 2.33333333rem);
+  top: 1.20833rem;
+  right: -0.08333rem;
+  border-top: 1.20833rem solid #4d4d4d;
+  clip: rect(1.25rem, 3.41667rem, 1.58333rem, 2.33333rem);
   border-radius: 416.625rem;
 }
 /* .below .left-arrow nub shape */
 .moon-tooltip.below.left-arrow .moon-tooltip-label {
-  border-radius: 0 1.41666667rem 1.41666667rem 1.41666667rem;
+  border-radius: 0 1.41667rem 1.41667rem 1.41667rem;
 }
 .moon-tooltip.below.left-arrow .moon-tooltip-label:before {
-  top: -2.08333333rem;
-  left: -0.08333333rem;
-  border-bottom: 1.20833333rem solid #4d4d4d;
-  clip: rect(0.08333333rem, 1rem, 2.5rem, 0.08333333rem);
+  top: -2.08333rem;
+  left: -0.08333rem;
+  border-bottom: 1.20833rem solid #4d4d4d;
+  clip: rect(0.08333rem, 1rem, 2.5rem, 0.08333rem);
   border-radius: 416.625rem;
 }
 /* .below .right-arrow nub shape */
 .moon-tooltip.below.right-arrow .moon-tooltip-label {
-  border-radius: 1.41666667rem 0rem 1.41666667rem 1.41666667rem;
+  border-radius: 1.41667rem 0rem 1.41667rem 1.41667rem;
 }
 .moon-tooltip.below.right-arrow .moon-tooltip-label:before {
-  top: -2.08333333rem;
-  right: -0.08333333rem;
-  border-bottom: 1.20833333rem solid #4d4d4d;
-  clip: rect(0.08333333rem, 3.41666667rem, 2.5rem, 2.33333333rem);
+  top: -2.08333rem;
+  right: -0.08333rem;
+  border-bottom: 1.20833rem solid #4d4d4d;
+  clip: rect(0.08333rem, 3.41667rem, 2.5rem, 2.33333rem);
   border-radius: 416.625rem;
 }
 /* AudioPlayback.css */
@@ -3592,14 +3592,14 @@ html {
 .moon-audio-playback-track-icon {
   position: relative;
   top: 0.25rem;
-  left: 0.16666666666666666rem;
-  width: 5.333333333333333rem;
-  height: 5.333333333333333rem;
+  left: 0.16667rem;
+  width: 5.33333rem;
+  height: 5.33333rem;
   background: transparent url() no-repeat 0rem 0rem;
   display: inline-block;
 }
 .moon-audio-playback-playtime {
-  font-size: 0.8333333333333334rem;
+  font-size: 0.83333rem;
 }
 .moon-audio-track-info,
 .moon-audio-control-buttons > * {
@@ -3607,8 +3607,8 @@ html {
   top: 0.25rem;
 }
 .moon-audio-play-time {
-  width: 3.3333333333333335rem;
-  font-size: 0.8333333333333334rem;
+  width: 3.33333rem;
+  font-size: 0.83333rem;
   padding-top: 3rem;
 }
 .moon-audio-play-time.left {
@@ -3622,20 +3622,20 @@ html {
 }
 .moon-audio-track-info {
   width: 40%;
-  padding: 0 0.4166666666666667rem;
+  padding: 0 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-audio-track-info {
   text-align: right;
   direction: rtl;
 }
 .moon-audio-top {
-  height: 2.7083333333333335rem;
+  height: 2.70833rem;
   padding-top: 0.625rem;
 }
 /* AudioPlayback styles for IconButton */
 .moon-audio-icon-button {
   background-color: #808080;
-  margin: 0.3333333333333333rem 0.16666666666666666rem;
+  margin: 0.33333rem 0.16667rem;
 }
 .moon-audio-icon-button.left {
   float: left;
@@ -3645,7 +3645,7 @@ html {
 }
 /* AudioPlayback styles for Slider */
 .moon-audio-slider-container {
-  padding-top: 0.4166666666666667rem;
+  padding-top: 0.41667rem;
 }
 .moon-audio-slider.spotlight > .moon-slider-knob {
   background-color: #cf0652;
@@ -3655,34 +3655,34 @@ html {
   height: 1.25rem;
   width: 1.25rem;
   border-radius: 0.625rem;
-  margin: -0.54166667rem -0.66666667rem;
+  margin: -0.54167rem -0.66667rem;
   background-color: #808080;
 }
 .moon-audio-slider > .moon-slider-knob.active,
 .moon-audio-slider > .moon-slider-knob.spotselect,
 .moon-audio-slider > .moon-slider-knob:active:hover {
-  height: 1.4166666666666667rem;
-  width: 1.4166666666666667rem;
-  border-radius: 0.7083333333333334rem;
+  height: 1.41667rem;
+  width: 1.41667rem;
+  border-radius: 0.70833rem;
   margin: -0.625rem -0.75rem;
   background-color: #808080;
 }
 .moon-audio-slider.moon-progress-bar {
   background-color: #cccccc;
   margin: 0rem;
-  top: 0.4166666666666667rem;
+  top: 0.41667rem;
 }
 .moon-audio-slider > .moon-progress-bar-bar {
   background-color: #666666;
 }
 /* AudioPlayback styles for queue */
 .moon-audio-playback-queue {
-  margin: 0rem 1.6666666666666667rem;
+  margin: 0rem 1.66667rem;
 }
 /* AudioPlayback styles for queue list items */
 .moon-audio-queue-list {
-  height: 4.166666666666667rem;
-  padding: 0.5rem 0.6666666666666666rem;
+  height: 4.16667rem;
+  padding: 0.5rem 0.66667rem;
   border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
 }
@@ -3695,17 +3695,17 @@ html {
   vertical-align: middle;
 }
 .moon-audio-queue-album-art {
-  width: 3.3333333333333335rem;
-  height: 3.3333333333333335rem;
+  width: 3.33333rem;
+  height: 3.33333rem;
   background: transparent none no-repeat 0rem 0rem;
-  padding-right: 0.4166666666666667rem;
+  padding-right: 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-audio-queue-album-art {
   padding-right: 0;
-  padding-left: 0.4166666666666667rem;
+  padding-left: 0.41667rem;
 }
 .moon-video-transport-slider {
-  height: 3.33333333rem;
+  height: 3.33333rem;
   background-color: #323232;
 }
 .moon-video-transport-slider .moon-slider-popup.above {
@@ -3722,7 +3722,7 @@ html {
   width: 0.25rem;
   border-radius: 0.125rem;
   margin: -0.125rem;
-  top: 0.83333333rem;
+  top: 0.83333rem;
   pointer-events: none;
 }
 .moon-video-transport-slider-knob {
@@ -3768,7 +3768,7 @@ html {
   display: inline-block;
 }
 .moon-video-transport-slider-indicator-wrapper {
-  height: 3.4166666666666665rem;
+  height: 3.41667rem;
   top: 0;
   position: absolute;
 }
@@ -3781,16 +3781,16 @@ html {
 .moon-video-transport-slider-indicator-bar-left {
   position: absolute;
   left: 49.5%;
-  top: 1.0416666666666667rem;
-  width: 0.08333333333333333rem;
+  top: 1.04167rem;
+  width: 0.08333rem;
   height: 1.25rem;
   background-color: #ffffff;
 }
 .moon-video-transport-slider-indicator-bar-right {
   position: absolute;
   left: 49.5%;
-  top: 1.0416666666666667rem;
-  width: 0.08333333333333333rem;
+  top: 1.04167rem;
+  width: 0.08333rem;
   height: 1.25rem;
   background-color: #ffffff;
 }
@@ -3798,7 +3798,7 @@ html {
   position: absolute;
   width: 100%;
   height: 1.25rem;
-  top: 0.9583333333333334rem;
+  top: 0.95833rem;
   font-size: 1.25rem;
   font-family: "Moonstone Miso";
   font-weight: bold;
@@ -3818,7 +3818,7 @@ html {
   background-color: #000000;
 }
 .moon-video-player:not(.enyo-fullscreen) {
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
 }
 .moon-video-player-container {
   display: block;
@@ -3837,8 +3837,8 @@ html {
   position: absolute;
   top: 50%;
   left: 50%;
-  margin-top: -1.52083333rem;
-  margin-left: -1.52083333rem;
+  margin-top: -1.52083rem;
+  margin-left: -1.52083rem;
 }
 /* Fullscreen CSS */
 :-webkit-full-screen.moon-video-player {
@@ -3882,32 +3882,32 @@ html {
   position: static;
 }
 .moon-video-inline {
-  padding-bottom: 3.3333333333333335rem;
+  padding-bottom: 3.33333rem;
 }
 .moon-video-inline-control {
   position: relative;
   width: 100%;
-  height: 3.3333333333333335rem;
+  height: 3.33333rem;
   background-color: #252525;
 }
 .moon-video-inline-control .moon-video-inline-control-play-pause {
   position: absolute;
-  bottom: 0.4166666666666667rem;
-  left: 0.4166666666666667rem;
+  bottom: 0.41667rem;
+  left: 0.41667rem;
 }
 .moon-video-inline-control .moon-video-inline-control-fullscreen {
   position: absolute;
-  bottom: 0.4166666666666667rem;
-  right: 0.4166666666666667rem;
+  bottom: 0.41667rem;
+  right: 0.41667rem;
 }
 .moon-video-inline-control-text {
   font-family: "Moonstone Miso";
   position: absolute;
-  bottom: 0.8333333333333334rem;
-  left: 4.166666666666667rem;
+  bottom: 0.83333rem;
+  left: 4.16667rem;
   background-color: transparent;
   color: #ffffff;
-  font-size: 1.3333333333333333rem;
+  font-size: 1.33333rem;
 }
 .moon-video-inline-control-text > * {
   display: inline;
@@ -3917,7 +3917,7 @@ html {
   bottom: 0rem;
   left: 0rem;
   width: 0%;
-  height: 3.3333333333333335rem;
+  height: 3.33333rem;
   background-color: #cf0652;
   transition: width 0.1s linear;
   -webkit-transition: width 0.1s linear;
@@ -3928,7 +3928,7 @@ html {
   bottom: 0rem;
   left: 0rem;
   width: 0%;
-  height: 3.3333333333333335rem;
+  height: 3.33333rem;
   background-color: #393939;
   transition: width 0.1s linear;
   -webkit-transition: width 0.1s linear;
@@ -3944,12 +3944,12 @@ html {
 .moon-video-inline-control .moon-icon-button.spotlight:active {
   color: #393939;
   background-color: #ffffff;
-  background-position: 0rem -2.08333333rem;
+  background-position: 0rem -2.08333rem;
 }
 .moon-video-inline-control .moon-icon-button.spotlight {
   color: #393939;
   background-color: #ffffff;
-  background-position: 0rem -2.08333333rem;
+  background-position: 0rem -2.08333rem;
 }
 /* --- Fullscreen control --- */
 .moon-video-fullscreen-control {
@@ -3998,7 +3998,7 @@ html {
   direction: ltr;
 }
 .moon-video-player-controls {
-  height: 3.54166667rem;
+  height: 3.54167rem;
   margin-bottom: 1.25rem;
 }
 .enyo-fittable-columns-layout.moon-video-player-controls {
@@ -4009,8 +4009,8 @@ html {
   width: 100%;
 }
 .moon-video-player-more-controls {
-  border-left: 0.08333333333333333rem solid white;
-  padding-left: 0.20833333333333334rem;
+  border-left: 0.08333rem solid white;
+  padding-left: 0.20833rem;
 }
 .moon-video-player-more-controls > * {
   vertical-align: middle;
@@ -4020,31 +4020,31 @@ html {
 }
 .moon-video-player-premium-placeholder-left {
   width: 8.75rem;
-  height: 3.54166667rem;
+  height: 3.54167rem;
   padding-left: 3.75rem;
 }
 .moon-video-player-premium-placeholder-right {
   width: 8.75rem;
-  height: 3.54166667rem;
-  padding-left: 0.20833333333333334rem;
+  height: 3.54167rem;
+  padding-left: 0.20833rem;
 }
 /* --- Buttons --- */
 .moon-video-fullscreen-control .moon-icon-button {
-  width: 3.54166667rem;
-  height: 3.54166667rem;
+  width: 3.54167rem;
+  height: 3.54167rem;
   border-radius: 0;
   border: 0rem;
   background-color: transparent;
   background-position: 0rem 0rem;
-  background-size: 3.54166667rem 7.08333333rem;
+  background-size: 3.54167rem 7.08333rem;
   color: #ffffff;
-  line-height: 3.54166667rem;
+  line-height: 3.54167rem;
 }
 .moon-icon-playpause-font-style {
-  font-size: 9.16666667rem;
+  font-size: 9.16667rem;
 }
 .moon-icon-video-main-control-font-style {
-  font-size: 7.91666667rem;
+  font-size: 7.91667rem;
 }
 /* this style is used for the two side controls and placeholders */
 .moon-icon-button.moon-icon-video-round-controls-style {
@@ -4053,7 +4053,7 @@ html {
   border-radius: 416.625rem;
 }
 .moon-icon-button.moon-icon-video-more-controls-font-style {
-  font-size: 4.66666667rem;
+  font-size: 4.66667rem;
 }
 .moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
 .moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
@@ -4061,7 +4061,7 @@ html {
 .moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
 .moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
 .moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
-  background-position: 0 -3.54166667rem;
+  background-position: 0 -3.54167rem;
   border: 0rem;
   background-color: transparent;
   color: #cf0652;
@@ -4084,7 +4084,7 @@ html {
   text-align: center;
 }
 .moon-video-fullscreen-control .moon-video-player-control-buttons > * {
-  margin: 0 1.6666666666666667rem;
+  margin: 0 1.66667rem;
 }
 .moon-video-fullscreen-control .moon-video-player-control-buttons > :first-child {
   margin-left: 0;
@@ -4095,7 +4095,7 @@ html {
 /* ---- Slider container styling ---- */
 .moon-video-player-slider-container {
   padding: 3.75rem 0 0 0;
-  height: 3.3333333333333335rem;
+  height: 3.33333rem;
 }
 .moon-video-player-slider-container .moon-slider {
   margin: 0 0 0 !important;
@@ -4115,12 +4115,12 @@ html {
 .moon-icon.moon-video-feedback-icon-left,
 .moon-icon.moon-video-feedback-icon-right {
   display: inline-block;
-  width: 1.33333333rem;
+  width: 1.33333rem;
   margin: 0 0 0 0.625rem;
   /* margin-right is inherited from moon-video-player-feedback */
   color: #cf0652;
-  font-size: 5.16666667rem;
-  line-height: 1.08333333rem;
+  font-size: 5.16667rem;
+  line-height: 1.08333rem;
   /* use line-height to middle align the icon, the defaut 32px from moon-icon will make it too low */
 }
 .moon-icon.moon-video-feedback-icon-left .small-icon-tap-area,
@@ -4135,18 +4135,18 @@ html {
   margin-right: 0.625rem;
 }
 .moon-icon.moon-video-feedback-icon-left.moon-icon-pausejumpbackward {
-  width: 1.54166667rem;
+  width: 1.54167rem;
 }
 .moon-icon.moon-video-feedback-icon-right.moon-icon-play {
   font-size: 3rem;
-  width: 0.91666667rem;
+  width: 0.91667rem;
 }
 .moon-icon.moon-video-feedback-icon-right.moon-icon-pause {
   font-size: 3rem;
-  width: 0.91666667rem;
+  width: 0.91667rem;
 }
 .moon-icon.moon-video-feedback-icon-right.moon-icon-pausejumpforward {
-  width: 1.54166667rem;
+  width: 1.54167rem;
 }
 .moon-video-player-feedback .moon-icon.small > .small-icon-tap-area {
   top: 0;
@@ -4156,7 +4156,7 @@ html {
 }
 .enyo-locale-non-latin .moon-video-feedback-icon-left,
 .enyo-locale-non-latin .moon-video-feedback-icon-right {
-  margin-bottom: 0.08333333333333333rem;
+  margin-bottom: 0.08333rem;
 }
 .enyo-locale-right-to-left .moon-video-player-feedback {
   margin: 0 0 0 0.625rem;
@@ -4170,11 +4170,11 @@ html {
 .moon-video-info-header {
   display: inline-block;
   vertical-align: top;
-  max-width: 45.833333333333336rem;
+  max-width: 45.83333rem;
 }
 .moon-video-player-info-datetime {
-  font-size: 1.33333333rem;
-  margin-bottom: 1.3333333333333333rem;
+  font-size: 1.33333rem;
+  margin-bottom: 1.33333rem;
   white-space: nowrap;
 }
 .moon-video-player-info-title {
@@ -4193,7 +4193,7 @@ html {
   font-family: "MuseoSans 700";
   font-size: 1.25rem;
   color: #ffffff;
-  margin-bottom: 0.9166666666666666rem;
+  margin-bottom: 0.91667rem;
   white-space: nowrap;
 }
 .enyo-locale-non-latin .moon-video-player-info-subtitle {
@@ -4203,15 +4203,15 @@ html {
 }
 .moon-video-player-info-subsubtitle {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #4b4b4b;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
   font-style: italic;
   color: #ffffff;
   display: inline-block;
   white-space: normal;
   max-width: 50rem;
-  margin-bottom: 0.4166666666666667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-video-player-info-subsubtitle a:link {
   color: #cf0652;
@@ -4231,18 +4231,18 @@ html {
 }
 .enyo-locale-non-latin .moon-video-player-info-subsubtitle {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
   color: #ffffff;
 }
 .moon-video-player-info-description {
   font-family: "MuseoSans 300";
-  font-size: 1.08333333rem;
+  font-size: 1.08333rem;
   color: #4b4b4b;
-  line-height: 1.33333333rem;
+  line-height: 1.33333rem;
   color: #ffffff;
   white-space: normal;
-  margin-bottom: 1.0416666666666667rem;
+  margin-bottom: 1.04167rem;
   -webkit-line-clamp: 3;
   display: -webkit-inline-box;
   overflow: hidden;
@@ -4267,33 +4267,33 @@ html {
 }
 .enyo-locale-non-latin .moon-video-player-info-description {
   font-family: "Moonstone LG Display Light";
-  font-size: 1.08333333rem;
-  line-height: 1.33333333rem;
+  font-size: 1.08333rem;
+  line-height: 1.33333rem;
   color: #ffffff;
 }
 .moon-video-player-info-client {
   display: inline-block;
-  margin: 0 0 0.4166666666666667rem 0.8333333333333334rem;
+  margin: 0 0 0.41667rem 0.83333rem;
 }
 .enyo-locale-right-to-left .moon-video-player-info-client {
-  margin: 0 0.8333333333333334rem 0.4166666666666667rem 0;
+  margin: 0 0.83333rem 0.41667rem 0;
 }
 .moon-video-player-info-client > * {
   display: inline-block;
-  margin: 0 0.20833333333333334rem;
+  margin: 0 0.20833rem;
 }
 .moon-channelinfo {
   display: inline-block;
   vertical-align: top;
   text-align: right;
   white-space: normal;
-  max-width: 33.333333333333336rem;
+  max-width: 33.33333rem;
 }
 .moon-channelinfo .moon-marquee {
   text-align: right;
 }
 .moon-video-player-channel-info-badges > * {
-  margin: 0.125rem 0 0.125rem 0.8333333333333334rem;
+  margin: 0.125rem 0 0.125rem 0.83333rem;
 }
 .moon-video-player-channel-info-no {
   font-family: "Moonstone Miso";
@@ -4311,7 +4311,7 @@ html {
   font-family: "MuseoSans 700";
   font-size: 1.25rem;
   color: #ffffff;
-  margin-bottom: 0.9166666666666666rem;
+  margin-bottom: 0.91667rem;
   white-space: nowrap;
 }
 .enyo-locale-non-latin .moon-video-player-channel-info-name {
@@ -4319,10 +4319,10 @@ html {
 }
 .moon-video-player-info-icon {
   font-family: "MuseoSans 700";
-  font-size: 0.83333333rem;
+  font-size: 0.83333rem;
   color: #000000;
   background-color: #ffffff;
-  border-radius: 0.20833333333333334rem;
+  border-radius: 0.20833rem;
   text-align: center;
   white-space: nowrap;
   padding: 0.125rem 0.375rem;
@@ -4334,7 +4334,7 @@ html {
 .moon-video-player-info-redicon {
   background-color: #fe4a4b;
   color: #ffffff;
-  margin-top: 0.5416666666666666rem;
+  margin-top: 0.54167rem;
 }
 .moon-background-wrapper {
   position: absolute;
@@ -4356,14 +4356,14 @@ html {
   height: 0;
 }
 .moon-background-wrapper-client-content.left {
-  padding: 0 1.25rem 0 2.9166666666666665rem;
+  padding: 0 1.25rem 0 2.91667rem;
   float: left;
 }
 .moon-background-wrapper-client-content.left:after {
   left: 100%;
   bottom: 0;
-  border-bottom: solid 41.666666666666664rem transparent;
-  border-left: solid 7.08333333rem #000000;
+  border-bottom: solid 41.66667rem transparent;
+  border-left: solid 7.08333rem #000000;
 }
 .moon-background-wrapper-client-content.right {
   padding: 0 1.25rem 0 0;
@@ -4372,8 +4372,8 @@ html {
 .moon-background-wrapper-client-content.right:after {
   right: 100%;
   top: 0;
-  border-top: solid 41.666666666666664rem transparent;
-  border-right: solid 7.08333333rem #000000;
+  border-top: solid 41.66667rem transparent;
+  border-right: solid 7.08333rem #000000;
 }
 .moon-background-wrapper-client-content > * {
   display: inline-block;
@@ -4383,7 +4383,7 @@ html {
   direction: rtl;
 }
 .moon-clock {
-  margin: 1.25rem 0.8333333333333334rem 1.25rem 1.6666666666666667rem;
+  margin: 1.25rem 0.83333rem 1.25rem 1.66667rem;
 }
 .moon-clock .moon-bold-text {
   font-size: 2.25rem;
@@ -4416,11 +4416,11 @@ html {
   -webkit-user-select: none;
 }
 .moon-scroller-client-wrapper.v-scroll-enabled {
-  padding-right: 2.91666667rem;
+  padding-right: 2.91667rem;
 }
 .enyo-locale-right-to-left .moon-scroller-client-wrapper.v-scroll-enabled {
   padding-right: 0;
-  padding-left: 2.91666667rem;
+  padding-left: 2.91667rem;
 }
 .moon-scroller-client-wrapper.h-scroll-enabled {
   padding-bottom: 2.5rem;
@@ -4458,12 +4458,12 @@ html {
 .moon-scroller-v-column {
   top: 0rem;
   bottom: 0rem;
-  right: 0.41666667rem;
+  right: 0.41667rem;
   width: 2.5rem;
 }
 .enyo-locale-right-to-left .moon-scroller-v-column {
   right: auto;
-  left: 0.41666667rem;
+  left: 0.41667rem;
 }
 /* Default position for horizontal scrollbar */
 .moon-scroller-h-column {
@@ -4502,8 +4502,8 @@ html {
 .moon-expandable-input .moon-input-decorator {
   width: 100%;
   box-sizing: border-box;
-  margin-top: 0.41666667rem;
-  margin-bottom: 0.41666667rem;
+  margin-top: 0.41667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-expandable-input .moon-input {
   width: 100%;
@@ -4525,7 +4525,7 @@ html {
 .moon-objaction.vertical .moon-objaction-actions {
   opacity: 0;
   text-align: center;
-  padding: 0 0.41666667rem;
+  padding: 0 0.41667rem;
   box-sizing: border-box;
 }
 .moon-objaction.vertical .moon-objaction-actions.stretch > * {
@@ -4537,24 +4537,24 @@ html {
 .moon-objaction.horizontal .moon-objaction-client {
   display: table-cell;
   width: 100%;
-  padding-right: 0.41666667rem;
+  padding-right: 0.41667rem;
 }
 .moon-objaction.horizontal .moon-objaction-actions {
   display: table-cell;
   opacity: 0;
   white-space: nowrap;
   vertical-align: middle;
-  padding-right: 0.41666667rem;
+  padding-right: 0.41667rem;
 }
 .enyo-locale-right-to-left .moon-objaction-client.horizontal .moon-objaction-client {
   padding-right: auto;
-  padding-left: 0.41666667rem;
+  padding-left: 0.41667rem;
 }
 .moon-objaction.vertical .moon-objaction-client .moon-item.spotlight {
   background-color: transparent;
 }
 .moon-objaction.vertical .moon-objaction-client .moon-item > img {
-  padding: 0.41666667rem;
+  padding: 0.41667rem;
 }
 .moon-objaction.vertical .moon-objaction-client .moon-item.spotlight > img {
   background-color: #cf0652;
@@ -4562,13 +4562,13 @@ html {
 /* FormCheckbox.css */
 .moon-item.moon-formcheckbox-item {
   background: none;
-  padding: 0 0 0 0.41666667rem;
-  margin-bottom: 0.41666667rem;
+  padding: 0 0 0 0.41667rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-item.moon-formcheckbox-item .moon-checkbox {
   position: absolute;
-  top: 0.20833333333333334rem;
-  left: 0.41666667rem;
+  top: 0.20833rem;
+  left: 0.41667rem;
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 416.625rem;
@@ -4577,21 +4577,21 @@ html {
   text-align: center;
 }
 .moon-item.moon-formcheckbox-item .moon-checkbox .moon-icon {
-  padding-bottom: 0.08333333333333333rem;
+  padding-bottom: 0.08333rem;
 }
 .moon-item.moon-formcheckbox-item .moon-checkbox-item-label-wrapper {
-  padding: 0.3333333333333333rem 0.4166666666666667rem;
+  padding: 0.33333rem 0.41667rem;
   margin-left: 1.75rem;
 }
 .enyo-locale-right-to-left .moon-item.moon-formcheckbox-item {
-  padding: 0 0.41666667rem 0 0;
+  padding: 0 0.41667rem 0 0;
 }
 .enyo-locale-right-to-left .moon-item.moon-formcheckbox-item .moon-checkbox-item-label-wrapper {
   margin-left: auto;
-  margin-right: 2.16666667rem;
+  margin-right: 2.16667rem;
 }
 .enyo-locale-right-to-left .moon-item.moon-formcheckbox-item .moon-checkbox {
-  right: 0.41666667rem;
+  right: 0.41667rem;
 }
 .moon-formcheckbox-item.spotlight .moon-checkbox {
   background-color: #cf0652;
@@ -4613,7 +4613,7 @@ html {
   margin: -1.25rem 0 0 -1.25rem;
   background-color: #ffffff;
   border-radius: 1.25rem;
-  background-position: center 0.20833333rem;
+  background-position: center 0.20833rem;
 }
 .moon-selection-overlay-support-scrim {
   display: none;
@@ -4626,8 +4626,8 @@ html {
   -webkit-transform-origin: 0rem 0rem;
   border: none;
   background: rgba(50, 50, 50, 0.8);
-  width: 0.16666666666666666rem;
-  height: 0.16666666666666666rem;
+  width: 0.16667rem;
+  height: 0.16667rem;
   border-radius: 0;
 }
 .moon-neutral .moon-thumb {
@@ -4640,10 +4640,10 @@ html {
   -webkit-transition: opacity 0.1s linear;
 }
 .moon-scroller-hthumb {
-  bottom: 1.16666667rem;
+  bottom: 1.16667rem;
 }
 .moon-scroller-vthumb {
-  right: 1.16666667rem;
+  right: 1.16667rem;
 }
 .moon-scroller-hthumb.hidden,
 .moon-scroller-vthumb.hidden {
@@ -4651,7 +4651,7 @@ html {
 }
 .moon-image {
   display: inline-block;
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
 }
 .moon-image.has-children {
   position: relative;
@@ -4670,7 +4670,7 @@ html {
   left: 0;
   right: 0;
   background: #6d6d6d;
-  padding: 0.3333333333333333rem;
+  padding: 0.33333rem;
   overflow: hidden;
   display: block;
 }
@@ -4696,7 +4696,7 @@ html {
   overflow: hidden;
 }
 .moon-expandable-text .moon-expandable-text-content {
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
   display: -webkit-inline-box;
   overflow: hidden;
   -webkit-box-orient: vertical;
@@ -4704,13 +4704,13 @@ html {
 .moon-expandable-text .moon-expandable-text-button {
   float: right;
   display: inline-block;
-  padding: 0.41666667rem 1.75rem 0.41666667rem 0.41666667rem;
+  padding: 0.41667rem 1.75rem 0.41667rem 0.41667rem;
   position: relative;
 }
 .moon-expandable-text .moon-expandable-text-button:after {
   position: absolute;
-  top: 0.41666667rem;
-  right: 0.45833333rem;
+  top: 0.41667rem;
+  right: 0.45833rem;
   font-family: "Moonstone Icons";
   content: "\0F0002";
   font-size: 2rem;
@@ -4726,14 +4726,14 @@ html {
   display: none;
 }
 .enyo-locale-non-latin .moon-expandable-text .moon-expandable-text-button:after {
-  top: 0.45833333rem;
+  top: 0.45833rem;
 }
 .enyo-locale-right-to-left .moon-expandable-text .moon-expandable-text-button {
   float: left;
-  padding: 0.41666667rem 0.41666667rem 0.41666667rem 1.75rem;
+  padding: 0.41667rem 0.41667rem 0.41667rem 1.75rem;
 }
 .enyo-locale-right-to-left .moon-expandable-text .moon-expandable-text-button:after {
-  left: 0.45833333rem;
+  left: 0.45833rem;
   right: auto;
 }
 .moon-body-text-control {
@@ -4743,7 +4743,7 @@ html {
   text-align: right;
 }
 .moon-icon-exitfullscreen.moon-icon-exitfullscreen-font-style {
-  font-size: 4.16666667rem;
+  font-size: 4.16667rem;
 }
 /* Put this at the end because we want these to take precedence over others */
 .moon-neutral {
@@ -4769,7 +4769,7 @@ html {
 .moon-hspacing > * {
   display: inline-block;
   vertical-align: middle;
-  margin: 0 0.41666667rem;
+  margin: 0 0.41667rem;
 }
 .moon-hspacing.top > * {
   vertical-align: top;
@@ -4779,7 +4779,7 @@ html {
   margin-left: 0;
 }
 .enyo-locale-right-to-left .moon-hspacing > :first-child {
-  margin-left: 0.41666667rem;
+  margin-left: 0.41667rem;
   margin-right: 0;
 }
 .moon-hspacing > :last-child,
@@ -4787,7 +4787,7 @@ html {
   margin-right: 0;
 }
 .enyo-locale-right-to-left .moon-hspacing > :last-child {
-  margin-right: 0.41666667rem;
+  margin-right: 0.41667rem;
   margin-left: 0;
 }
 /* -------------------------- */
@@ -4795,7 +4795,7 @@ html {
 /* -------------------------- */
 .moon-vspacing > * {
   display: block;
-  margin: 0.41666667rem 0;
+  margin: 0.41667rem 0;
 }
 .moon-vspacing > :first-child {
   margin-top: 0;
@@ -4809,33 +4809,33 @@ html {
 .moon-vspacing-s > .moon-item:not(.moon-formcheckbox-item),
 .moon-vspacing-s > .moon-expandable-list-item:not(.open) .moon-item,
 .moon-vspacing-s > .moon-expandable-list-item.open {
-  padding-bottom: 0.41666667rem;
+  padding-bottom: 0.41667rem;
 }
 .moon-vspacing-s > .moon-button,
 .moon-vspacing-s > .moon-input-decorator,
 .moon-vspacing-s > .moon-formcheckbox-item {
-  margin-top: 0.20833333rem;
-  margin-bottom: 0.41666667rem;
+  margin-top: 0.20833rem;
+  margin-bottom: 0.41667rem;
 }
 .moon-vspacing-m > .moon-item:not(.moon-formcheckbox-item),
 .moon-vspacing-m > .moon-expandable-list-item:not(.open) .moon-item,
 .moon-vspacing-m > .moon-expandable-list-item.open {
-  padding-bottom: 0.83333333rem;
+  padding-bottom: 0.83333rem;
 }
 .moon-vspacing-m > .moon-button,
 .moon-vspacing-m > .moon-input-decorator,
 .moon-vspacing-m > .moon-formcheckbox-item {
-  margin-top: 0.41666667rem;
-  margin-bottom: 0.83333333rem;
+  margin-top: 0.41667rem;
+  margin-bottom: 0.83333rem;
 }
 .moon-vspacing-l > .moon-item:not(.moon-formcheckbox-item),
 .moon-vspacing-l > .moon-expandable-list-item:not(.open) .moon-item,
 .moon-vspacing-l > .moon-expandable-list-item.open {
-  padding-bottom: 1.66666667rem;
+  padding-bottom: 1.66667rem;
 }
 .moon-vspacing-l > .moon-button,
 .moon-vspacing-l > .moon-input-decorator,
 .moon-vspacing-l > .moon-formcheckbox-item {
-  margin-top: 0.83333333rem;
-  margin-bottom: 1.66666667rem;
+  margin-top: 0.83333rem;
+  margin-bottom: 1.66667rem;
 }


### PR DESCRIPTION
### Issue
With the change from https://github.com/enyojs/enyo/pull/994, we are limiting the number of decimal places in our converted measurements, necessitating a regeneration of the CSS.

### Fix
The CSS has been regenerated. I went through the samples and didn't notice any adverse effects from slightly less fractional digits.

### Notes
Travis will fail until https://github.com/enyojs/enyo/pull/994 has been merged and the build is rerun.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>