### PR TITLE
Fixes ENYO-800

### DIFF
--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -181,16 +181,6 @@
 		/**
 		* @private
 		*/
-		rendered: enyo.inherit(function (sup) {
-			return function () {
-				sup.apply(this, arguments);
-				this.selectedIndexChanged();
-			};
-		}),
-
-		/**
-		* @private
-		*/
 		scrollIntoView: function() {
 			this.bubble('onRequestScrollIntoView');
 		},
@@ -379,14 +369,7 @@
 		* @private
 		*/
 		selectedIndexChanged: function() {
-			// FIXME: Accounting for issue with sub-pixels and setting a percentage transformation.
-			// It appears that percentage transformations utilize the nearest whole-pixel value.
-			if (!this._clientWidth) this._clientWidth = this.$.client.generated && this.$.client.hasNode().getBoundingClientRect().width;
-			if (this.$.client.generated && this._clientWidth) { // correction for rounding (after we can measure the control width)
-				enyo.dom.transform(this.$.client, {translateX: enyo.dom.unit(this.selectedIndex * this._clientWidth * -1, 'rem')});
-			} else { // initial (rounded) transformation
-				enyo.dom.transform(this.$.client, {translateX: (this.selectedIndex * -100) + '%'});
-			}
+			enyo.dom.transform(this.$.client, {translateX: (this.selectedIndex * -100) + '%'});
 			this.updateMarqueeDisable();
 			this.setSelected(this.getClientControls()[this.selectedIndex]);
 			this.fireChangedEvent();


### PR DESCRIPTION
## Issue
SimplePicker fires its onChange event on it rendered instead of when, you know, it changes.

## Fix
With ENYO-736 changing measurements to be multiples of 3, the original
logic for SimplePicker is effective so reverting the additional logic
to deal with subpixel measurements which cleans things up and removes
the trigger for onChange at render time.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)