### PR TITLE
ENYO-890: Prevent running animation when no arrangement is needed.

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -699,12 +699,13 @@
 			this.toIndex = index;
 
 			this.queuedIndex = null;
+			this._willMove = null;
 
 			// Ensure any VKB is closed when transitioning panels
 			this.blurActiveElementIfHiding(index);
 
 			// If panels will move for this index change, kickoff animation. Otherwise skip it.
-			if (this.shouldArrange() && this.animate) {
+			if (this.shouldAnimate()) {
 				enyo.Spotlight.mute(this);
 				this.startTransition();
 				this.triggerPreTransitions();
@@ -737,8 +738,18 @@
 		},
 
 		/**
-		* Returns `true` if any panels will move in the transition from `fromIndex` to
+		* Returns `true` if the panels should animate in the transition from `fromIndex` to
 		* `toIndex`.
+		*
+		* @private
+		*/
+		shouldAnimate: function () {
+			this._willMove = this._willMove || (this._willMove == null && (this.shouldArrange() && this.animate));
+			return this._willMove;
+		},
+
+		/**
+		* Returns `true` if any panels will move in the transition from `fromIndex` to `toIndex`.
 		*
 		* @private
 		*/

--- a/source/Panels.js
+++ b/source/Panels.js
@@ -744,8 +744,12 @@
 		* @private
 		*/
 		shouldAnimate: function () {
-			this._willMove = this._willMove || (this._willMove == null && (this.shouldArrange() && this.animate));
-			return this._willMove;
+			if (this._willMove == null) {
+				return (this._willMove = this.animate && this.shouldArrange());
+			}
+			else {
+				return this._willMove;
+			}
 		},
 
 		/**


### PR DESCRIPTION
### Issue
There was a delay when moving Spotlight focus between joined panels.

### Fix
We ensure that we only execute the extensive animation cycle (involving `enyo.Animator`) when an arrangement is required, so the case of joined panels should be excluded. Additionally, we store the value of `shouldAnimate` once we have calculated it for a given index change, so that it does not need to be recalculated when the `indexChanged` method of `enyo.Panels` is run.

### Note
This PR is dependent on https://github.com/enyojs/layout/pull/117

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>