### PR TITLE
Fixes ENYO-819

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -222,6 +222,13 @@
 		isModifyingPanels: false,
 
 		/**
+		* Flag to indicate if the Panels are currently transitioning to a new index
+		*
+		* @private
+		*/
+		transitioning: false,
+
+		/**
 		* Checks the state of panel transitions.
 		*
 		* @return {Boolean} `true` if a transition between panels is currently in progress;


### PR DESCRIPTION
## Issue
Default value for `transitioning` is not defined on moon.Panels so calls to `isTransitioning()` returns `undefined` instead of a boolean.

## Fix
Set the default value of `transitioning` to `false` on the kind

## Notes
Regression from ENYO-719 (PR #1887)

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)