### PR TITLE
ENYO-1100: Replace existing OGG videos in the Panels Video Player sample

### DIFF
--- a/samples/PanelsVideoPlayerSample.js
+++ b/samples/PanelsVideoPlayerSample.js
@@ -90,7 +90,7 @@ enyo.kind({
 		}
 		// Set source by sources array
 		this.sources = [
-			{src: undefined, type: "video/mp4"},
+			{src: "http://media.w3.org/2010/05/video/movie_300.mp4", type: "video/mp4"},
 			{src: "http://media.w3.org/2010/05/video/movie_300.ogv", type: "video/ogg"},
 			{src: "http://media.w3.org/2010/05/video/movie_300.webm", type: "video/webm"}
 		];
@@ -103,9 +103,8 @@ enyo.kind({
 		}
 		// Set source by sources array
 		this.sources = [
-			{src: null, type: "video/mp4"},
-			{src: "http://media.w3.org/2010/05/bunny/movie.ogv", type: "video/ogg"},
-			{src: "http://media.w3.org/2010/05/bunny/movie.webm", type: "video/webm"}
+			{src: "http://media.w3.org/2010/05/bunny/movie.mp4", type: "video/mp4"},
+			{src: "http://media.w3.org/2010/05/bunny/movie.ogv", type: "video/ogg"}
 		];
 		this.$.player.setSources(this.sources);
 		this.$.videoInfoHeader.setTitle("Bunny Video");

--- a/samples/VideoPlayerSample.js
+++ b/samples/VideoPlayerSample.js
@@ -9,8 +9,8 @@ enyo.kind({
 			kind: "moon.VideoPlayer",
 			sources: [
 				{src: "http://media.w3.org/2010/05/bunny/movie.mp4", type: "video/mp4"},
-				{src: "http://media.w3.org/2010/05/bunny/movie.ogg", type: "video/ogg"},
-				{src: "http://media.w3.org/2010/05/bunny/movie.webm", type: "video/webm"}
+				{src: "http://media.w3.org/2010/05/bunny/movie.ogv", type: "video/ogg"},
+				{src: "http://media.w3.org/2010/05/sintel/trailer.webm", type: "video/webm"}
 			],
 			poster: "$lib/moonstone/samples/assets/video-poster.png",
 			autoplay:true,
@@ -93,8 +93,8 @@ enyo.kind({
 		// We can set source by sources array
 		this.sources = [
 			{src: "http://media.w3.org/2010/05/bunny/movie.mp4", type: "video/mp4"},
-			{src: "http://media.w3.org/2010/05/bunny/movie.ogg", type: "video/ogg"},
-			{src: "http://media.w3.org/2010/05/bunny/movie.webm", type: "video/webm"}
+			{src: "http://media.w3.org/2010/05/bunny/movie.ogv", type: "video/ogg"},
+			{src: "http://media.w3.org/2010/05/sintel/trailer.webm", type: "video/webm"}
 		];
 		this.$.player.setSources(this.sources);
 	}


### PR DESCRIPTION
### Issue:
The Inline Video Player no longer supports the OGG video format (Bunny and Counter video). The Sintel video is the only functional video that plays back.
### Fix:
verify and fix paths to w3 media files
Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan <krishna.rangarajan@lge.com>