### PR TITLE
ENYO-923: Stop marquee when window throw blur event

### DIFF
--- a/samples/MarqueeSample.css
+++ b/samples/MarqueeSample.css
@@ -1,8 +1,10 @@
-
 .moon-marquee-start-on-render {
 	width: 600px;
 }
 .moon-marquee-start-on-focus {
+	width: 600px;
+}
+.moon-marquee-start-on-hover {
 	width: 600px;
 }
 .moon-marquee-start-on-focus.spotlight {

--- a/samples/MarqueeSample.js
+++ b/samples/MarqueeSample.js
@@ -22,6 +22,15 @@ enyo.kind({
 				{name: "marqueeStartOnFocus3", marqueeOnSpotlight: true, mixins: ["moon.MarqueeSupport", "moon.MarqueeItem"], spotlight: true, classes: "moon-marquee-start-on-focus", content: "This is third long text for marquee test which is not syncronized with first and second marquee text"},
 				{tag: "br"},
 
+				{kind: "moon.Divider", content: "Marquee on Hover:"},
+				{kind: "moon.MarqueeDecorator", marqueeOnHover: true, marqueeOnSpotlight: false, components: [
+					{name: "marqueeStartOnHover1", kind: "moon.MarqueeText", classes: "moon-marquee-start-on-hover", content: "This is first long text for marquee test which is starting marquee on mouse hover"},
+					{name: "marqueeStartOnHover2", kind: "moon.MarqueeText", classes: "moon-marquee-start-on-hover", content: "This is second long text for marquee test which is syncronized with first marquee text"}
+				]},
+				{name: "marqueeStartOnHover3", marqueeOnHover: true, marqueeOnSpotlight: false, mixins: ["moon.MarqueeSupport", "moon.MarqueeItem"], classes: "moon-marquee-start-on-hover", content: "This is third long text for marquee test which is not syncronized with first and second marquee text"},
+				{tag: "br"},
+
+
 				{kind: "moon.Divider", content: "Marquee on content changed:"},
 				{kind: "moon.InputDecorator", components: [
 					{kind: "moon.Input", placeholder: "JUST TYPE", oninput:"contentChange"}

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -296,6 +296,9 @@
 			this._marquee_isHovered = true;
 			if ((this.marqueeOnHover && !this.marqueeOnSpotlight) ||
 			(this.disabled && this.marqueeOnSpotlight)) {
+				if (this.marqueeOnHover) {
+					moon.Marquee.setMarqueeOnHoverControl(this);
+				}
 				this.startMarquee();
 			}
 		},
@@ -306,6 +309,9 @@
 		_marquee_leave: function (sender, ev) {
 			this._marquee_isHovered = false;
 			if ((this.marqueeOnHover && !this.marqueeOnSpotlight) || (this.disabled && this.marqueeOnSpotlight)) {
+				if (this.marqueeOnHover) {
+					moon.Marquee.setMarqueeOnHoverControl(null);
+				}
 				this.stopMarquee();
 			}
 		},
@@ -1108,4 +1114,26 @@
 		style: 'overflow: hidden;'
 	});
 
+
+	moon.Marquee = {
+		_marqueeOnHoverControl: null,
+
+		setMarqueeOnHoverControl: function(oControl) {
+			this._marqueeOnHoverControl = oControl;
+		},
+
+		getMarqueeOnHoverControl: function() {
+			return this._marqueeOnHoverControl;
+		}
+	};
+
+	enyo.dispatcher.features.push(
+		function (e) {
+			if ("blur" === e.type) {
+				// Stop marquee when onblur event comes from window
+				var c = moon.Marquee.getMarqueeOnHoverControl();
+				if (c) c._marquee_leave();
+			}
+		}
+	);
 })(enyo, this);

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -245,7 +245,7 @@
 		*/
 		destroy: enyo.inherit(function (sup) {
 			return function () {
-				if (_getMarqueeOnHoverControl()) 
+				if (this == _getMarqueeOnHoverControl()) 
 					_setMarqueeOnHoverControl(null);
 				sup.apply(this, arguments);
 			};

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -245,8 +245,9 @@
 		*/
 		destroy: enyo.inherit(function (sup) {
 			return function () {
-				if (this == _getMarqueeOnHoverControl()) 
+				if (this === _getMarqueeOnHoverControl()) {
 					_setMarqueeOnHoverControl(null);
+				}
 				sup.apply(this, arguments);
 			};
 		}),

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -1,4 +1,15 @@
 (function (enyo, scope) {
+
+	var _marqueeOnHoverControl = null;
+
+	this._setMarqueeOnHoverControl = function(oControl) {
+		_marqueeOnHoverControl = oControl;
+	};
+
+	this._getMarqueeOnHoverControl = function() {
+		return _marqueeOnHoverControl;
+	};
+
 	/**
 	* Fires to queue up a list of child animations.
 	*
@@ -234,8 +245,8 @@
 		*/
 		destroy: enyo.inherit(function (sup) {
 			return function () {
-				if (moon.Marquee.getMarqueeOnHoverControl()) 
-					moon.Marquee.setMarqueeOnHoverControl(null);
+				if (_getMarqueeOnHoverControl()) 
+					_setMarqueeOnHoverControl(null);
 				sup.apply(this, arguments);
 			};
 		}),
@@ -309,7 +320,7 @@
 			if ((this.marqueeOnHover && !this.marqueeOnSpotlight) ||
 			(this.disabled && this.marqueeOnSpotlight)) {
 				if (this.marqueeOnHover) {
-					moon.Marquee.setMarqueeOnHoverControl(this);
+					_setMarqueeOnHoverControl(this);
 				}
 				this.startMarquee();
 			}
@@ -322,7 +333,7 @@
 			this._marquee_isHovered = false;
 			if ((this.marqueeOnHover && !this.marqueeOnSpotlight) || (this.disabled && this.marqueeOnSpotlight)) {
 				if (this.marqueeOnHover) {
-					moon.Marquee.setMarqueeOnHoverControl(null);
+					_setMarqueeOnHoverControl(null);
 				}
 				this.stopMarquee();
 			}
@@ -1126,23 +1137,11 @@
 		style: 'overflow: hidden;'
 	});
 
-	moon.Marquee = new function() {
-		var _marqueeOnHoverControl = null;
-
-		this.setMarqueeOnHoverControl = function(oControl) {
-			_marqueeOnHoverControl = oControl;
-		};
-
-		this.getMarqueeOnHoverControl = function() {
-			return _marqueeOnHoverControl;
-		};
-	};
-
 	enyo.dispatcher.features.push(
 		function (e) {
 			if ("blur" === e.type && window === e.target) {
 				// Stop marquee when onblur event comes from window
-				var c = moon.Marquee.getMarqueeOnHoverControl();
+				var c = _getMarqueeOnHoverControl();
 				if (c) c._marquee_leave();
 			}
 		}

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -1,12 +1,12 @@
 (function (enyo, scope) {
 
-	var _marqueeOnHoverControl = null;
+	var _marqueeOnHoverControl = null,
 
-	this._setMarqueeOnHoverControl = function(oControl) {
+	_setMarqueeOnHoverControl = function(oControl) {
 		_marqueeOnHoverControl = oControl;
-	};
+	},
 
-	this._getMarqueeOnHoverControl = function() {
+	_getMarqueeOnHoverControl = function() {
 		return _marqueeOnHoverControl;
 	};
 

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -234,7 +234,8 @@
 		*/
 		destroy: enyo.inherit(function (sup) {
 			return function () {
-				moon.Marquee.setMarqueeOnHoverControl(null);
+				if (moon.Marquee.getMarqueeOnHoverControl()) 
+					moon.Marquee.setMarqueeOnHoverControl(null);
 				sup.apply(this, arguments);
 			};
 		}),
@@ -1125,21 +1126,17 @@
 		style: 'overflow: hidden;'
 	});
 
+	moon.Marquee = new function() {
+		var _marqueeOnHoverControl = null;
 
-	enyo.singleton({
-		name: 'moon.Marquee',
+		this.setMarqueeOnHoverControl = function(oControl) {
+			_marqueeOnHoverControl = oControl;
+		};
 
-		_marqueeOnHoverControl: null,
-
-		setMarqueeOnHoverControl: function(oControl) {
-			this._marqueeOnHoverControl = oControl;
-		},
-
-		getMarqueeOnHoverControl: function() {
-			return this._marqueeOnHoverControl;
-		}
-	});
-
+		this.getMarqueeOnHoverControl = function() {
+			return _marqueeOnHoverControl;
+		};
+	};
 
 	enyo.dispatcher.features.push(
 		function (e) {

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -232,6 +232,17 @@
 		* @method
 		* @private
 		*/
+		destroy: enyo.inherit(function (sup) {
+			return function () {
+				moon.Marquee.setMarqueeOnHoverControl(null);
+				sup.apply(this, arguments);
+			};
+		}),
+
+		/**
+		* @method
+		* @private
+		*/
 		dispatchEvent: enyo.inherit(function (sup) {
 			return function (sEventName, oEvent, oSender) {
 				// Needed for proper onenter/onleave handling
@@ -1115,7 +1126,9 @@
 	});
 
 
-	moon.Marquee = {
+	enyo.singleton({
+		name: 'moon.Marquee',
+
 		_marqueeOnHoverControl: null,
 
 		setMarqueeOnHoverControl: function(oControl) {
@@ -1125,11 +1138,12 @@
 		getMarqueeOnHoverControl: function() {
 			return this._marqueeOnHoverControl;
 		}
-	};
+	});
+
 
 	enyo.dispatcher.features.push(
 		function (e) {
-			if ("blur" === e.type) {
+			if ("blur" === e.type && window === e.target) {
 				// Stop marquee when onblur event comes from window
 				var c = moon.Marquee.getMarqueeOnHoverControl();
 				if (c) c._marquee_leave();


### PR DESCRIPTION
### Issue:
On app change state between BG and FG, div which is under cursor is not getting onleave event.
While marquee is flow on hover, it is not stop because it is not getting onleave event when app  goes to BG.

### Fix:
- Add blur on windowEvents array to handle on dispatcher feature. (Core)
- Remember last hovered marqueeSupport control on global variable. (Marquee)
- Call onleave event handler of last hovered marqueeSupport control when app is getting onblur event. (Marquee)

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com