### PR TITLE
ENYO-937: Adjust tap area for moon.Icon controls in moon.Item controls.

### DIFF
--- a/css/Item.less
+++ b/css/Item.less
@@ -18,6 +18,10 @@
 		cursor: default;
 		opacity: @moon-disabled-opacity;
 	}
+
+	> .moon-icon:first-child, > .moon-icon:last-child {
+		.moon-item-icon-tap-area-adjust;
+	}
 }
 
 .enyo-locale-non-latin .moon-item {

--- a/css/ItemOverlay.less
+++ b/css/ItemOverlay.less
@@ -6,6 +6,9 @@
 		&.right {
 			float: right;
 		}
+		&.beginning .moon-icon:first-child, &.ending .moon-icon:last-child {
+			.moon-item-icon-tap-area-adjust;
+		}
 		&.beginning .moon-icon:first-child {
 			margin-left: 0;
 		}

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -6,6 +6,10 @@
 /* minifier to fall back to using CSS files in place of the same-name       */
 /* LESS file.                                                               */
 
+.moon-item-icon-tap-area-adjust.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
 html {
   font-size: 1rem;
   font-size: 24px;
@@ -1142,6 +1146,11 @@ html {
   cursor: default;
   opacity: 0.6;
 }
+.moon-item > .moon-icon:first-child.small > .small-icon-tap-area,
+.moon-item > .moon-icon:last-child.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
 .enyo-locale-non-latin .moon-item {
   font-family: "Moonstone LG Display Bold";
   font-size: 1.25rem;
@@ -1152,6 +1161,11 @@ html {
 }
 .moon-item .moon-item-overlay.right {
   float: right;
+}
+.moon-item .moon-item-overlay.beginning .moon-icon:first-child.small > .small-icon-tap-area,
+.moon-item .moon-item-overlay.ending .moon-icon:last-child.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
 }
 .moon-item .moon-item-overlay.beginning .moon-icon:first-child {
   margin-left: 0;

--- a/css/moonstone-dark.less
+++ b/css/moonstone-dark.less
@@ -4,5 +4,8 @@
 // Moonstone default parameters defined here
 @import "moonstone-variables.less";
 
+// Moonstone mixins defined here
+@import "moonstone-mixins.less";
+
 // Moonstone rules defined here
 @import "moonstone-rules.less";

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -6,6 +6,10 @@
 /* minifier to fall back to using CSS files in place of the same-name       */
 /* LESS file.                                                               */
 
+.moon-item-icon-tap-area-adjust.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
 html {
   font-size: 1rem;
   font-size: 24px;
@@ -1142,6 +1146,11 @@ html {
   cursor: default;
   opacity: 0.35;
 }
+.moon-item > .moon-icon:first-child.small > .small-icon-tap-area,
+.moon-item > .moon-icon:last-child.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
 .enyo-locale-non-latin .moon-item {
   font-family: "Moonstone LG Display Bold";
   font-size: 1.25rem;
@@ -1152,6 +1161,11 @@ html {
 }
 .moon-item .moon-item-overlay.right {
   float: right;
+}
+.moon-item .moon-item-overlay.beginning .moon-icon:first-child.small > .small-icon-tap-area,
+.moon-item .moon-item-overlay.ending .moon-icon:last-child.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
 }
 .moon-item .moon-item-overlay.beginning .moon-icon:first-child {
   margin-left: 0;

--- a/css/moonstone-light.less
+++ b/css/moonstone-light.less
@@ -4,5 +4,8 @@
 // Moonstone default parameters defined here
 @import "moonstone-variables.less";
 
+// Moonstone mixins defined here
+@import "moonstone-mixins.less";
+
 // Moonstone rules defined here
 @import "moonstone-rules.less";

--- a/css/moonstone-mixins.less
+++ b/css/moonstone-mixins.less
@@ -1,0 +1,6 @@
+.moon-item-icon-tap-area-adjust {
+	&.small > .small-icon-tap-area {
+		left: -@moon-spotlight-outset;
+		right: -@moon-spotlight-outset;
+	}
+}


### PR DESCRIPTION
### Issue
The recent addition of the `moon.ItemOverlay` exposed an issue with `moon.Icon` controls nested inside `moon.Item` controls. In particular, the tap area of `moon.Icon` extended beyond the outer limits of `moon.Item`, causing there to be a non-zero `scrollWidth` for `moon.Item`. The result was that this control would unnecessarily be added to the marquee waitlist, but would never be popped as our originating control for the `onMarqueeEnded` event would be the `moon.MarqueeText` control and not the `moon.Item` control; this prevented the marquee from restarting.

### Fix
I went with the direction of adjusting the tap area to fit within `moon.Item`. This involved adjusting the `right` and `left` values accordingly (both are adjusted to the same value to preserve the position of the icon), based on the value of `@moon-spotlight-outset` which effectively defines the padding of `moon.Item`. I threw these rules into a LESS mixin (which necessitated a new file to house the mixin), so that this could be shared in both the styling for `moon.ItemOverlay` and `moon.Item`, as this is a potential issue for the standard `moon.Item` control (without overlay) as well.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>