### PR TITLE
ENYO-905: Adding min-height on Dialog Title Area

### DIFF
--- a/css/Dialog.less
+++ b/css/Dialog.less
@@ -8,6 +8,9 @@
 .moon-dialog-sub-title {
 	font-size: @moon-superscript-text-size;
 }
+.moon-dialog-client-wrapper {
+	min-height: 114px;
+}
 .moon-dialog-content {
 	margin: 0 0 0;
 }

--- a/css/Dialog.less
+++ b/css/Dialog.less
@@ -9,7 +9,7 @@
 	font-size: @moon-superscript-text-size;
 }
 .moon-dialog-client-wrapper {
-	min-height: 102px;
+	min-height: 108px;
 }
 .moon-dialog-content {
 	margin: 0 0 0;

--- a/css/Dialog.less
+++ b/css/Dialog.less
@@ -9,7 +9,7 @@
 	font-size: @moon-superscript-text-size;
 }
 .moon-dialog-client-wrapper {
-	min-height: 114px;
+	min-height: 102px;
 }
 .moon-dialog-content {
 	margin: 0 0 0;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3493,7 +3493,7 @@ html {
   font-size: 1rem;
 }
 .moon-dialog-client-wrapper {
-  min-height: 4.75rem;
+  min-height: 4.25rem;
 }
 .moon-dialog-content {
   margin: 0 0 0;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3492,6 +3492,9 @@ html {
 .moon-dialog-sub-title {
   font-size: 1rem;
 }
+.moon-dialog-client-wrapper {
+  min-height: 4.75rem;
+}
 .moon-dialog-content {
   margin: 0 0 0;
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3493,7 +3493,7 @@ html {
   font-size: 1rem;
 }
 .moon-dialog-client-wrapper {
-  min-height: 4.25rem;
+  min-height: 4.5rem;
 }
 .moon-dialog-content {
   margin: 0 0 0;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3493,7 +3493,7 @@ html {
   font-size: 1rem;
 }
 .moon-dialog-client-wrapper {
-  min-height: 4.75rem;
+  min-height: 4.25rem;
 }
 .moon-dialog-content {
   margin: 0 0 0;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3492,6 +3492,9 @@ html {
 .moon-dialog-sub-title {
   font-size: 1rem;
 }
+.moon-dialog-client-wrapper {
+  min-height: 4.75rem;
+}
 .moon-dialog-content {
   margin: 0 0 0;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3493,7 +3493,7 @@ html {
   font-size: 1rem;
 }
 .moon-dialog-client-wrapper {
-  min-height: 4.25rem;
+  min-height: 4.5rem;
 }
 .moon-dialog-content {
   margin: 0 0 0;

--- a/source/Dialog.js
+++ b/source/Dialog.js
@@ -114,6 +114,7 @@
 			{name: 'closeButton', kind: 'moon.IconButton', icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', showing:false},
 
 			{
+				classes: 'moon-dialog-client-wrapper',
 				components: [
 					{name: 'client', classes: 'moon-dialog-client'},
 					{components: [


### PR DESCRIPTION
Regression of https://github.com/enyojs/moonstone/pull/1889

## Issue:
After change the client layout to be float right, the divider area can be also floated abound by buttons.

## Fix:
Adding min-height on Title area of Dialog popup so divider is not collapsed with client buttons.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com