### PR TITLE
ENYO-888: Remove stale reference to Sample.css

### DIFF
--- a/samples/package.js
+++ b/samples/package.js
@@ -99,8 +99,6 @@ enyo.depends(
 	"ProgressSample.js",
 	"RadioItemSample.css",
 	"RadioItemSample.js",
-	"Sample.css",
-	"Sample.js",
 	"Scroller2dSample.css",
 	"Scroller2dSample.js",
 	"ScrollerHorizontalSample.css",


### PR DESCRIPTION
### Issue
There is a stale reference to `Sample.css` and `Sample.html` in the `package.js` for the sample folder, which can cause build issues.

### Fix
The stale references have been removed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>