### PR TITLE
Fixes ENYO-1139

### DIFF
--- a/source/Slider.js
+++ b/source/Slider.js
@@ -323,6 +323,7 @@
 		* @public
 		*/
 		animateTo: function(start, end) {
+			start = this.clampValue(this.min, this.max, start);
 			end = this.clampValue(this.min, this.max, end); // Moved from animatorStep
 			this.animatingTo = end;
 


### PR DESCRIPTION
## Issue

Previously, only the end value was clamped which allowed the slider to
animate from an invalid value.

## Fix
Clamp start of Slider.animateTo

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)