### PR TITLE
ENYO-1026 (release-2.5.3-pre.17.t)

### DIFF
--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -117,7 +117,7 @@
 		var p = moon.DataGridList.delegates.verticalGrid = enyo.clone(enyo.DataGridList.delegates.verticalGrid);
 		enyo.kind.extendMethods(p, {
 			/**
-			* Overriding refresh() to resize scroller and stop scrolling.
+			* Overriding refresh() to stop scroller and stop scrolling.
 			*
 			* @method
 			* @private

--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -125,7 +125,7 @@
 			refresh: enyo.inherit(function (sup) {
 				return function (list) {
 					sup.apply(this, arguments);
-					list.$.scroller.resize();
+					list.$.scroller.stop();
 				};
 			}),
 

--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -117,6 +117,19 @@
 		var p = moon.DataGridList.delegates.verticalGrid = enyo.clone(enyo.DataGridList.delegates.verticalGrid);
 		enyo.kind.extendMethods(p, {
 			/**
+			* Overriding refresh() to resize scroller and stop scrolling.
+			*
+			* @method
+			* @private
+			*/
+			refresh: enyo.inherit(function (sup) {
+				return function (list) {
+					sup.apply(this, arguments);
+					list.$.scroller.resize();
+				};
+			}),
+
+			/**
 			* Overriding scrollToControl() to specify Moonstone-specific scroller options.
 			* No need to call the super method, so we don't wrap in enyo.inherit().
 			*


### PR DESCRIPTION
Cherry-picking the changes from https://github.com/enyojs/moonstone/pull/2001 into `release-2.5.3-pre.17.t`, creating a PR for tracking purposes.