### PR TITLE
Fixes ENYO-736

### DIFF
--- a/css/Item.less
+++ b/css/Item.less
@@ -2,7 +2,7 @@
 .moon-item {
 	.moon-sub-header-text;
 	line-height: @moon-item-line-height;
-	padding: @moon-spotlight-outset;
+	.hd(padding; @moon-spotlight-outset);
 	position: relative;
 
 	&.spotlight {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1123,6 +1123,11 @@ html {
   padding: 0.41666667rem;
   position: relative;
 }
+@media only screen and (max-width: 1280px) {
+  .moon-item {
+    padding: 0.375rem;
+  }
+}
 .moon-item.spotlight {
   background-color: #cf0652;
   color: #ffffff;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1123,10 +1123,8 @@ html {
   padding: 0.41666667rem;
   position: relative;
 }
-@media only screen and (max-width: 1280px) {
-  .moon-item {
-    padding: 0.375rem;
-  }
+.moon-res-hd .moon-item {
+  padding: 0.375rem;
 }
 .moon-item.spotlight {
   background-color: #cf0652;

--- a/css/moonstone-hd.less
+++ b/css/moonstone-hd.less
@@ -17,9 +17,7 @@
 }
 
 .hd-media(@property, @value) {
-	@media only screen and (max-width: 1280px) {
-		& {
-			@{property}: @value;
-		}
+	.moon-res-hd & {
+		@{property}: @value;
 	}
 }

--- a/css/moonstone-hd.less
+++ b/css/moonstone-hd.less
@@ -1,0 +1,25 @@
+.hd(@property, @value) {
+	@{property}: @value;
+}
+
+.hd(@property, @value) when (mod(@value, 3) > 0) {
+	@{property}: @value;
+
+	.hd-media(@property, round(@value / 3) * 3);
+}
+
+.hd(@property, @value) when (length(@value) = 2) {
+	.hd-media(@property, round(extract(@value, 1) / 3) * 3 round(extract(@value, 2) / 3) * 3);
+}
+
+.hd(@property, @value) when (length(@value) = 4) {
+	.hd-media(@property, round(extract(@value, 1) / 3) * 3 round(extract(@value, 2) / 3) * 3 round(extract(@value, 3) / 3) * 3 round(extract(@value, 4) / 3) * 3);
+}
+
+.hd-media(@property, @value) {
+	@media only screen and (max-width: 1280px) {
+		& {
+			@{property}: @value;
+		}
+	}
+}

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1123,6 +1123,11 @@ html {
   padding: 0.41666667rem;
   position: relative;
 }
+@media only screen and (max-width: 1280px) {
+  .moon-item {
+    padding: 0.375rem;
+  }
+}
 .moon-item.spotlight {
   background-color: #cf0652;
   color: #ffffff;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1123,10 +1123,8 @@ html {
   padding: 0.41666667rem;
   position: relative;
 }
-@media only screen and (max-width: 1280px) {
-  .moon-item {
-    padding: 0.375rem;
-  }
+.moon-res-hd .moon-item {
+  padding: 0.375rem;
 }
 .moon-item.spotlight {
   background-color: #cf0652;

--- a/css/moonstone-rules.less
+++ b/css/moonstone-rules.less
@@ -59,6 +59,7 @@ html {
 	will-change: transform;
 }
 
+@import "moonstone-hd.less";
 @import "moonstone-text.less";
 
 .border-box {


### PR DESCRIPTION
## Issue
Since the base size is 1080p, values converted to 720p are multiplied
by 2/3 which results in sub-pixel values for many properties. The
effect is that the browser may alter the dimensions of a node based
on the accumulation of the fractional part of box model property
values.

## Fix
This mixin rounds the value to the lower multiple of 3 so the
conversion results in a round integer value thereby avoiding the
fractional accumulation issue

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)