### PR TITLE
ENYO-865: Integrate acceleration config into init.js

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,0 +1,11 @@
+// Override the default holdpulse config to account for greater delays between keydown and keyup
+// events in Moonstone with certain input devices.
+if (enyo && enyo.gesture && enyo.gesture.drag) {
+	enyo.gesture.drag.configureHoldPulse({
+		frequency: 200,
+		events: [{name: 'hold', time: 400}],
+		resume: false,
+		moveTolerance: 16,
+		endHold: 'onMove'
+	});
+}

--- a/init.js
+++ b/init.js
@@ -1,4 +1,19 @@
 (function(enyo, scope) {
+	/**
+	* @namespace moon
+	*/
+	var moon = scope.moon = scope.moon || {};
+
+	/**
+	* Global *design-time* configuration options for Moonstone
+	*
+	* @param {Boolean} Set accelerate `false` to prefer position properties over CSS transforms.
+	* @type {Object}
+	*/
+	moon.config = enyo.mixin({
+		accelerate: true
+	}, moon.config);
+
 	// Override the default holdpulse config to account for greater delays between keydown and keyup
 	// events in Moonstone with certain input devices.
 	if (enyo && enyo.gesture && enyo.gesture.drag) {
@@ -10,4 +25,5 @@
 			endHold: 'onMove'
 		});
 	}
+
 })(enyo, this);

--- a/init.js
+++ b/init.js
@@ -1,11 +1,13 @@
-// Override the default holdpulse config to account for greater delays between keydown and keyup
-// events in Moonstone with certain input devices.
-if (enyo && enyo.gesture && enyo.gesture.drag) {
-	enyo.gesture.drag.configureHoldPulse({
-		frequency: 200,
-		events: [{name: 'hold', time: 400}],
-		resume: false,
-		moveTolerance: 16,
-		endHold: 'onMove'
-	});
-}
+(function(enyo, scope) {
+	// Override the default holdpulse config to account for greater delays between keydown and keyup
+	// events in Moonstone with certain input devices.
+	if (enyo && enyo.gesture && enyo.gesture.drag) {
+		enyo.gesture.drag.configureHoldPulse({
+			frequency: 200,
+			events: [{name: 'hold', time: 400}],
+			resume: false,
+			moveTolerance: 16,
+			endHold: 'onMove'
+		});
+	}
+})(enyo, this);

--- a/package.js
+++ b/package.js
@@ -1,5 +1,6 @@
 enyo.depends(
 	'version.js',
+	'init.js',
 	'css',
 	'source',
 	'moonstone.design'

--- a/version.js
+++ b/version.js
@@ -5,19 +5,9 @@
 
 		@namespace moon
 	*/
-	var moon = scope.moon = scope.moon || {};
 
 	if (enyo && enyo.version) {
 		enyo.version.moonstone = "2.5.4-pre.3";
 	}
 
-	/**
-	* Global *design-time* configuration options for Moonstone
-	*
-	* @param {Boolean} accelerate `true` to prefer CSS transforms over position properties
-	* @type {Object}
-	*/
-	moon.config = enyo.mixin({
-		accelerate: false
-	}, moon.config);
 })(enyo, this);


### PR DESCRIPTION
### Issue
We want to enable acceleration by default for standard builds of Moonstone.

### Fix
We integrate the existing `moon.config` logic into `init.js`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>