### PR TITLE
ENYO-1030: Moving moon.History initialization out of create()

### DIFF
--- a/source/History.js
+++ b/source/History.js
@@ -161,16 +161,13 @@
 		/**
 		* @private
 		*/
-		create: enyo.inherit(function(sup) {
-			return function(props) {
-				sup.apply(this, arguments);
-				scope.onpopstate = enyo.bind(this, function(inEvent) {this.popStateHandler();});
-				if (enyo.LunaService) {
-					this.createChrome(this.lunaServiceComponents);
-					this._getAppID();
-				}
-			};
-		}),
+		init: function() {
+			scope.onpopstate = enyo.bind(this, function(inEvent) {this.popStateHandler();});
+			if (enyo.LunaService) {
+				this.createChrome(this.lunaServiceComponents);
+				this._getAppID();
+			}
+		},
 
 		/**
 		* When our platform is "PalmSystem", we need the appID to access the proper appinfo.json.
@@ -399,5 +396,9 @@
 			}
 			return true;
 		}
+	});
+
+	enyo.ready(function() {
+		moon.History.init();
 	});
 })(enyo, this);


### PR DESCRIPTION
The moon.History singleton was doing some initialization in its
create() method that depended on the presence of webOS.js. This
was working fine in unminified app source (and probably in the
container as well), but not in deployed app source, because the
singleton was being created before webOS.js could be loaded.

To address this issue, we move the initialization code out of
create() and into a separate init() method that we invoke in a
call to enyo.ready().

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)