### PR TITLE
ENYO-1138: Ensuring requestScrollIntoView's originator is showing before...

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -715,16 +715,19 @@
 		* @private
 		*/
 		requestScrollIntoView: function(sender, event) {
-			var showVertical, showHorizontal,
+			var originator, showVertical, showHorizontal,
 				bubble = false;
 			if (!enyo.Spotlight.getPointerMode() || event.scrollInPointerMode === true) {
+				originator = event.originator;
+				showVertical = this.showVertical();
+				showHorizontal = this.showHorizontal();
 				this.scrollBounds = this._getScrollBounds();
 				this.setupBounds();
 				showVertical = this.showVertical();
 				showHorizontal = this.showHorizontal();
 				this.scrollBounds = null;
-				if (showVertical || showHorizontal) {
-					this.animateToControl(event.originator, event.scrollFullPage, event.scrollInPointerMode || false);
+				if ((showVertical || showHorizontal) && (originator.showing)) {
+					this.animateToControl(originator, event.scrollFullPage, event.scrollInPointerMode || false);
 					if ((showVertical && this.$.scrollMath.bottomBoundary) || (showHorizontal && this.$.scrollMath.rightBoundary)) {
 						this.alertThumbs();
 					}


### PR DESCRIPTION
... triggering the scroll.

### Issue
Developers could have a need to arbitrarily hide controls at any time - including after issuing a "requestScrollIntoView" event, causing an unexpected scroll to a hidden control (or bounce-effect).

### Fix
Ensuring controls are showing before performing the scroll should eliminate these edge-cases.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>