### PR TITLE
ENYO-817: Correct positioning of checkbox in RTL.

### DIFF
--- a/css/CheckboxItem.less
+++ b/css/CheckboxItem.less
@@ -2,25 +2,25 @@
 	position: relative;
 	overflow: hidden;
 
-	// Checkbox 
+	// Checkbox
 	.moon-checkbox {
 		position: absolute;
 		top: @moon-spotlight-outset - 3;
 		right: @moon-spotlight-outset - 3;
 	}
-	// Label 
+	// Label
 	.moon-checkbox-item-label-wrapper {
 		height: @moon-item-line-height;
 		margin-right: @moon-item-indent;
 	}
 
-	// Left-handed checkbox 
+	// Left-handed checkbox
 	&.left-handed  {
-		// Checkbox 
+		// Checkbox
 		.moon-checkbox {
 			left: @moon-spotlight-outset - 3;
 		}
-		// Label 
+		// Label
 		.moon-checkbox-item-label-wrapper {
 			margin-right: 0px;
 			margin-left: @moon-item-indent;
@@ -51,7 +51,7 @@
 .enyo-locale-right-to-left .moon-checkbox-item {
 	// Checkbox
 	.moon-checkbox {
-		left: @moon-spotlight-outset + 3;
+		left: @moon-spotlight-outset - 3;
 		right: auto;
 	}
 	.moon-checkbox-item-label-wrapper {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -955,7 +955,7 @@ html {
 }
 /* Right to left */
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox {
-  left: 0.625rem;
+  left: 0.375rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox-item-label-wrapper {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -955,7 +955,7 @@ html {
 }
 /* Right to left */
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox {
-  left: 0.625rem;
+  left: 0.375rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox-item-label-wrapper {


### PR DESCRIPTION
### Issue
In RTL mode, for a `moon.CheckboxItem` control, the `moon.Checkbox` control overlaps with the client area.

### Fix
We correct the positioning of the `moon.Checkbox` control by changing `left:@moon-spotlight-outset + 3` to `left:@moon-spotlight-outset - 3`, to match the rule we have for the `right` property.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>