### PR TITLE
ENYO-1091: Marquee (when set marqueeOnHover as true) is not stop when fo...

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -1140,8 +1140,9 @@
 
 	enyo.dispatcher.features.push(
 		function (e) {
-			if ("blur" === e.type && window === e.target) {
-				// Stop marquee when onblur event comes from window
+			if (("blur" === e.type && window === e.target) || 
+				("onSpotlightFocused" === e.type)) {
+				// Stop marquee when onblur or onSpotlightFocused event comes
 				var c = _getMarqueeOnHoverControl();
 				if (c) c._marquee_leave();
 			}


### PR DESCRIPTION
...cus moves to other control by 5way

### Issue:
Header title marquee is not stop after focus move to 'switch mode' in 5way.

### Fix:
Stops marquee if other control is focused only when a marquee control which is having marqueeOnHover option as true is flow.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com