### PR TITLE
ENYO-1149: Update samples to utilize custom LESS script.

### DIFF
--- a/samples/AccordionSample.html
+++ b/samples/AccordionSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/AccordionSample.html
+++ b/samples/AccordionSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Accordion Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ActivityPanelsSample.html
+++ b/samples/ActivityPanelsSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/ActivityPanelsSample.html
+++ b/samples/ActivityPanelsSample.html
@@ -7,16 +7,11 @@
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script>
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/ActivityPanelsWithVideoSample.html
+++ b/samples/ActivityPanelsWithVideoSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/ActivityPanelsWithVideoSample.html
+++ b/samples/ActivityPanelsWithVideoSample.html
@@ -6,17 +6,12 @@
 	<title>Activity Panels With Video Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/AlwaysViewingPanelsSample.html
+++ b/samples/AlwaysViewingPanelsSample.html
@@ -6,17 +6,12 @@
 	<title>Always Viewing Panels Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/AlwaysViewingPanelsSample.html
+++ b/samples/AlwaysViewingPanelsSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/AlwaysViewingPanelsWithVideoSample.html
+++ b/samples/AlwaysViewingPanelsWithVideoSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/AlwaysViewingPanelsWithVideoSample.html
+++ b/samples/AlwaysViewingPanelsWithVideoSample.html
@@ -6,17 +6,12 @@
 	<title>Always Viewing Panels Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/AudioPlaybackSample.html
+++ b/samples/AudioPlaybackSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/AudioPlaybackSample.html
+++ b/samples/AudioPlaybackSample.html
@@ -6,17 +6,12 @@
 	<title>Audio Playback Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/BodyLargeTextSample.html
+++ b/samples/BodyLargeTextSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Body Large Text Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/BodyLargeTextSample.html
+++ b/samples/BodyLargeTextSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/BodyTextSample.html
+++ b/samples/BodyTextSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Body Text Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/BodyTextSample.html
+++ b/samples/BodyTextSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ButtonSample.html
+++ b/samples/ButtonSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/ButtonSample.html
+++ b/samples/ButtonSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Button Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/CalendarSample.html
+++ b/samples/CalendarSample.html
@@ -6,17 +6,12 @@
 	<title>Calendar Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/CalendarSample.html
+++ b/samples/CalendarSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/CheckboxItemSample.html
+++ b/samples/CheckboxItemSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Check Item Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/CheckboxItemSample.html
+++ b/samples/CheckboxItemSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ClockSample.html
+++ b/samples/ClockSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/ClockSample.html
+++ b/samples/ClockSample.html
@@ -6,17 +6,12 @@
 	<title>Clock Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/ContextualPopupSample.html
+++ b/samples/ContextualPopupSample.html
@@ -6,17 +6,12 @@
 	<title>Contextual Popup Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ContextualPopupSample.html
+++ b/samples/ContextualPopupSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DataGridListSample.html
+++ b/samples/DataGridListSample.html
@@ -6,17 +6,12 @@
 	<title>DataGridList Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DataGridListSample.html
+++ b/samples/DataGridListSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DataListSample.html
+++ b/samples/DataListSample.html
@@ -6,17 +6,12 @@
 	<title>DataList Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DataListSample.html
+++ b/samples/DataListSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DatePickerSample.html
+++ b/samples/DatePickerSample.html
@@ -6,17 +6,17 @@
 	<title>Date Picker Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="enyo/tools/less-ri.js"></script> -->
+	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/full-package.js" type="text/javascript"></script>

--- a/samples/DatePickerSample.html
+++ b/samples/DatePickerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->

--- a/samples/DialogSample.html
+++ b/samples/DialogSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/DialogSample.html
+++ b/samples/DialogSample.html
@@ -6,17 +6,12 @@
 	<title>Dialog Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/DividerSample.html
+++ b/samples/DividerSample.html
@@ -6,17 +6,12 @@
 	<title>Divider Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DividerSample.html
+++ b/samples/DividerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DrawerSample.html
+++ b/samples/DrawerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DrawerSample.html
+++ b/samples/DrawerSample.html
@@ -6,17 +6,12 @@
 	<title>Drawer Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DynamicPanelsSample.html
+++ b/samples/DynamicPanelsSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/DynamicPanelsSample.html
+++ b/samples/DynamicPanelsSample.html
@@ -7,16 +7,11 @@
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
-	<!-- <script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandableDataPickerSample.html
+++ b/samples/ExpandableDataPickerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandableDataPickerSample.html
+++ b/samples/ExpandableDataPickerSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Expandable Data Picker Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandableInputSample.html
+++ b/samples/ExpandableInputSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Expandable Input Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandableInputSample.html
+++ b/samples/ExpandableInputSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandableListItemSample.html
+++ b/samples/ExpandableListItemSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Expandable ListItem Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandableListItemSample.html
+++ b/samples/ExpandableListItemSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandablePickerSample.html
+++ b/samples/ExpandablePickerSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Expandable Picker Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandablePickerSample.html
+++ b/samples/ExpandablePickerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandableTextSample.html
+++ b/samples/ExpandableTextSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Expandable Text Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ExpandableTextSample.html
+++ b/samples/ExpandableTextSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/FormCheckboxSample.html
+++ b/samples/FormCheckboxSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone FormCheckBox Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/FormCheckboxSample.html
+++ b/samples/FormCheckboxSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/HeaderAutoCollapsingSample.html
+++ b/samples/HeaderAutoCollapsingSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/HeaderAutoCollapsingSample.html
+++ b/samples/HeaderAutoCollapsingSample.html
@@ -6,17 +6,12 @@
 	<title>Header Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/HeaderSample.html
