### PR TITLE
ENYO-799: Adjust title width when header type changes.

### DIFF
--- a/source/Header.js
+++ b/source/Header.js
@@ -576,6 +576,7 @@
 			this.addRemoveClass('moon-medium-header', this.get('type') == 'medium');
 			this.addRemoveClass('moon-small-header', this.get('type') == 'small');
 			this.contentChanged();
+			if (this.generated) this.adjustTitleWidth();
 		},
 
 		/**

--- a/source/Panel.js
+++ b/source/Panel.js
@@ -461,7 +461,6 @@
 		*/
 		headerTypeChanged: function () {
 			this.$.header.setType(this.headerType);
-			this.$.header.adjustTitleWidth();
 			if (this.generated) {
 				this.$.contentWrapper.resize();
 			}


### PR DESCRIPTION
### Issue
When changing the type of a `moon.Header` where the client space changes, this width is not being recalculated and the title width is not being adjusted, resulting in overlap.

### Fix
We call `adjustTitleWidth` whenever the `type` changes, after we have been generated (to not interfere with the logic in `rendered`). Additionally, the call to `adjustTitleWidth` from `moon.Panel` is no longer necessary and has been removed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>