### PR TITLE
ENYO-857: moon.FormCheckbox text color is wrong when used in moon.Popup

### DIFF
--- a/css/FormCheckbox.less
+++ b/css/FormCheckbox.less
@@ -47,3 +47,7 @@
 		color: @moon-sub-header-text-color;
 	}
 }
+
+.moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
+	color: @moon-white;
+}

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4602,6 +4602,9 @@ html {
 .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
   color: #a6a6a6;
 }
+.moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
+  color: #ffffff;
+}
 .selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim {
   display: block;
   text-align: center;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4602,6 +4602,9 @@ html {
 .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
   color: #4b4b4b;
 }
+.moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
+  color: #ffffff;
+}
 .selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim {
   display: block;
   text-align: center;


### PR DESCRIPTION
Issue:
Form check box text color is gray when it is used in popup

Fix:
Change color when form check box is used under moon-neutral css.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com