### PR TITLE
Fixes ENYO-771

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -882,7 +882,7 @@
 				} else {
 					this.$.marqueeText.applyStyle('left', this._marquee_adjustDistanceForRTL(distance) + 'px');
 				}
-			}), enyo.platform.firefox ? 100 : 0);
+			}), enyo.platform.firefox ? 100 : 16);
 		},
 
 		/**


### PR DESCRIPTION
## Issue
setTimeout(fn, 0) in _marquee_addAnimationStyles is executing before the browser has rendered/repainted/something? the newly created marqueeText node. As a result, it already has the transform/left style applied so the animation is skipped and it's just painted at it's final position.
## Fix
Increase the timeout to apply the final style value to marquee text

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)