### PR TITLE
ENYO-519 : add moon.DayPicker component as a Dreadlocks UX requirements

### DIFF
--- a/samples/ExpandablePickerSample.js
+++ b/samples/ExpandablePickerSample.js
@@ -43,6 +43,7 @@ enyo.kind({
 						{kind: "moon.ExpandableIntegerPicker", disabled:true, autoCollapse: true, content: "Disabled Integer Picker", value: 2, min: 1, max: 15, unit: "sec"},
 						{kind: "moon.DatePicker", noneText: "Pick a Date", content: "Date Picker"},
 						{kind: "moon.TimePicker", noneText: "Pick a Date", content: "Time Picker"},
+						{kind: "moon.DayPicker", noneText: "Pick a Day", content: "Day Picker"},
 						{kind: "moon.ExpandableInput", noneText: "Enter text", content: "Expandable Input", placeholder: "Enter text"},
 						{kind: "moon.ExpandableDataPicker", content: "Expandable Data Picker", noneText: "Nothing Selected", components: [
 							{bindings: [

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -1,7 +1,7 @@
 (function (enyo, scope) {
 	/**
 	* {@link moon.DayPicker}, which extends {@link moon.ExpandablePicker}, is
-	* a drop-down picker menu that solicits day of the week from the user. 
+	* a drop-down picker menu that solicits day of the week from the user.
 	*
 	* ```
 	* {kind: 'moon.DayPicker'}
@@ -13,7 +13,7 @@
 	*
 	* The content of representative value can be changed.
 	* ```
-	* {kind: 'moon.DayPicker', everyWeekday:'Weekdays', everyWeekend:'Weekends', everyday:'Daily'}
+	* {kind: 'moon.DayPicker', everyWeekdayText:'Weekdays', everyWeekendText:'Weekends', everyDayText:'Daily'}
 	* ```
 	*
 	* @class moon.DayPicker
@@ -47,7 +47,7 @@
 		/**
 		* @private
 		*/
-		content: moon.$L('Select days'), 
+		content: moon.$L('Select days'),
 
 		/**
 		* @private
@@ -59,10 +59,10 @@
 			* Text to be displayed when all of the day are selected.
 			*
 			* @type {String}
-			* @default 'Everyday'
+			* @default 'Every Day'
 			* @public
 			*/
-			everydayText: moon.$L('Everyday'),
+			everyDayText: moon.$L('Every Day'),
 
 			/**
 			* Text to be displayed when all of the weekday are selected.
@@ -125,7 +125,7 @@
 			var joinIndex = this.selectedIndex.join();
 
 			if (indexLength === 7) {
-				return this.everydayText;
+				return this.everyDayText;
 			} else if (indexLength === 5 && joinIndex == '0,1,2,3,4') {
 				return this.everyWeekdayText;
 			} else if (indexLength === 2 && joinIndex == '5,6') {

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -1,0 +1,153 @@
+(function (enyo, scope) {
+	/**
+	* {@link moon.DayPicker}, which extends {@link moon.ExpandablePicker}, is
+	* a drop-down picker menu that solicits day of the week from the user. 
+	*
+	* ```
+	* {kind: 'moon.DayPicker'}
+	* ```
+	*
+	* When the picker is minimized, the currently selected day are
+	* displayed as subtext below the picker label. And if the picker select every weekday,
+	* subtext will be changed 'Every Weekday' automatically.
+	*
+	* The content of representative value can be changed.
+	* ```
+	* {kind: 'moon.DayPicker', everyWeekday:'Weekdays', everyWeekend:'Weekends', everyday:'Daily'}
+	* ```
+	*
+	* @class moon.DayPicker
+	* @extends moon.ExpandablePicker
+	* @ui
+	* @public
+	*/
+	enyo.kind(
+		/** @lends moon.DayPicker.prototype */ {
+
+		/**
+		* @private
+		*/
+		name: 'moon.DayPicker',
+
+		/**
+		* @private
+		*/
+		kind: 'moon.ExpandablePicker',
+
+		/**
+		* @private
+		*/
+		autoCollapseOnSelect: false,
+
+		/**
+		* @private
+		*/
+		multipleSelection: true,
+
+		/**
+		* @private
+		*/
+		content: 'Select days', 
+
+		/**
+		* @private
+		* @lends moon.DayPicker.prototype
+		*/
+		published: {
+
+			/**
+			* Text to be displayed when all of the day are selected.
+			*
+			* @type {String}
+			* @default 'Everyday'
+			* @public
+			*/
+			everyday: 'Everyday',
+
+			/**
+			* Text to be displayed when all of the weekday are selected.
+			*
+			* @type {String}
+			* @default 'Every Weekday'
+			* @public
+			*/
+			everyWeekday: 'Every Weekday',
+
+			/**
+			* Text to be displayed when all of the weekend are selected.
+			*
+			* @type {String}
+			* @default 'Every Weekend'
+			* @public
+			*/
+			everyWeekend: 'Every Weekend',
+
+			/**
+			* Text to be displayed as the current value if no item is currently selected.
+			*
+			* @type {String}
+			* @default 'Nothing selected'
+			* @public
+			*/
+			noneText: 'Nothing selected',
+		},
+
+		/**
+		* @private
+		*/
+		dayOfTheWeek: [
+			{content: "Monday"},
+			{content: "Tuesday"},
+			{content: "Wednesday"},
+			{content: "Thursday"},
+			{content: "Friday"},
+			{content: "Saturday"},
+			{content: "Sunday"}
+		],
+
+		/**
+		* @private
+		*/
+		create: enyo.inherit(function (sup) {
+			return function() {
+				// super initialization
+				sup.apply(this, arguments);
+
+				this.createComponents(this.dayOfTheWeek);
+			};
+		}),
+
+		/**
+		* @private
+		*/
+		multiSelectCurrentValue: function () {
+			var indexLength = this.selectedIndex.length;
+			var joinIndex = this.selectedIndex.join();
+
+			if (indexLength === 7) {
+				return this.everyday;
+			} else if (indexLength === 5 && joinIndex == "0,1,2,3,4") {
+				return this.everyWeekday;
+			} else if (indexLength === 2 && joinIndex == "5,6") {
+				return this.everyweekend;
+			}
+
+			var controls = this.getCheckboxControls();
+			var str = '';
+			this.selectedIndex.sort();
+			for (var i=0; i < this.selectedIndex.length; i++) {
+				if (!str) {
+					str = controls[this.selectedIndex[i]].getContent().substring(0,3);
+				} else {
+					str = str + ', ' + controls[this.selectedIndex[i]].getContent().substring(0,3);
+				}
+			}
+			if (!str) {
+				str = this.getNoneText();
+			}
+			return str;
+		}
+
+	});
+
+})(enyo, this);

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -219,12 +219,12 @@
 			case 7 :
 				return this.everyDayText;
 			case 5 :
-				if (!hasWeekEnd) {
+				if (hasWeekEnd === false) {
 					return this.everyWeekdayText;
 				}
 				break;
 			case 2 :
-				if (hasWeekEnd) {
+				if (hasWeekEnd === true) {
 					return this.everyWeekendText;
 				}
 				break;

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -47,7 +47,7 @@
 		/**
 		* @private
 		*/
-		content: 'Select days', 
+		content: moon.$L('Select days'), 
 
 		/**
 		* @private
@@ -62,7 +62,7 @@
 			* @default 'Everyday'
 			* @public
 			*/
-			everyday: 'Everyday',
+			everydayText: moon.$L('Monday'),
 
 			/**
 			* Text to be displayed when all of the weekday are selected.
@@ -71,7 +71,7 @@
 			* @default 'Every Weekday'
 			* @public
 			*/
-			everyWeekday: 'Every Weekday',
+			everyWeekdayText: moon.$L('Every Weekday'),
 
 			/**
 			* Text to be displayed when all of the weekend are selected.
@@ -80,7 +80,7 @@
 			* @default 'Every Weekend'
 			* @public
 			*/
-			everyWeekend: 'Every Weekend',
+			everyWeekendText: moon.$L('Every Weekend'),
 
 			/**
 			* Text to be displayed as the current value if no item is currently selected.
@@ -89,20 +89,20 @@
 			* @default 'Nothing selected'
 			* @public
 			*/
-			noneText: 'Nothing selected',
+			noneText: moon.$L('Nothing selected')
 		},
 
 		/**
 		* @private
 		*/
 		dayOfTheWeek: [
-			{content: "Monday"},
-			{content: "Tuesday"},
-			{content: "Wednesday"},
-			{content: "Thursday"},
-			{content: "Friday"},
-			{content: "Saturday"},
-			{content: "Sunday"}
+			{content: 'Monday'},
+			{content: 'Tuesday'},
+			{content: 'Wednesday'},
+			{content: 'Thursday'},
+			{content: 'Friday'},
+			{content: 'Saturday'},
+			{content: 'Sunday'}
 		],
 
 		/**
@@ -125,16 +125,15 @@
 			var joinIndex = this.selectedIndex.join();
 
 			if (indexLength === 7) {
-				return this.everyday;
-			} else if (indexLength === 5 && joinIndex == "0,1,2,3,4") {
-				return this.everyWeekday;
-			} else if (indexLength === 2 && joinIndex == "5,6") {
-				return this.everyweekend;
+				return this.everydayText;
+			} else if (indexLength === 5 && joinIndex == '0,1,2,3,4') {
+				return this.everyWeekdayText;
+			} else if (indexLength === 2 && joinIndex == '5,6') {
+				return this.everyWeekendText;
 			}
 
 			var controls = this.getCheckboxControls();
 			var str = '';
-			this.selectedIndex.sort();
 			for (var i=0; i < this.selectedIndex.length; i++) {
 				if (!str) {
 					str = controls[this.selectedIndex[i]].getContent().substring(0,3);
@@ -142,10 +141,7 @@
 					str = str + ', ' + controls[this.selectedIndex[i]].getContent().substring(0,3);
 				}
 			}
-			if (!str) {
-				str = this.getNoneText();
-			}
-			return str;
+			return str || this.getNoneText();
 		}
 
 	});

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -146,15 +146,16 @@
 				this.days = sdf.getDaysOfWeek();
 				this.firstDayOfWeek = this.firstDayOfWeek || li.getFirstDayOfWeek();
 
+				var index;
 				if (this.firstDayOfWeek == 1) {
-					for (var i = 1; i < this.daysComponents.length; i++) {
-						this.daysComponents[i-1].content = daysFullName[i];
+					for (index = 1; index < this.daysComponents.length; index++) {
+						this.daysComponents[index-1].content = daysFullName[index];
 					}
 					this.daysComponents[6].content = daysFullName[0];
 					this.days.push(this.days.shift());
 				} else {
-					for (var i = 0; i < this.daysComponents.length; i++) {
-						this.daysComponents[i].content = daysFullName[i];
+					for (index = 0; index < this.daysComponents.length; index++) {
+						this.daysComponents[index].content = daysFullName[index];
 					}
 				}
 			}

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -62,7 +62,7 @@
 			* @default 'Everyday'
 			* @public
 			*/
-			everydayText: moon.$L('Monday'),
+			everydayText: moon.$L('Everyday'),
 
 			/**
 			* Text to be displayed when all of the weekday are selected.

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -89,7 +89,7 @@
 			* @default 'Nothing selected'
 			* @public
 			*/
-			noneText: moon.$L('Nothing selected'),
+			noneText: moon.$L('Nothing selected')
 		},
 
 		/**
@@ -213,7 +213,6 @@
 		*/
 		checkDays: function () {
 			var indexLength = this.selectedIndex.length;
-			var joinIndex = this.selectedIndex.join();
 			var hasWeekEnd = this.checkWeekEnd();
 
 			switch (indexLength) {

--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -205,7 +205,9 @@
 		],
 
 		/**
-		* @private
+		*  'create()' can be overridden by subkinds, such as moon.DayPicker
+		*
+		* @protected
 		*/
 		create: enyo.inherit(function (sup) {
 			return function() {

--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -205,9 +205,7 @@
 		],
 
 		/**
-		*  'create()' can be overridden by subkinds, such as moon.DayPicker
-		*
-		* @protected
+		* @private
 		*/
 		create: enyo.inherit(function (sup) {
 			return function() {
@@ -245,7 +243,9 @@
 		},
 
 		/**
-		* @private
+		*  'multiSelectCurrentValue()' can be overridden by subkinds, such as moon.DayPicker
+		*
+		* @protected
 		*/
 		multiSelectCurrentValue: function () {
 			if (!this.multipleSelection) {

--- a/source/package.js
+++ b/source/package.js
@@ -36,6 +36,7 @@ enyo.depends(
 	'PagingControl.js',
 	'DateTimePickerBase.js',
 	'DatePicker.js',
+	'DayPicker.js',
 	'TimePicker.js',
 	'Input.js',
 	'InputDecorator.js',


### PR DESCRIPTION
### Issue
There is a requirement for supporting string overlay on Expandable picker in Dreadlocks.
(Especially, it target expandable picker which can select day of the week and shows representative value )

### Solution
For resolving the requirement, make a new kind which inherited from Expandable Picker and add features which are described in ENYO-519

DCO-1.1-Signed-Off-By: Sungbae Cho sb.cho@lge.com