### PR TITLE
ENYO-892: Prevent unnecessary re-setting of ilib locale.

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -104,7 +104,7 @@
 		create: function () {
 			this.inherited(arguments);
 		},
-		
+
 		/**
 		* @private
 		*/
@@ -119,7 +119,7 @@
 		 * When [iLib]{@glossary ilib} is supported, calculates the minimum year in the
 		 * current calendar. Otherwise, returns the value of the published property
 		 * [minYear]{@link moon.DatePicker#minYear}.
-		 * 
+		 *
 		 * @private
 		 */
 		getMinYear: function() {
@@ -140,12 +140,12 @@
 				return this.minYear;
 			}
 		},
-		
+
 		/**
 		 * When [iLib]{@glossary ilib} is supported, calculates the maximum year in the
 		 * current calendar. Otherwise, returns the value of the published property
 		 * [maxYear]{@link moon.DatePicker#maxYear}.
-		 * 
+		 *
 		 * @private
 		 */
 		getMaxYear: function() {
@@ -166,7 +166,7 @@
 				return this.maxYear;
 			}
 		},
-		
+
 
 		/**
 		* @private
@@ -282,16 +282,22 @@
 			if (this.value && typeof ilib !== 'undefined') {
 				this.localeValue = ilib.Date.newInstance({unixtime: this.value.getTime(), timezone: "local"});
 			}
-			var values = this.calcPickerValues();
 
-			this.$.year.set('value', values.fullYear);
-			this.$.month.set('value', values.month);
-			this.$.day.set('value', values.date);
-			this.$.month.set('max', values.maxMonths);
-			this.$.day.set('max', this.monthLength(values.fullYear, values.month));
-			this.$.currentValue.setContent(this.formatValue());
+			if (this.localeValue || this.value) {
+				var values = this.calcPickerValues();
+
+				this.$.year.set('value', values.fullYear);
+				this.$.month.set('value', values.month);
+				this.$.day.set('value', values.date);
+				this.$.month.set('max', values.maxMonths);
+				this.$.day.set('max', this.monthLength(values.fullYear, values.month));
+				this.$.currentValue.setContent(this.formatValue());
+			}
 		},
 
+		/**
+		* @private
+		*/
 		calcPickerValues: function () {
 			var values = {};
 			if (typeof ilib !== 'undefined') {

--- a/source/DateTimePickerBase.js
+++ b/source/DateTimePickerBase.js
@@ -173,7 +173,6 @@
 			};
 
 			fmtParams.locale = this.locale;
-			ilib.setLocale(this.locale);
 			this.iLibLocale = ilib.getLocale();
 			this._tf = new ilib.DateFmt(fmtParams);
 		},


### PR DESCRIPTION
### tl;dr
ilib's locale can be set to the wrong value when using `enyo.updateLocale` where there are multiple date/time pickers. This was exposed by another issue, both of which have been addressed.

### Issue
This was a seemingly minor issue that pointed to larger problems. In the `DatePickerSample`, changing the locale resulted in the disabled picker becoming valued. Technically a regression from https://github.com/enyojs/moonstone/pull/1800, the change in that PR was necessary to properly change locales without affecting other samples (i.e. via Sampler). This pointed to the fact that whenever we receive the `onlocalechange` signal (in this case triggered by a call to `enyo.updateLocale`), if there are multiple `moon.DatePicker` or `moon.TimePicker` controls, the locale of ilib would be set to the *original* locale of the first control, and subsequent controls would not evaluate the conditional in `handleLocaleChangeEvent` to be true, resulting in the value of the control being initialized by executing the other code path. In addition (and arguably more important), the value of ilib's locale would be incorrect.

### Fix
The fix is two-pronged. First, in `moon.DateTimePickerBase`, the setting of ilib's locale is removed from `initiLib` as ilib now handles null values and will already be properly initialized to the local value. In the event that the locale is changed, resulting in the `onlocalechange` signal, ilib will have already responded to this signal and updated its own locale. In the other case of programmatically setting the locale of this control, there is code in the `localeChanged` function to set ilib's locale. Second, we add some guard code to `setChildPickers` in `moon.DatePicker` so that the child pickers are not initialized if our control is not valued. Without the guard code, the child pickers would have null values set, which would ultimately result in our `moon.DatePicker` control being valued unintentionally.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>