+++ b/samples/HeaderSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/HeaderSample.html
+++ b/samples/HeaderSample.html
@@ -6,17 +6,12 @@
 	<title>Header Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/HighlightTextSample.html
+++ b/samples/HighlightTextSample.html
@@ -6,17 +6,12 @@
 	<title>Highlight Text Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/HighlightTextSample.html
+++ b/samples/HighlightTextSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/IconButtonSample.html
+++ b/samples/IconButtonSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone IconButton Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/IconButtonSample.html
+++ b/samples/IconButtonSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/IconSample.html
+++ b/samples/IconSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Icon Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/IconSample.html
+++ b/samples/IconSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ImageBadgeSample.html
+++ b/samples/ImageBadgeSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Image Badge Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ImageBadgeSample.html
+++ b/samples/ImageBadgeSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ImageItemSample.html
+++ b/samples/ImageItemSample.html
@@ -6,17 +6,12 @@
 	<title>ImageItem Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ImageItemSample.html
+++ b/samples/ImageItemSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/InputHeaderSample.html
+++ b/samples/InputHeaderSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/InputHeaderSample.html
+++ b/samples/InputHeaderSample.html
@@ -6,17 +6,12 @@
 	<title>Header Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/InputSample.html
+++ b/samples/InputSample.html
@@ -6,17 +6,12 @@
 	<title>Input Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/InputSample.html
+++ b/samples/InputSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/IntegerPickerSample.html
+++ b/samples/IntegerPickerSample.html
@@ -6,17 +6,12 @@
 	<title>Integer Scroll Picker Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/IntegerPickerSample.html
+++ b/samples/IntegerPickerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ItemSample.html
+++ b/samples/ItemSample.html
@@ -6,17 +6,12 @@
 	<title>Item Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ItemSample.html
+++ b/samples/ItemSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/LabeledTextItemSample.html
+++ b/samples/LabeledTextItemSample.html
@@ -6,17 +6,12 @@
 	<title>Labeled TextItem Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/LabeledTextItemSample.html
+++ b/samples/LabeledTextItemSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ListActionsSample.html
+++ b/samples/ListActionsSample.html
@@ -6,17 +6,12 @@
 	<title>List Actions Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ListActionsSample.html
+++ b/samples/ListActionsSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/MarqueeSample.html
+++ b/samples/MarqueeSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/MarqueeSample.html
+++ b/samples/MarqueeSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Marquee Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ObjectActionHorizontalTypeSample.html
+++ b/samples/ObjectActionHorizontalTypeSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ObjectActionHorizontalTypeSample.html
+++ b/samples/ObjectActionHorizontalTypeSample.html
@@ -6,17 +6,12 @@
 	<title>Object Action: horizontal Type Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ObjectActionVerticalTypeSample.html
+++ b/samples/ObjectActionVerticalTypeSample.html
@@ -6,17 +6,12 @@
 	<title>Object Action: vertical Type Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ObjectActionVerticalTypeSample.html
+++ b/samples/ObjectActionVerticalTypeSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/PanelsVideoPlayerSample.html
+++ b/samples/PanelsVideoPlayerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/PanelsVideoPlayerSample.html
+++ b/samples/PanelsVideoPlayerSample.html
@@ -6,17 +6,12 @@
 	<title>Video Player Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/PanelsWithCardArrangerSample.html
+++ b/samples/PanelsWithCardArrangerSample.html
@@ -6,17 +6,12 @@
 	<title>Panels with Card Arranger Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/PanelsWithCardArrangerSample.html
+++ b/samples/PanelsWithCardArrangerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/PanelsWithCarouselArrangerSample.html
+++ b/samples/PanelsWithCarouselArrangerSample.html
@@ -6,17 +6,12 @@
 	<title>Panels with Carousel Arranger Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/PanelsWithCarouselArrangerSample.html
+++ b/samples/PanelsWithCarouselArrangerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/PopupSample.html
+++ b/samples/PopupSample.html
@@ -6,17 +6,12 @@
 	<title>Popup Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/PopupSample.html
