### PR TITLE
ENYO-965 Restore spotlight focus to contextual popup

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -67,6 +67,12 @@
 		/**
 		* @private
 		*/
+		events: {
+			onRequestSpot: ''
+		},
+		/**
+		* @private
+		*/
 		handlers: {
 			onRequestShowPopup        : 'requestShow',
 			onRequestHidePopup        : 'requestHide',
@@ -556,6 +562,20 @@
 					moon.History.ignorePopState();
 				}
 			}
+		},
+
+		/**
+		* @private
+		*/
+		backKeyHandler: function() {
+			if (this.showing) {
+				this.hide();
+			}
+
+			if (this.spotlight && !this.spotlightDisabled) {
+				this.doRequestSpot();
+			}
+			return true;
 		},
 
 		/**

--- a/source/ContextualPopupDecorator.js
+++ b/source/ContextualPopupDecorator.js
@@ -136,6 +136,7 @@
 		*/
 		requestSpot: function (inSender, inEvent) {
 			enyo.Spotlight.spot(this);
+			return true;
 		}
 	});
 

--- a/source/ContextualPopupDecorator.js
+++ b/source/ContextualPopupDecorator.js
@@ -55,7 +55,8 @@
 		handlers: {
 			onActivate: 'activated',
 			onShow: 'popupShown',
-			onHide: 'popupHidden'
+			onHide: 'popupHidden',
+			onRequestSpot: 'requestSpot'
 		},
 
 		/**
@@ -126,6 +127,15 @@
 		*/
 		requestHidePopup: function () {
 			this.waterfallDown('onRequestHidePopup');
+		},
+
+		/**
+		* When back key is pressed, return spotlight focus to popup button
+		*
+		* @private
+		*/
+		requestSpot: function (inSender, inEvent) {
+			enyo.Spotlight.spot(this);
 		}
 	});
 


### PR DESCRIPTION
Issue
-------
After pressing back key in ContexualPopup, spotlight focus does not return to origin.

Cause
--------
When popup is opened, contents of popup had spotlight focus. 
But back key hide popup without spotlight focusing, so spotlight focus lost its way and back to container.

Fix
----
When popup is closed with back key, trigger onRequestSpot event to focus contextualPopup button.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com