### PR TITLE
Fixes BHV-23301

### DIFF
--- a/source/VideoTransportSlider.js
+++ b/source/VideoTransportSlider.js
@@ -367,9 +367,9 @@
 		* @private
 		*/
 		enterTapArea: function(sender, e) {
+			this.startPreview();
 			if (!this.disabled) {
 				this.addClass('visible');
-				this.startPreview();
 				this.doEnterTapArea();
 			}
 		},


### PR DESCRIPTION
## Issue
If the pointer is enters the slider tap area while the slider is disabled, future pointer movements do not correctly display the preview because preview mode was not enabled when the pointer entered.

## Fix
Since displaying the preview is also guarded by a disabled check, we
can always enable preview mode when entering the tap area so that if
the slider is enabled while the pointer is still within the tap area,
future pointer movements will correctly update the preview display.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho (sb.cho@lge.com)