### PR TITLE
ENYO-805: Prevent incorrect marquee distance calculation.

### DIFF
--- a/css/Marquee.less
+++ b/css/Marquee.less
@@ -1,9 +1,11 @@
 .moon-marquee {
-    width: auto;
-    text-overflow: ellipsis;
-    white-space: pre !important;
-    overflow: hidden;
-    text-align: left;
+	width: auto;
+	text-overflow: ellipsis;
+	white-space: pre !important;
+	overflow: hidden;
+	text-align: left;
+	/* Note: This should not be set to "inline" as this will cause incorrect scrollWidth measurements */
+	display: block;
 
 	span {
 		pointer-events: none !important;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -728,6 +728,8 @@ html {
   white-space: pre !important;
   overflow: hidden;
   text-align: left;
+  /* Note: This should not be set to "inline" as this will cause incorrect scrollWidth measurements */
+  display: block;
 }
 .moon-marquee span {
   pointer-events: none !important;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -728,6 +728,8 @@ html {
   white-space: pre !important;
   overflow: hidden;
   text-align: left;
+  /* Note: This should not be set to "inline" as this will cause incorrect scrollWidth measurements */
+  display: block;
 }
 .moon-marquee span {
   pointer-events: none !important;


### PR DESCRIPTION
### Issue
The `scrollWidth` of a `moon.Marquee` can have an incorrect value of 0.

### Fix
This is due to the `display:inline` rule being applied to the `moon.Marquee` control. We add a comment about overriding this rule. Credit to @Djspaceg for the fix.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>