### PR TITLE
Patches ENYO-800

### DIFF
--- a/source/SimplePicker.js
+++ b/source/SimplePicker.js
@@ -184,7 +184,7 @@
 		rendered: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
-				this.selectedIndexChanged();
+				this.adjustClientPosition();
 			};
 		}),
 
@@ -378,7 +378,7 @@
 		/**
 		* @private
 		*/
-		selectedIndexChanged: function() {
+		adjustClientPosition: function () {
 			// FIXME: Accounting for issue with sub-pixels and setting a percentage transformation.
 			// It appears that percentage transformations utilize the nearest whole-pixel value.
 			if (!this._clientWidth) this._clientWidth = this.$.client.generated && this.$.client.hasNode().getBoundingClientRect().width;
@@ -387,6 +387,13 @@
 			} else { // initial (rounded) transformation
 				enyo.dom.transform(this.$.client, {translateX: (this.selectedIndex * -100) + '%'});
 			}
+		},
+
+		/**
+		* @private
+		*/
+		selectedIndexChanged: function() {
+			this.adjustClientPosition();
 			this.updateMarqueeDisable();
 			this.setSelected(this.getClientControls()[this.selectedIndex]);
 			this.fireChangedEvent();


### PR DESCRIPTION
## Issue
SimplePicker fires its onChange event on it rendered instead of when, you know, it changes.

## Fix
Since the purpose of calling it was to adjust the position of the client based on the calculated size of the picker controls, we can refactor that into another method and call that instead of selectedIndexChanged.

## Notes
This is a patch for the issue which is resolved correctly by ENYO-736 and #1906. If those are merged, this can be closed.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)