### PR TITLE
Added redirection code to catch samples being loaded with the old-style ... (2.5)

### DIFF
--- a/samples/.htaccess
+++ b/samples/.htaccess
@@ -9,11 +9,13 @@ RewriteBase /
 RewriteCond $0#%{REQUEST_URI} ([^#]*)#(.*)\1$
 RewriteRule ^.*$ - [E=CWD:%2]
 
+# Requiesting a file that doesn't exist
 RewriteCond %{REQUEST_FILENAME} !-f
-RewriteRule ^index\.html?$ %{ENV:CWD}Sample.html?All [R,QSA,L]
+RewriteRule ^index\.html?$ %{ENV:CWD}Sample.html?All [NC,R,QSA,L]
 
+# Requesting the current directory or a non-existant index.htm(l)
 RewriteCond %{REQUEST_FILENAME} -d
-RewriteCond %{REQUEST_FILENAME}index.html !-f [NC]
+RewriteCond %{REQUEST_FILENAME}index.html !-f
 RewriteRule .* %{ENV:CWD}Sample.html?All [R,QSA,L]
 
 # verify that we're only looking for files ending in htm(l) that don't exist

--- a/samples/Sample.html
+++ b/samples/Sample.html
@@ -6,6 +6,17 @@
 	<title>Moonstone Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<script type="text/javascript">
+	;(function (scope) {
+		// If we're trying to access a Sample with a locale, just automatically redirect to the All code.
+		// This should be before any of the packages so we don't have to load them twice.
+		if (!scope.location.search.match(/^\?All/) && scope.location.hash.match(/\//)) {
+			// Check for the presence of a / in the hash. If it's there, inject the All Sample into the
+			// URL and forward the hash portion through.
+			 scope.location.href = scope.location.href.replace(/#/, '?All#');
+		}
+	})(this);
+	</script>
 	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
 	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
 	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>


### PR DESCRIPTION
Cherry-picking the changes from https://github.com/enyojs/moonstone/pull/1957 into `2.5-upkeep`, creating a PR for tracking purposes.