### PR TITLE
Fixes ENYO-783

### DIFF
--- a/css/Header.less
+++ b/css/Header.less
@@ -96,7 +96,6 @@
 		right: 0;
 		text-align: right;	/* fallback in case text-align:end isn't supported */
 		text-align: end;	/* CSS3 for RTL support */
-		z-index: 1;         /* Fixme: Inverse component stack order */
 	}
 
 	&.moon-medium-header .moon-header-client,

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1590,8 +1590,6 @@ html {
   /* fallback in case text-align:end isn't supported */
   text-align: end;
   /* CSS3 for RTL support */
-  z-index: 1;
-  /* Fixme: Inverse component stack order */
 }
 .moon-header.moon-medium-header .moon-header-client,
 .moon-header.moon-small-header .moon-header-client {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1590,8 +1590,6 @@ html {
   /* fallback in case text-align:end isn't supported */
   text-align: end;
   /* CSS3 for RTL support */
-  z-index: 1;
-  /* Fixme: Inverse component stack order */
 }
 .moon-header.moon-medium-header .moon-header-client,
 .moon-header.moon-small-header .moon-header-client {


### PR DESCRIPTION
## Issue
Tooltips on buttons in Header's `headerComponents` area were clipped by the panel body because of the `z-index` change to it introduced by PR #1852.

## Fix
Remove an unnecessary `z-index` from `.moon-header-client`.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)