### PR TITLE
ENYO-1137: Correct positioning of selection overlay.

### DIFF
--- a/source/SelectionOverlaySupport.js
+++ b/source/SelectionOverlaySupport.js
@@ -133,7 +133,7 @@
 		* @private
 		*/
 		selectionOverlayHorizontalOffsetChanged: function () {
-			this.$.selectionScrimIcon.applyStyle((this.rtl ? 'right' : 'left'), this.selectionOverlayHorizontalOffset + '%');
+			this.$.selectionScrimIcon.applyStyle('left', this.selectionOverlayHorizontalOffset + '%');
 		}
 	};
 


### PR DESCRIPTION
### Issue
In RTL mode, the selection overlay icon is not positioned in the center. This is due to the fact that we are setting different positioning based on directionality, but are not accounting for this when setting the `translateX` value to adjust the selection overlay icon back to the center.

### Fix
We could add a CSS rule to set `translateX(50%)` when in RTL mode, but it seemed more straightforward to eliminate unnecessary RTL handling where possible, so we always absolutely position the selection overlay icon utilizing the `left` property, as we are only concerned with the icon being centered.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>