### PR TITLE
ENYO-1033: Scroll into view expanded controls at the edge of the scrollable region.

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -162,7 +162,7 @@
 			}
 
 			enyo.TouchScrollStrategy.prototype.rendered._inherited.apply(this, arguments);
-			
+
 			if (measure) {
 				this._measureScrollColumns();
 			}
@@ -175,11 +175,11 @@
 		* available space for list controls. These metrics are derived via some LESS
 		* calculations, so to avoid brittleness we choose to measure them from the DOM
 		* rather than mirror the calculations in JavaScript.
-		* 
+		*
 		* Upon request, we do the measurement here (the first time a scroller is rendered)
 		* and cache the values in static properties, to avoid re-measuring each time we need
 		* the metrics.
-		* 
+		*
 		* @private
 		*/
 		_measureScrollColumns: function() {
@@ -680,7 +680,7 @@
 
 		/**
 		* Decorate spotlight events from paging controls so user can 5-way out of container
-		* 
+		*
 		* @private
 		*/
 		spotPaging: function (sender, event) {
@@ -708,10 +708,10 @@
 			var showVertical, showHorizontal,
 				bubble = false;
 			if (!enyo.Spotlight.getPointerMode() || event.scrollInPointerMode === true) {
-				showVertical = this.showVertical();
-				showHorizontal = this.showHorizontal();
 				this.scrollBounds = this._getScrollBounds();
 				this.setupBounds();
+				showVertical = this.showVertical();
+				showHorizontal = this.showHorizontal();
 				this.scrollBounds = null;
 				if (showVertical || showHorizontal) {
 					this.animateToControl(event.originator, event.scrollFullPage, event.scrollInPointerMode || false);


### PR DESCRIPTION
### Issue
When there is an expandable control that is at the edge of a scrollable region which currently does not require scrolling, expanding the control does not result in the control being properly scrolled into view.

### Fix
There was an ordering issue where we were first determining whether we needed to scroll, before the bounds were updated. This change made it into 2.3.x, but not in anything after (2.4.x, 2.5.x, 2.6.x).

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>