### PR TITLE
ENYO-1014: Adding a 'hideScrollColumnsWhenFit' option to moon.Scroller t...

### DIFF
--- a/samples/ScrollerTextSample.js
+++ b/samples/ScrollerTextSample.js
@@ -12,7 +12,8 @@ enyo.kind({
 			{kind:"FittableColumns", noStretch:true, components: [
 				{fit:true, components: [
 					{kind:"moon.ToggleButton", name:"lengthToggle", content:"Long Text", value:true},
-					{kind:"moon.ToggleButton", name:"spotToggle", content:"Spot Paging Controls", value:false}
+					{kind:"moon.ToggleButton", name:"spotToggle", content:"Spot Paging Controls", value:false},
+					{kind:"moon.ToggleButton", name:"hideToggle", content:"Hide Paging Controls when fit", value:false}
 				]},
 				{kind:"moon.Button", content:"Sign me Up!"}
 			]}
@@ -22,6 +23,7 @@ enyo.kind({
 	shortText: "The quick brown fox jumped over the lazy dog.",
 	bindings: [
 		{from: "$.lengthToggle.value", to:"$.text.content", transform: function(val) { return val ? this.longText : this.shortText; } },
-		{from: "$.spotToggle.value", to:"$.scroller.spotlightPagingControls" }
+		{from: "$.spotToggle.value", to:"$.scroller.spotlightPagingControls" },
+		{from: "$.hideToggle.value", to:"$.scroller.hideScrollColumnsWhenFit" }
 	]
 });

--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -72,7 +72,17 @@
 			* @default 8
 			* @public
 			*/
-			paginationScrollMultiplier: 8
+			paginationScrollMultiplier: 8,
+
+			/**
+			* If 'true', paging controls are hidden when content fit in scroller
+			* even when spotlightPagingControls is true.
+			*
+			* @type {Boolean}
+			* @default false
+			* @public
+			*/
+			hideScrollColumnsWhenFit: false
 		},
 
 		/**
@@ -835,7 +845,8 @@
 		showVertical: function() {
 			return (this.getVertical() == 'scroll' ||
 					(this.getVertical() !== 'hidden' &&
-					((-1 * this.$.scrollMath.bottomBoundary > 0) || this.spotlightPagingControls)));
+					((-1 * this.$.scrollMath.bottomBoundary > 0) ||
+					(this.spotlightPagingControls && !this.hideScrollColumnsWhenFit))));
 		},
 
 		/**
@@ -846,7 +857,17 @@
 		showHorizontal: function() {
 			return (this.getHorizontal() == 'scroll' ||
 					(this.getHorizontal() !== 'hidden' &&
-					((-1 * this.$.scrollMath.rightBoundary > 0) || this.spotlightPagingControls)));
+					((-1 * this.$.scrollMath.rightBoundary > 0) ||
+					(this.spotlightPagingControls && !this.hideScrollColumnsWhenFit))));
+		},
+
+		/**
+		* Update bounds after change hideScrollColumnsWhenFit option changes.
+		*
+		* @private
+		*/
+		hideScrollColumnsWhenFitChanged: function(old) {
+			this.requestSetupBounds();
 		},
 
 		/**

--- a/source/Scroller.js
+++ b/source/Scroller.js
@@ -72,6 +72,16 @@
 			spotlightPagingControls: false,
 
 			/**
+			* If 'true', paging controls are hidden when content fit in scroller
+			* even when spotlightPagingControls is true.
+			*
+			* @type {Boolean}
+			* @default false
+			* @public
+			*/
+			hideScrollColumnsWhenFit: false,
+
+			/**
 			* Relative parameter used to determine scroll speed.
 			*
 			* @type {Number}
@@ -224,7 +234,8 @@
 			{from: '.scrollWheelMultiplier',		to:'.$.strategy.scrollWheelMultiplier'},
 			{from: '.scrollWheelPageMultiplier',	to:'.$.strategy.scrollWheelPageMultiplier'},
 			{from: '.paginationPageMultiplier',		to:'.$.strategy.paginationPageMultiplier'},
-			{from: '.paginationScrollMultiplier',	to:'.$.strategy.paginationScrollMultiplier'}
+			{from: '.paginationScrollMultiplier',	to:'.$.strategy.paginationScrollMultiplier'},
+			{from: '.hideScrollColumnsWhenFit',		to:'.$.strategy.hideScrollColumnsWhenFit'}
 		],
 
 		/**


### PR DESCRIPTION
...hat is hiding paging controls even when spotlightPagingControls is true.

- Add a hideScrollColumnsWhenFit option to moon.Scroller
- Bind hideScrollColumnsWhenFit option from moon.Scroller to moon.MoonScrollStrategy
- Ignore spotlightPagingControls option when hideScrollColumnsWhenFit is true. Only consider scroll boundary.
- Add hideScrollColumnsWhenFit changed handler to update bounds

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com