### PR TITLE
ENYO-866: Remove specification of 2.5-gordon branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   npm -g install jshint &&
   echo -e "\x1b\x5b35;1m*** Checking out Enyo\x1b\x5b0m" &&
   cd .. &&
-  git clone --depth 1 -b 2.5-gordon https://github.com/enyojs/enyo.git enyo &&
+  git clone --depth 1 https://github.com/enyojs/enyo.git enyo &&
   mkdir lib &&
   mv moonstone lib/moonstone
 script:


### PR DESCRIPTION
### Issue
We had previously been specifying the `2.5-gordon` branch to checkout for Travis, as this was the only branch in the `enyo` repo that contained resolution-independence support.

### Fix
With the pending merge / explosion, this should be removed as we should not have references to `2.5-gordon` in other branches, and this should be functional shortly as resolution-independence support will be merged into master.

### Notes
This will obviously fail Travis until resolution-independence support is merged into master, but we will likely need to accept this change first before the merge occurs. Blind faith by the integrator. :)

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>