### PR TITLE
ENYO-874: Settings app has a problem of not showing scroller content und...

### DIFF
--- a/source/Panels.js
+++ b/source/Panels.js
@@ -291,7 +291,7 @@
 			this.isModifyingPanels = true;
 
 			if (!options) { options = {}; }
-			var lastIndex = this.getPanels().length - 1,
+			var lastIndex = this.getPanels().length,
 				oPanels = this.createComponents(info, commonInfo),
 				nPanel;
 
@@ -301,10 +301,9 @@
 			this.reflow();
 			if (options.targetIndex || options.targetIndex === 0) {
 				lastIndex = options.targetIndex;
-			} else {
-				lastIndex++;
 			}
-			oPanels[lastIndex].show();
+			lastIndex = this.clamp(lastIndex);
+			this.getPanels()[lastIndex].show();
 			for (nPanel = 0; nPanel < oPanels.length; ++nPanel) {
 				oPanels[nPanel].resize();
 			}


### PR DESCRIPTION
...er fittable layout

- Fix oPanels to this.getPanels() because oPanels is not including whole panels but new panels which is created.
- Add clamp on lastIndex to cover negative options.targetIndex case.
- Remove else case which is adding +1 and remove -1 from lastIndex initial value.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com