### PR TITLE
ENYO-900: Skip creation of selection overlay div until it is actually se...

### DIFF
--- a/source/SelectionOverlaySupport.js
+++ b/source/SelectionOverlaySupport.js
@@ -91,9 +91,8 @@
 		* @method
 		* @private
 		*/
-		create: enyo.inherit(function (sup) {
+		createOverlay: enyo.inherit(function (sup) {
 			return function () {
-				sup.apply(this, arguments);
 				this.createChrome(this._selectionScrim);
 				this.selectionOverlayHorizontalOffset = this.selectionOverlayHorizontalOffset === undefined ? 50 : this.selectionOverlayHorizontalOffset;
 				this.selectionOverlayVerticalOffset = this.selectionOverlayVerticalOffset === undefined ? 50 : this.selectionOverlayVerticalOffset;
@@ -117,7 +116,7 @@
 		* @private
 		*/
 		_selectionScrim: [
-			{classes: 'enyo-fit moon-selection-overlay-support-scrim', components: [
+			{name: 'selectionScrim', classes: 'enyo-fit moon-selection-overlay-support-scrim', components: [
 				{name:'selectionScrimIcon', kind: 'moon.Icon', small: false, icon: "check", spotlight: false}
 			]}
 		],
@@ -134,7 +133,17 @@
 		*/
 		selectionOverlayHorizontalOffsetChanged: function () {
 			this.$.selectionScrimIcon.applyStyle((this.rtl ? 'right' : 'left'), this.selectionOverlayHorizontalOffset + '%');
-		}
+		},
+
+		selectedChanged: enyo.inherit(function (sup) {
+			return function () {
+				sup.apply(this, arguments);
+				if (this.selected && !this.$.selectionScrim) {
+					this.createOverlay();
+					this.$.selectionScrim.render();
+				}
+			};
+		})
 	};
 
 })(enyo, this);


### PR DESCRIPTION
...lected

Issue:
App is creating many DataGridList items on initial render which is creating SelectionOverlaySupport div also.
This can leads to bad app launch time performance.

Fix:
- We can skip creation of selection overlay div until it is actually selected.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com