### PR TITLE
ENYO-1026: Call scroller resize on moon.DataGridList refresh

### DIFF
--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -131,6 +131,19 @@
 		var p = moon.DataGridList.delegates.verticalGrid = enyo.clone(enyo.DataGridList.delegates.verticalGrid);
 		enyo.kind.extendMethods(p, {
 			/**
+			* Overriding refresh() to resize scroller and stop scrolling.
+			*
+			* @method
+			* @private
+			*/
+			refresh: enyo.inherit(function (sup) {
+				return function (list) {
+					sup.apply(this, arguments);
+					list.$.scroller.resize();
+				};
+			}),
+
+			/**
 			* Overriding scrollToControl() to specify Moonstone-specific scroller options.
 			* No need to call the super method, so we don't wrap in enyo.inherit().
 			*

--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -139,7 +139,7 @@
 			refresh: enyo.inherit(function (sup) {
 				return function (list) {
 					sup.apply(this, arguments);
-					list.$.scroller.resize();
+					list.$.scroller.stop();
 				};
 			}),
 

--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -131,7 +131,7 @@
 		var p = moon.DataGridList.delegates.verticalGrid = enyo.clone(enyo.DataGridList.delegates.verticalGrid);
 		enyo.kind.extendMethods(p, {
 			/**
-			* Overriding refresh() to resize scroller and stop scrolling.
+			* Overriding refresh() to stop scroller and stop scrolling.
 			*
 			* @method
 			* @private


### PR DESCRIPTION
### Issue:
moon.DataGridList showing blank page when empty and add collection while scrolling.
This regression is introduced when we remove duplicated page generation https://github.com/enyojs/moonstone/pull/1868/files#diff-ad39c65132790ca5d3df3e181f58d645R115

### Fix:
Originally, scroll strategy was stop scrolling when collection empty.
Because, we called scroller resize on DataGridList refresh.
So, add refresh function back to DataGridList and checked page generation is still not duplicated.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com