### PR TITLE
ENYO-829: Correct typo for HD resolution.

### DIFF
--- a/samples/ItemSample.js
+++ b/samples/ItemSample.js
@@ -41,7 +41,7 @@ enyo.kind({
 				{kind: "moon.Item", components: [
 					{kind: "moon.MarqueeText", content: "Item with more complex components"},
 					{kind: "moon.Image", src: {
-						"hd" : "http://placehold.it/100x100&text=Image+Three",
+						"hd" : "http://placehold.it/100x100&text=Image+Four",
 						"fhd": "http://placehold.it/150x150&text=Image+Four"
 					}, style: "float: right; margin: 10px 0px 10px 10px", alt: "Image Two"},
 					{kind: "moon.BodyText", style: "margin: 10px 0", content: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa."}


### PR DESCRIPTION
### Issue
In HD resolutions, the fourth image in the sample displays the text `Item 3`. This is a regression from https://github.com/enyojs/moonstone/pull/1909 due to over-aggressive copy/paste. I take solace in being the one to discover my own mistake.

### Fix
Correct the text to display `Item 4` in these cases.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>