### PR TITLE
ENYO-907: Remove unnecessary padding.

### DIFF
--- a/css/CheckboxItem.less
+++ b/css/CheckboxItem.less
@@ -2,25 +2,25 @@
 	position: relative;
 	overflow: hidden;
 
-	// Checkbox 
+	// Checkbox
 	.moon-checkbox {
 		position: absolute;
 		top: @moon-spotlight-outset - 3;
 		right: @moon-spotlight-outset - 3;
 	}
-	// Label 
+	// Label
 	.moon-checkbox-item-label-wrapper {
 		height: @moon-item-line-height;
 		margin-right: @moon-item-indent;
 	}
 
-	// Left-handed checkbox 
+	// Left-handed checkbox
 	&.left-handed  {
-		// Checkbox 
+		// Checkbox
 		.moon-checkbox {
 			left: @moon-spotlight-outset - 3;
 		}
-		// Label 
+		// Label
 		.moon-checkbox-item-label-wrapper {
 			margin-right: 0px;
 			margin-left: @moon-item-indent;
@@ -40,11 +40,6 @@
 /* Special treatment inside of ExpandablePicker (checkbox nudged up) */
 .moon-expandable-picker .moon-checkbox-item .moon-checkbox {
 	top: @moon-spotlight-outset;
-}
-
-/* this is a fix for TV only - left-side of letter cut off in list-action item drawer*/
-.moon-list-actions-drawer-client .moon-checkbox-item .moon-checkbox-item-label-wrapper {
-	padding-left: 3px;
 }
 
 /* Right to left */

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -949,10 +949,6 @@ html {
 .moon-expandable-picker .moon-checkbox-item .moon-checkbox {
   top: 0.5rem;
 }
-/* this is a fix for TV only - left-side of letter cut off in list-action item drawer*/
-.moon-list-actions-drawer-client .moon-checkbox-item .moon-checkbox-item-label-wrapper {
-  padding-left: 0.125rem;
-}
 /* Right to left */
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox {
   left: 0.625rem;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -949,10 +949,6 @@ html {
 .moon-expandable-picker .moon-checkbox-item .moon-checkbox {
   top: 0.5rem;
 }
-/* this is a fix for TV only - left-side of letter cut off in list-action item drawer*/
-.moon-list-actions-drawer-client .moon-checkbox-item .moon-checkbox-item-label-wrapper {
-  padding-left: 0.125rem;
-}
 /* Right to left */
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox {
   left: 0.625rem;


### PR DESCRIPTION
### Issue
In a previous fix (https://github.com/enyojs/moonstone/pull/796), we had added a rule to add padding for `moon.CheckboxItem` to correct an aberration observed only the TV. Due to a WebKit issue where padding would not be properly measured when determining the `scrollWidth` value in RTL mode, this caused the initial measurement of the distance to marquee to be incorrect, and in particular, to be zero in this case, causing the content to not marquee at all.

### Fix
I've created a fiddle (actually an old one I had created a while back as we had run into this issue previously: http://jsfiddle.net/aarontam/pp2rw/) that demonstrates the WebKit issue. Meanwhile, while this issue is being investigated, the now-unnecessary rule has been removed and I've verified the original issue does not occur with this change. Additionally, I wasn't able to reproduce the original issue using the older framework code (just before 2.3.0-rc.1), so I'm wondering if this was caused by a quirk of TV WebKit that has since been updated.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>