### PR TITLE
ENYO-980: Lite: Fixed size was set in moon.ContextualPopup

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -150,14 +150,14 @@
 		*
 		* @private
 		*/
-		widePopup: moon.riScale(201),
+		widePopup: moon.riScale(210),
 
 		/**
 		* Popups longer than this value are considered long (for layout purposes).
 		*
 		* @private
 		*/
-		longPopup: moon.riScale(201),
+		longPopup: moon.riScale(210),
 
 		/**
 		* Do not allow horizontal flush popups past spec'd amount of buffer space on left/right

--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -150,14 +150,14 @@
 		*
 		* @private
 		*/
-		widePopup: moon.riScale(200),
+		widePopup: moon.riScale(201),
 
 		/**
 		* Popups longer than this value are considered long (for layout purposes).
 		*
 		* @private
 		*/
-		longPopup: moon.riScale(200),
+		longPopup: moon.riScale(201),
 
 		/**
 		* Do not allow horizontal flush popups past spec'd amount of buffer space on left/right
@@ -165,7 +165,7 @@
 		*
 		* @private
 		*/
-		horizBuffer: moon.riScale(16),
+		horizBuffer: moon.riScale(15),
 
 		/**
 		* @private

--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -150,14 +150,14 @@
 		*
 		* @private
 		*/
-		widePopup: 200,
+		widePopup: moon.riScale(200),
 
 		/**
 		* Popups longer than this value are considered long (for layout purposes).
 		*
 		* @private
 		*/
-		longPopup: 200,
+		longPopup: moon.riScale(200),
 
 		/**
 		* Do not allow horizontal flush popups past spec'd amount of buffer space on left/right
@@ -165,7 +165,7 @@
 		*
 		* @private
 		*/
-		horizBuffer: 16,
+		horizBuffer: moon.riScale(16),
 
 		/**
 		* @private


### PR DESCRIPTION
## Issue
Some private properties are set by fixed number

## Fix
Set private properties as resolution independent by using moon.riScale()