### PR TITLE
ENYO-811: Use multi-res hash for image sources, update classname for moon.ImageMultiRes.

### DIFF
--- a/samples/ImageBadgeSample.js
+++ b/samples/ImageBadgeSample.js
@@ -5,25 +5,51 @@ enyo.kind({
 	components: [
 		{kind: "moon.Scroller", fit: true, components: [
 			{kind: "moon.Divider", content: "Image Badges:"},
-			{kind: "moon.Image", src: "http://placehold.it/340x360&text=Image+One", alt: "Image One", components: [
+			{kind: "moon.Image", src: "http://placehold.it/342x360&text=Image+One", alt: "Image One", components: [
+				{kind: "moon.Icon", icon: "skipbackward"},
+				{kind: "moon.Icon", icon: "play"},
+				{kind: "moon.Icon", icon: "skipforward"},
+				{kind: "moon.Icon", icon: "search", classes: "float-right"}
+			]},
+			{kind: "moon.Image", src: {
+				"hd" : "http://placehold.it/228x240&text=Image+Two",
+				"fhd": "http://placehold.it/342x360&text=Image+Two"
+			}, alt: "Image Two", components: [
 				{kind: "moon.Icon", icon: "check"},
 				{kind: "moon.Icon", icon: "closex"},
 				{kind: "moon.Icon", icon: "drawer", classes: "float-right"}
 			]},
-			{kind: "moon.Image", src: "http://placehold.it/180x240&text=Image+Two", alt: "Image Two", components: [
+			{kind: "moon.Image", src: {
+				"hd" : "http://placehold.it/120x160&text=Image+Three",
+				"fhd": "http://placehold.it/180x240&text=Image+Three"
+			}, alt: "Image Three", components: [
 				{kind: "moon.Icon", icon: "closex"}
 			]},
 			
 			{kind: "moon.Divider", classes: "image-badge-sample-divider", content: "Image Badges - Show on Spotlight:"},
 			{kind: "moon.Item", components: [
-				{kind: "moon.Image", src: "http://placehold.it/340x360&text=Image+One", alt: "Image One", showBadgesOnSpotlight: true, components: [
+				{kind: "moon.Image", src: "http://placehold.it/342x360&text=Image+One", alt: "Image One", showBadgesOnSpotlight: true, components: [
+					{kind: "moon.Icon", icon: "skipbackward"},
+					{kind: "moon.Icon", icon: "play"},
+					{kind: "moon.Icon", icon: "skipforward"},
+					{kind: "moon.Icon", icon: "search", classes: "float-right"}
+				]}
+			]},
+			{kind: "moon.Item", components: [
+				{kind: "moon.Image", src: {
+					"hd" : "http://placehold.it/228x240&text=Image+Two",
+					"fhd": "http://placehold.it/342x360&text=Image+Two"
+				}, alt: "Image Two", showBadgesOnSpotlight: true, components: [
 					{kind: "moon.Icon", icon: "check"},
 					{kind: "moon.Icon", icon: "closex"},
 					{kind: "moon.Icon", icon: "drawer", classes: "float-right"}
 				]}
 			]},
 			{kind: "moon.Item", components: [
-				{kind: "moon.Image", src: "http://placehold.it/180x240&text=Image+Two", alt: "Image Two", showBadgesOnSpotlight: true, components: [
+				{kind: "moon.Image", src: {
+					"hd" : "http://placehold.it/120x160&text=Image+Three",
+					"fhd": "http://placehold.it/180x240&text=Image+Three"
+				}, alt: "Image Three", showBadgesOnSpotlight: true, components: [
 					{kind: "moon.Icon", icon: "closex"}
 				]}
 			]}

--- a/source/ImageMultiRes.js
+++ b/source/ImageMultiRes.js
@@ -40,7 +40,7 @@
 		/**
 		* @private
 		*/
-		classes: 'moon-image',
+		classes: 'moon-image-multires',
 
 		srcChanged: function () {
 			this.src = moon.ri.selectSrc(this.src);


### PR DESCRIPTION
### Issue
`moon.ImageMultiRes` had the `moon-image` class applied, which resulted in the class being applied to both this control and its parent control `moon.Image`, resulting in the margin amount being compounded.

### Fix
We update the images to use the multi-res hash and change the class name to `moon-image-multires`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>