+++ b/samples/PopupSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ProgressButtonSample.html
+++ b/samples/ProgressButtonSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Progress Button Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ProgressButtonSample.html
+++ b/samples/ProgressButtonSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ProgressSample.html
+++ b/samples/ProgressSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Progress Bar Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ProgressSample.html
+++ b/samples/ProgressSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/RadioItemSample.html
+++ b/samples/RadioItemSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Radio Item Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/RadioItemSample.html
+++ b/samples/RadioItemSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/Scroller2dSample.html
+++ b/samples/Scroller2dSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone 2D Scroller Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/Scroller2dSample.html
+++ b/samples/Scroller2dSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ScrollerHorizontalSample.html
+++ b/samples/ScrollerHorizontalSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ScrollerHorizontalSample.html
+++ b/samples/ScrollerHorizontalSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Horizontal Scroller Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ScrollerTextSample.html
+++ b/samples/ScrollerTextSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Text Scrolling Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ScrollerTextSample.html
+++ b/samples/ScrollerTextSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ScrollerVerticalSample.html
+++ b/samples/ScrollerVerticalSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Scroller Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ScrollerVerticalSample.html
+++ b/samples/ScrollerVerticalSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/SelectableItemSample.html
+++ b/samples/SelectableItemSample.html
@@ -6,17 +6,12 @@
 	<title>SelectableItem Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/SelectableItemSample.html
+++ b/samples/SelectableItemSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/SimpleIntegerPickerSample.html
+++ b/samples/SimpleIntegerPickerSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Simple Integer Picker Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/SimpleIntegerPickerSample.html
+++ b/samples/SimpleIntegerPickerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/SimplePickerSample.html
+++ b/samples/SimplePickerSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Simple Picker Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/SimplePickerSample.html
+++ b/samples/SimplePickerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/SliderSample.html
+++ b/samples/SliderSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/SliderSample.html
+++ b/samples/SliderSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Slider Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/SpinnerSample.html
+++ b/samples/SpinnerSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Spinner Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/SpinnerSample.html
+++ b/samples/SpinnerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/TableSample.html
+++ b/samples/TableSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/TableSample.html
+++ b/samples/TableSample.html
@@ -6,17 +6,12 @@
 	<title>Table Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/TimePickerSample.html
+++ b/samples/TimePickerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../enyo-cordova/package.js" type="text/javascript"></script>

--- a/samples/TimePickerSample.html
+++ b/samples/TimePickerSample.html
@@ -6,17 +6,12 @@
 	<title>Time Picker Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../enyo-cordova/package.js" type="text/javascript"></script>

--- a/samples/ToggleButtonSample.html
+++ b/samples/ToggleButtonSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/ToggleButtonSample.html
+++ b/samples/ToggleButtonSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Toggle Button Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/ToggleItemSample.html
+++ b/samples/ToggleItemSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Toggle Item Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/ToggleItemSample.html
+++ b/samples/ToggleItemSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>

--- a/samples/TooltipSample.html
+++ b/samples/TooltipSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/TooltipSample.html
+++ b/samples/TooltipSample.html
@@ -6,17 +6,12 @@
 	<title>Moonstone Tooltip Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/VideoPlayerInlineSample.html
+++ b/samples/VideoPlayerInlineSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/VideoPlayerInlineSample.html
+++ b/samples/VideoPlayerInlineSample.html
@@ -6,23 +6,18 @@
 	<title>Inline Video Player Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>
 	<script src="../../layout/package.js" type="text/javascript"></script>
 	<script src="../../moonstone/package.js" type="text/javascript"></script>
-	<script src="../../spotlight/package.js" type="text/javascript"></script>	
+	<script src="../../spotlight/package.js" type="text/javascript"></script>
 	<!-- -->
 	<link href="VideoPlayerInlineSample.css" rel="stylesheet">
 	<script src="VideoPlayerInlineSample.js" type="text/javascript"></script>

--- a/samples/VideoPlayerSample.html
+++ b/samples/VideoPlayerSample.html
@@ -11,7 +11,7 @@
 	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
 		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
 		script is uncommented). -->
-	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
+	<!-- <script src="../../../enyo/tools/less.js" ri></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>

--- a/samples/VideoPlayerSample.html
+++ b/samples/VideoPlayerSample.html
@@ -6,17 +6,12 @@
 	<title>Video Player Sample</title>
 	<!-- -->
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) 
-	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
-	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
-		<script>
-			;(function(){
-				var less = window.less || {};
-				var ri = new enyoLessRiPlugin();
-				less.plugins = [ri];
-				window.less = less;
-			}())
-		</script> -->
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS) -->
+	<!-- <script src="../../../enyo/tools/less.js"></script> -->
+	<!-- Resolution-independent version of LESS that parses and converts both LESS and CSS. Uncomment for client-side
+		rendering of resolution-independent stylesheets; leave commented for standard LESS (make sure the above less.js
+		script is uncommented). -->
+	<!-- <script src="../../../enyo/tools/less-ri.js"></script> -->
 	<!-- -->
 	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
 	<script src="../../enyo-ilib/package.js" type="text/javascript"></script>


### PR DESCRIPTION
### Issue
The current samples utilize direct paths to the specific LESS version we're currently running. We wanted to reference our custom LESS script so that we can easily utilize the resolution-independence version of LESS as needed.

### Fix
The paths have been updated (keeping with the default of all being commented-out) to reference `less.js`.

### Notes
This is dependent on https://github.com/enyojs/enyo/pull/1062 being integrated first.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>