### PR TITLE
ENYO-874: Settings app has a problem of not showing scroller content und...

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -254,6 +254,7 @@
 				oPanel = this.createComponent(info, moreInfo);
 			oPanel.render();
 			this.reflow();
+			oPanel.show();
 			oPanel.resize();
 			this.setIndex(lastIndex+1);
 			this.isModifyingPanels = false;
@@ -298,15 +299,16 @@
 				oPanels[nPanel].render();
 			}
 			this.reflow();
-			for (nPanel = 0; nPanel < oPanels.length; ++nPanel) {
-				oPanels[nPanel].resize();
-			}
-
 			if (options.targetIndex || options.targetIndex === 0) {
 				lastIndex = options.targetIndex;
 			} else {
 				lastIndex++;
 			}
+			oPanels[lastIndex].show();
+			for (nPanel = 0; nPanel < oPanels.length; ++nPanel) {
+				oPanels[nPanel].resize();
+			}
+
 			// If transition was explicitly set to false, since null or undefined indicate "never set" or unset
 			if (options.transition === false) {
 				this.setIndexDirect(lastIndex);


### PR DESCRIPTION
...er fittable layout

Issue:
There is a chance to set fittable set height as 0 on pushPanel.
- pushPanel is create a panel, render, reflow panels, resize, setIndex
- reflow can change new panel showing property as false
- following resize always fail, so set height to 0
Problem happens when setIndex fails to set valid height

Fix:
- We can remove the chance of set height 0 on panel resize
- So that we can show valid height even if we fail to reflow on following setIndex

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com