### PR TITLE
ENYO-976: Adjust client position of Dialog.

### DIFF
--- a/css/Dialog.less
+++ b/css/Dialog.less
@@ -20,7 +20,7 @@
 	margin: 18px 0 18px;
 }
 .moon-dialog-client {
-	padding: 36px 0 0;
+	padding: 24px 0 0;
 	float: right;
 }
 .moon-dialog-client > * {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -3543,7 +3543,7 @@ html {
   margin: 0.75rem 0 0.75rem;
 }
 .moon-dialog-client {
-  padding: 1.5rem 0 0;
+  padding: 1rem 0 0;
   float: right;
 }
 .moon-dialog-client > * {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -3543,7 +3543,7 @@ html {
   margin: 0.75rem 0 0.75rem;
 }
 .moon-dialog-client {
-  padding: 1.5rem 0 0;
+  padding: 1rem 0 0;
   float: right;
 }
 .moon-dialog-client > * {


### PR DESCRIPTION
### Issue
After some tweaks to the layout of `moon.Dialog`, the position of the client area required some adjustment.

### Fix
We adjust the position of the client area such that it is higher above the divider.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>