### PR TITLE
ENYO-576: Reworked SelectionOverlay CSS to be more efficient.

### DIFF
--- a/css/SelectionOverlaySupport.less
+++ b/css/SelectionOverlaySupport.less
@@ -1,48 +1,30 @@
+.moon-selection-overlay-support-scrim {
+	display: none;
+}
 .selection-enabled {
-	.moon-selection-overlay-support {
-		&.selected {
-			.moon-selection-overlay-ghost {
-				color: @moon-accent;
-				>* {
-					display: block;
-				}
-				.moon-icon {
-					color: @moon-accent;
-					line-height: @moon-icon-button-small-size + @moon-button-border-width;
-					font-size: @moon-icon-small-size * 2 + 9;
-				}
-			}
-		}
-	}
-	.moon-selection-overlay-ghost {
+	.moon-selection-overlay-support-scrim {
 		display: block;
-	  	width: @moon-icon-button-small-size;
-		height: @moon-icon-button-small-size;
-		border: @moon-button-border-width solid;
-		color: rgba(0,0,0,0.5);
-		background-color: rgba(255,255,255,0.5);
-		margin: -@moon-icon-button-small-size / 2 0 0 -@moon-icon-button-small-size / 2;
-		border-radius: 50%;
-		position: absolute;
-		>* {
+		z-index: 1000;
+		text-align: center;
+
+		.moon-icon {
+			display: block;
 			width: @moon-icon-button-small-size;
 			height: @moon-icon-button-small-size;
-			display: none;
-			background-size: cover;
-			background-color: @moon-selection-overlay-bg-color;
-			border-radius: @moon-icon-button-small-size / 2;
-			background-position: center center;
+			line-height: @moon-icon-button-small-size;
+			border: @moon-button-border-width solid black;
+			background-color: white;
+			color: transparent;
+			-webkit-transform: translateX(-50%) translateY(-50%);
 			margin: 0;
+			border-radius: 50%;
+			position: absolute;
+			opacity: 0.5;
 		}
 	}
-}
-
-.moon-selection-overlay-support-scrim {
-	display: block;
-	z-index: 1000;
-	text-align: center;
-}
-
-.moon-selection-overlay-ghost {
-	display: none;
+	.selected .moon-selection-overlay-support-scrim .moon-icon {
+		color: @moon-accent;
+		border-color: @moon-accent;
+		opacity: 1;
+	}
 }

--- a/css/SelectionOverlaySupport.less
+++ b/css/SelectionOverlaySupport.less
@@ -19,8 +19,8 @@
 	  	width: @moon-icon-button-small-size;
 		height: @moon-icon-button-small-size;
 		border: @moon-button-border-width solid;
-		color: rgba(0,0,0,0.45);
-		background-color: rgba(255,255,255,0.4);
+		color: rgba(0,0,0,0.5);
+		background-color: rgba(255,255,255,0.5);
 		margin: -@moon-icon-button-small-size / 2 0 0 -@moon-icon-button-small-size / 2;
 		border-radius: 50%;
 		position: absolute;

--- a/css/SelectionOverlaySupport.less
+++ b/css/SelectionOverlaySupport.less
@@ -1,32 +1,48 @@
 .selection-enabled {
 	.moon-selection-overlay-support {
 		&.selected {
-			.moon-selection-overlay-support-scrim {
-				display: block;
-				text-align: center;
-
+			.moon-selection-overlay-ghost {
+				color: @moon-accent;
+				>* {
+					display: block;
+				}
 				.moon-icon {
-					position: absolute;
-					width: @moon-icon-button-small-size;
-					height: @moon-icon-button-small-size;
-					line-height: @moon-icon-button-small-size;
-					font-size: @moon-icon-small-size * 2 + 9;
 					color: @moon-accent;
-					margin: -@moon-icon-button-small-size / 2 0 0 -@moon-icon-button-small-size / 2;
-					background-color: @moon-selection-overlay-bg-color;
-					border-radius: @moon-icon-button-small-size / 2;
-					background-position: center @moon-button-border-width;
+					line-height: @moon-icon-button-small-size + @moon-button-border-width;
+					font-size: @moon-icon-small-size * 2 + 9;
 				}
 			}
+		}
+	}
+	.moon-selection-overlay-ghost {
+		display: block;
+	  	width: @moon-icon-button-small-size;
+		height: @moon-icon-button-small-size;
+		border: @moon-button-border-width solid;
+		color: rgba(0,0,0,0.45);
+		background-color: rgba(255,255,255,0.4);
+		margin: -@moon-icon-button-small-size / 2 0 0 -@moon-icon-button-small-size / 2;
+		border-radius: 50%;
+		position: absolute;
+		>* {
+			width: @moon-icon-button-small-size;
+			height: @moon-icon-button-small-size;
+			display: none;
+			background-size: cover;
+			background-color: @moon-selection-overlay-bg-color;
+			border-radius: @moon-icon-button-small-size / 2;
+			background-position: center center;
+			margin: 0;
 		}
 	}
 }
 
 .moon-selection-overlay-support-scrim {
-	display: none;
+	display: block;
 	z-index: 1000;
+	text-align: center;
 }
 
-.enyo-locale-right-to-left .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim .moon-icon {
-	margin: -@moon-icon-button-small-size / 2 -@moon-icon-button-small-size / 2 0 0;
+.moon-selection-overlay-ghost {
+	display: none;
 }

--- a/css/SelectionOverlaySupport.less
+++ b/css/SelectionOverlaySupport.less
@@ -16,6 +16,7 @@
 			background-color: white;
 			color: transparent;
 			-webkit-transform: translateX(-50%) translateY(-50%);
+			transform: translateX(-50%) translateY(-50%);
 			margin: 0;
 			border-radius: 50%;
 			position: absolute;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4667,8 +4667,8 @@ html {
   width: 2.5rem;
   height: 2.5rem;
   border: 0.25rem solid;
-  color: rgba(0, 0, 0, 0.45);
-  background-color: rgba(255, 255, 255, 0.4);
+  color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(255, 255, 255, 0.5);
   margin: -1.25rem 0 0 -1.25rem;
   border-radius: 50%;
   position: absolute;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4651,45 +4651,32 @@ html {
 .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
   color: #ffffff;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost {
-  color: #cf0652;
-}
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost > * {
-  display: block;
-}
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost .moon-icon {
-  color: #cf0652;
-  line-height: 2.75rem;
-  font-size: 3.375rem;
-}
-.selection-enabled .moon-selection-overlay-ghost {
-  display: block;
-  width: 2.5rem;
-  height: 2.5rem;
-  border: 0.25rem solid;
-  color: rgba(0, 0, 0, 0.5);
-  background-color: rgba(255, 255, 255, 0.5);
-  margin: -1.25rem 0 0 -1.25rem;
-  border-radius: 50%;
-  position: absolute;
-}
-.selection-enabled .moon-selection-overlay-ghost > * {
-  width: 2.5rem;
-  height: 2.5rem;
-  display: none;
-  background-size: cover;
-  background-color: #ffffff;
-  border-radius: 1.25rem;
-  background-position: center center;
-  margin: 0;
-}
 .moon-selection-overlay-support-scrim {
+  display: none;
+}
+.selection-enabled .moon-selection-overlay-support-scrim {
   display: block;
   z-index: 1000;
   text-align: center;
 }
-.moon-selection-overlay-ghost {
-  display: none;
+.selection-enabled .moon-selection-overlay-support-scrim .moon-icon {
+  display: block;
+  width: 2.5rem;
+  height: 2.5rem;
+  line-height: 2.5rem;
+  border: 0.25rem solid #000000;
+  background-color: white;
+  color: transparent;
+  -webkit-transform: translateX(-50%) translateY(-50%);
+  margin: 0;
+  border-radius: 50%;
+  position: absolute;
+  opacity: 0.5;
+}
+.selection-enabled .selected .moon-selection-overlay-support-scrim .moon-icon {
+  color: #cf0652;
+  border-color: #cf0652;
+  opacity: 1;
 }
 .moon-thumb {
   -webkit-transform-origin: 0rem 0rem;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4668,6 +4668,7 @@ html {
   background-color: white;
   color: transparent;
   -webkit-transform: translateX(-50%) translateY(-50%);
+  transform: translateX(-50%) translateY(-50%);
   margin: 0;
   border-radius: 50%;
   position: absolute;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4651,28 +4651,45 @@ html {
 .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
   color: #ffffff;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim {
-  display: block;
-  text-align: center;
+.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost {
+  color: #cf0652;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim .moon-icon {
-  position: absolute;
+.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost > * {
+  display: block;
+}
+.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost .moon-icon {
+  color: #cf0652;
+  line-height: 2.75rem;
+  font-size: 3.375rem;
+}
+.selection-enabled .moon-selection-overlay-ghost {
+  display: block;
   width: 2.5rem;
   height: 2.5rem;
-  line-height: 2.5rem;
-  font-size: 3.375rem;
-  color: #cf0652;
+  border: 0.25rem solid;
+  color: rgba(0, 0, 0, 0.45);
+  background-color: rgba(255, 255, 255, 0.4);
   margin: -1.25rem 0 0 -1.25rem;
+  border-radius: 50%;
+  position: absolute;
+}
+.selection-enabled .moon-selection-overlay-ghost > * {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: none;
+  background-size: cover;
   background-color: #ffffff;
   border-radius: 1.25rem;
-  background-position: center 0.25rem;
+  background-position: center center;
+  margin: 0;
 }
 .moon-selection-overlay-support-scrim {
-  display: none;
+  display: block;
   z-index: 1000;
+  text-align: center;
 }
-.enyo-locale-right-to-left .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim .moon-icon {
-  margin: -1.25rem -1.25rem 0 0;
+.moon-selection-overlay-ghost {
+  display: none;
 }
 .moon-thumb {
   -webkit-transform-origin: 0rem 0rem;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4667,8 +4667,8 @@ html {
   width: 2.5rem;
   height: 2.5rem;
   border: 0.25rem solid;
-  color: rgba(0, 0, 0, 0.45);
-  background-color: rgba(255, 255, 255, 0.4);
+  color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(255, 255, 255, 0.5);
   margin: -1.25rem 0 0 -1.25rem;
   border-radius: 50%;
   position: absolute;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4651,45 +4651,32 @@ html {
 .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
   color: #ffffff;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost {
-  color: #cf0652;
-}
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost > * {
-  display: block;
-}
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost .moon-icon {
-  color: #cf0652;
-  line-height: 2.75rem;
-  font-size: 3.375rem;
-}
-.selection-enabled .moon-selection-overlay-ghost {
-  display: block;
-  width: 2.5rem;
-  height: 2.5rem;
-  border: 0.25rem solid;
-  color: rgba(0, 0, 0, 0.5);
-  background-color: rgba(255, 255, 255, 0.5);
-  margin: -1.25rem 0 0 -1.25rem;
-  border-radius: 50%;
-  position: absolute;
-}
-.selection-enabled .moon-selection-overlay-ghost > * {
-  width: 2.5rem;
-  height: 2.5rem;
-  display: none;
-  background-size: cover;
-  background-color: #ffffff;
-  border-radius: 1.25rem;
-  background-position: center center;
-  margin: 0;
-}
 .moon-selection-overlay-support-scrim {
+  display: none;
+}
+.selection-enabled .moon-selection-overlay-support-scrim {
   display: block;
   z-index: 1000;
   text-align: center;
 }
-.moon-selection-overlay-ghost {
-  display: none;
+.selection-enabled .moon-selection-overlay-support-scrim .moon-icon {
+  display: block;
+  width: 2.5rem;
+  height: 2.5rem;
+  line-height: 2.5rem;
+  border: 0.25rem solid #000000;
+  background-color: white;
+  color: transparent;
+  -webkit-transform: translateX(-50%) translateY(-50%);
+  margin: 0;
+  border-radius: 50%;
+  position: absolute;
+  opacity: 0.5;
+}
+.selection-enabled .selected .moon-selection-overlay-support-scrim .moon-icon {
+  color: #cf0652;
+  border-color: #cf0652;
+  opacity: 1;
 }
 .moon-thumb {
   -webkit-transform-origin: 0rem 0rem;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4668,6 +4668,7 @@ html {
   background-color: white;
   color: transparent;
   -webkit-transform: translateX(-50%) translateY(-50%);
+  transform: translateX(-50%) translateY(-50%);
   margin: 0;
   border-radius: 50%;
   position: absolute;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4651,28 +4651,45 @@ html {
 .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
   color: #ffffff;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim {
-  display: block;
-  text-align: center;
+.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost {
+  color: #cf0652;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim .moon-icon {
-  position: absolute;
+.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost > * {
+  display: block;
+}
+.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-ghost .moon-icon {
+  color: #cf0652;
+  line-height: 2.75rem;
+  font-size: 3.375rem;
+}
+.selection-enabled .moon-selection-overlay-ghost {
+  display: block;
   width: 2.5rem;
   height: 2.5rem;
-  line-height: 2.5rem;
-  font-size: 3.375rem;
-  color: #cf0652;
+  border: 0.25rem solid;
+  color: rgba(0, 0, 0, 0.45);
+  background-color: rgba(255, 255, 255, 0.4);
   margin: -1.25rem 0 0 -1.25rem;
+  border-radius: 50%;
+  position: absolute;
+}
+.selection-enabled .moon-selection-overlay-ghost > * {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: none;
+  background-size: cover;
   background-color: #ffffff;
   border-radius: 1.25rem;
-  background-position: center 0.25rem;
+  background-position: center center;
+  margin: 0;
 }
 .moon-selection-overlay-support-scrim {
-  display: none;
+  display: block;
   z-index: 1000;
+  text-align: center;
 }
-.enyo-locale-right-to-left .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim .moon-icon {
-  margin: -1.25rem -1.25rem 0 0;
+.moon-selection-overlay-ghost {
+  display: none;
 }
 .moon-thumb {
   -webkit-transform-origin: 0rem 0rem;

--- a/source/SelectionOverlaySupport.js
+++ b/source/SelectionOverlaySupport.js
@@ -51,7 +51,7 @@
 		* @private
 		*/
 		name: 'moon.SelectionOverlaySupport',
-		
+
 		/**
 		* @private
 		*/
@@ -118,9 +118,7 @@
 		*/
 		_selectionScrim: [
 			{classes: 'enyo-fit moon-selection-overlay-support-scrim', components: [
-				{name:'selectionGhost', classes:"moon-selection-overlay-ghost", components:[
-					{name:'selectionScrimIcon', kind: 'moon.Icon', small: false, icon: "check", spotlight: false}
-				]}
+				{name:'selectionScrimIcon', kind: 'moon.Icon', small: false, icon: 'check', spotlight: false}
 			]}
 		],
 
@@ -128,14 +126,14 @@
 		* @private
 		*/
 		selectionOverlayVerticalOffsetChanged: function () {
-			this.$.selectionGhost.applyStyle('top', this.selectionOverlayVerticalOffset + '%');
+			this.$.selectionScrimIcon.applyStyle('top', this.selectionOverlayVerticalOffset + '%');
 		},
 
 		/**
 		* @private
 		*/
 		selectionOverlayHorizontalOffsetChanged: function () {
-			this.$.selectionGhost.applyStyle((this.rtl ? 'right' : 'left'), this.selectionOverlayHorizontalOffset + '%');
+			this.$.selectionScrimIcon.applyStyle((this.rtl ? 'right' : 'left'), this.selectionOverlayHorizontalOffset + '%');
 		}
 	};
 

--- a/source/SelectionOverlaySupport.js
+++ b/source/SelectionOverlaySupport.js
@@ -101,7 +101,7 @@
 				this.selectionOverlayVerticalOffsetChanged();
 				// Allow the icon to be modified by user
 				if (this.selectionScrimIcon) {
-					this.$.selectionScrimIcon.removeClass('moon-icon-' + this.$.selectionScrimIcon.icon);
+					this.$.selectionScrimIcon.set('icon','');
 				}
 			};
 		}),
@@ -118,7 +118,9 @@
 		*/
 		_selectionScrim: [
 			{classes: 'enyo-fit moon-selection-overlay-support-scrim', components: [
-				{name:'selectionScrimIcon', kind: 'moon.Icon', small: false, icon: "check", spotlight: false}
+				{name:'selectionGhost', classes:"moon-selection-overlay-ghost", components:[
+					{name:'selectionScrimIcon', kind: 'moon.Icon', small: false, icon: "check", spotlight: false}
+				]}
 			]}
 		],
 
@@ -126,14 +128,14 @@
 		* @private
 		*/
 		selectionOverlayVerticalOffsetChanged: function () {
-			this.$.selectionScrimIcon.applyStyle('top', this.selectionOverlayVerticalOffset + '%');
+			this.$.selectionGhost.applyStyle('top', this.selectionOverlayVerticalOffset + '%');
 		},
 
 		/**
 		* @private
 		*/
 		selectionOverlayHorizontalOffsetChanged: function () {
-			this.$.selectionScrimIcon.applyStyle((this.rtl ? 'right' : 'left'), this.selectionOverlayHorizontalOffset + '%');
+			this.$.selectionGhost.applyStyle((this.rtl ? 'right' : 'left'), this.selectionOverlayHorizontalOffset + '%');
 		}
 	};
 


### PR DESCRIPTION
* SelectionOverlaySupport only needs the original icon it had, and no additional modifications.
* The CSS is simplified to provide support for the following states: normal nothing visible, selectable/unselected, and selectable+selected.
* With only one element in the scrim, the CSS and DOM become much simpler, we only need to set the general sizing, the unselected colors, and the selected colors.