### PR TITLE
ENYO-904: light-package.js doesn't include init.js

### DIFF
--- a/light-package.js
+++ b/light-package.js
@@ -1,5 +1,6 @@
 enyo.depends(
 	"version.js",
+	'init.js',
 	"css/light-package.js",
 	"source",
 	"moonstone.design"


### PR DESCRIPTION
### Issue:
Light theme app such as Settings are not able to find moon.config.accelerate on app launch.

### Fix:
Add init.js into light-package.js

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com