### PR TITLE
ENYO-1013: Set background image when sizing is specified.

### DIFF
--- a/source/Image.js
+++ b/source/Image.js
@@ -113,9 +113,9 @@
 		* @private
 		*/
 		bindings: [
+			{from: '.sizing', to: '.$.image.sizing'},
 			{from: '.src', to: '.$.image.src'},
 			{from: '.alt', to: '.$.image.alt'},
-			{from: '.sizing', to: '.$.image.sizing'},
 			{from: '.position', to: '.$.image.position'}
 		],
 


### PR DESCRIPTION
### Issue
This seems to have been broken for a long time, but setting the `sizing` property of `moon.Image` does not properly set the background-image as there is an ordering issue where the setting of the background-image is gated by the value of `sizing`, but in the current ordering of the bindings, the value of `sizing` would be set after the value of `src` at create time.

### Fix
We modify the order of the bindings such that the binding for `sizing` occurs before the binding for `src`. Additionally, we update the sample to demonstrate the use of the `sizing` property.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>