### PR TITLE
ENYO-1146: Reassigned font sizes

### DIFF
--- a/css/Calendar.less
+++ b/css/Calendar.less
@@ -64,7 +64,7 @@
 }
 
 .moon-calendar-picker-date {
-	.moon-sub-header-text-base (@moon-sub-header-font-size, @moon-calendar-picker-date-color);
+	.moon-text-base (@moon-sub-header-font-size, @moon-calendar-picker-date-color);
 	width: @moon-button-small-height;
 	line-height: @moon-picker-button-width;
 	border-radius: @moon-button-border-radius;

--- a/css/ChannelInfo.less
+++ b/css/ChannelInfo.less
@@ -20,7 +20,7 @@
 	.enyo-locale-non-latin .moon-video-player-info-title
 }
 .moon-video-player-channel-info-name {
-	.moon-sub-header-text-base (@moon-sub-header-font-size, @moon-player-channel-info-name-text-color);
+	.moon-text-base (@moon-sub-header-font-size, @moon-player-channel-info-name-text-color);
 	margin-bottom: 18px;
 	white-space: nowrap;
 }
@@ -28,7 +28,7 @@
 	font-family: @moon-non-latin-font-family;
 }
 .moon-video-player-info-icon {
-	.moon-sub-header-text-base (@moon-video-player-info-icon-text-size, @moon-videoplayer-info-icon-text-color);
+	.moon-text-base (@moon-video-player-info-icon-text-size, @moon-videoplayer-info-icon-text-color);
 	background-color: @moon-videoplayer-info-icon-bg-color;
 	border-radius: 6px;
 	text-align: center;

--- a/css/Dialog.less
+++ b/css/Dialog.less
@@ -5,9 +5,6 @@
 .moon-dialog-title {
 	margin-bottom: 12px;
 }
-.moon-dialog-sub-title {
-	font-size: @moon-superscript-text-size;
-}
 .moon-dialog-client-wrapper {
 	min-height: 108px;
 }

--- a/css/Header.less
+++ b/css/Header.less
@@ -33,7 +33,8 @@
 		}
 	}
 
-	.moon-header-title-below, .moon-header-sub-title-below {
+	.moon-header-title-below,
+	.moon-header-sub-title-below {
 		height: 48px;
 	}
 
@@ -64,7 +65,8 @@
 			line-height: @moon-medium-header-line-height;
 		}
 
-		.moon-header-title-below, .moon-header-sub-title-below {
+		.moon-header-title-below,
+		.moon-header-sub-title-below {
 			height: 42px;
 		}
 	}
@@ -73,7 +75,9 @@
 	&.moon-small-header {
 		height: @moon-header-height-small;
 
-		.moon-header-title-above, .moon-header-title-below, .moon-header-sub-title-below {
+		.moon-header-title-above,
+		.moon-header-title-below,
+		.moon-header-sub-title-below {
 			display: none;
 		}
 

--- a/css/Item.less
+++ b/css/Item.less
@@ -1,6 +1,6 @@
 /* Item.css */
 .moon-item {
-	.moon-sub-header-text;
+	.moon-text-base (@moon-item-font-size);
 	line-height: @moon-item-line-height;
 	padding: @moon-spotlight-outset;
 	position: relative;

--- a/css/ListActions.less
+++ b/css/ListActions.less
@@ -3,6 +3,7 @@
 	position:relative;
 	display:inline-block;
 	overflow:visible;
+
 	.moon-icon-button {
 		margin:0;
 	}
@@ -73,7 +74,7 @@
 	z-index: 50;
 	pointer-events: none;
 	* {
-		pointer-events: auto;		
+		pointer-events: auto;
 	}
 
 	&.stacked .moon-list-actions-menu {
@@ -107,7 +108,7 @@
 	}
 }
 .moon-list-actions.stacked .enyo-fittable-rows-layout > * {
-	height: auto !important;	
+	height: auto !important;
 }
 .moon-panels .moon-header .moon-list-actions-drawer {
 	pointer-events: none;

--- a/css/VideoInfoHeader.less
+++ b/css/VideoInfoHeader.less
@@ -1,6 +1,6 @@
 .moon-video-info-header {
-	display:inline-block; 
-	vertical-align:top;
+	display: inline-block;
+	vertical-align: top;
 	max-width: 1110px;
 }
 .moon-video-player-info-datetime {
@@ -12,8 +12,7 @@
 	font-size: 126px;
 	margin-bottom: 0;
 	white-space: nowrap;
-	-webkit-font-kerning:normal;
-	font-kerning:normal;
+	.font-kerning;
 }
 .enyo-locale-non-latin .moon-video-player-info-title {
 	line-height: @moon-non-latin-header-text-line-height;
@@ -21,7 +20,7 @@
 	height: 1.4em;
 }
 .moon-video-player-info-subtitle {
-	.moon-sub-header-text-base (@moon-sub-header-font-size, @moon-white);
+	.moon-text-base (@moon-sub-header-font-size, @moon-white);
 	margin-bottom: 18px;
 	white-space: nowrap;
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -422,31 +422,25 @@ html {
   -webkit-font-kerning: normal;
   font-kerning: normal;
 }
-.moon-sub-header-text {
-  font-family: "MuseoSans 700";
-  font-size: 1.25rem;
-  color: #a6a6a6;
-}
 .moon-super-header-text {
   font-family: "Moonstone Miso";
   font-size: 1.375rem;
   -webkit-font-kerning: normal;
 }
-.moon-popup-header-text {
-  font-family: "Moonstone Miso";
-  font-size: 3rem;
-  -webkit-font-kerning: normal;
-}
-.moon-divider-text {
-  font-family: "MuseoSans 700 Italic";
-  font-size: 0.875rem;
+.moon-sub-header-text {
+  font-family: "MuseoSans 700";
+  font-size: 1.25rem;
   color: #a6a6a6;
+}
+.moon-header-sub-title-below {
+  font-family: "MuseoSans 300";
+  font-size: 1.125rem;
 }
 .moon-body-text {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-body-text a:link {
   color: #cf0652;
@@ -465,14 +459,14 @@ html {
   text-decoration: none;
 }
 .moon-body-large-text {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
+  font-size: 1.5rem;
+  line-height: 2rem;
 }
 .moon-bold-text {
   font-family: "MuseoSans 900";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-bold-text a:link {
   color: #cf0652;
@@ -495,7 +489,7 @@ html {
 }
 .moon-large-button-text {
   font-family: "Moonstone Miso Bold";
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   -webkit-font-kerning: normal;
 }
 .moon-small-button-text {
@@ -507,6 +501,23 @@ html {
   font-family: "Moonstone Icons";
   font-size: 3rem;
   color: #ffffff;
+}
+.moon-popup-header-text,
+.moon-dialog-title {
+  font-family: "Moonstone Miso";
+  font-size: 3rem;
+  -webkit-font-kerning: normal;
+}
+.moon-dialog-sub-title {
+  font-size: 1.125rem;
+}
+.moon-dialog-content {
+  font-size: 1.25rem;
+}
+.moon-divider-text {
+  font-family: "MuseoSans 700 Italic";
+  font-size: 1rem;
+  color: #a6a6a6;
 }
 .enyo-locale-non-latin .moon,
 .enyo-locale-non-latin .moon input,
@@ -1123,7 +1134,7 @@ html {
 /* Item.css */
 .moon-item {
   font-family: "MuseoSans 700";
-  font-size: 1.25rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
   line-height: 1.2em;
   padding: 0.5rem;
@@ -1437,9 +1448,9 @@ html {
 }
 .moon-expandable-list-item-client .moon-item {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-expandable-list-item-client .moon-item a:link {
   color: #cf0652;
@@ -1509,8 +1520,8 @@ html {
 /* Current Value */
 .moon-expandable-picker-current-value {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
-  line-height: 1.375rem;
+  font-size: 1.375rem;
+  line-height: 1.625rem;
   color: #a6a6a6;
   margin: 0rem;
 }
@@ -1687,9 +1698,9 @@ html {
 }
 .moon-gridlist-imageitem .sub-caption {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-gridlist-imageitem .sub-caption a:link {
   color: #cf0652;
@@ -2452,7 +2463,7 @@ html {
   border: 0;
   cursor: pointer;
   background: transparent;
-  height: 4.125rem;
+  height: 4.875rem;
   width: 12.5rem;
   color: #4b4b4b;
   resize: none;
@@ -2624,9 +2635,9 @@ html {
 /* Text */
 .moon-labeledtextitem .text {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   text-transform: none;
   margin: 0rem;
   padding: 0rem;
@@ -3725,9 +3736,6 @@ html {
 .moon-dialog-title {
   margin-bottom: 0.5rem;
 }
-.moon-dialog-sub-title {
-  font-size: 1rem;
-}
 .moon-dialog-client-wrapper {
   min-height: 4.5rem;
 }
@@ -4003,7 +4011,7 @@ html {
 }
 .moon-video-transport-slider-popup-label {
   font-family: "Moonstone Miso Bold";
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   -webkit-font-kerning: normal;
   white-space: nowrap;
   color: #4b4b4b;
@@ -4450,9 +4458,9 @@ html {
 }
 .moon-video-player-info-subsubtitle {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   font-style: italic;
   color: #ffffff;
   display: inline-block;
@@ -4484,9 +4492,9 @@ html {
 }
 .moon-video-player-info-description {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   color: #ffffff;
   white-space: normal;
   margin-bottom: 1rem;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -422,31 +422,25 @@ html {
   -webkit-font-kerning: normal;
   font-kerning: normal;
 }
-.moon-sub-header-text {
-  font-family: "MuseoSans 700";
-  font-size: 1.25rem;
-  color: #4b4b4b;
-}
 .moon-super-header-text {
   font-family: "Moonstone Miso";
   font-size: 1.375rem;
   -webkit-font-kerning: normal;
 }
-.moon-popup-header-text {
-  font-family: "Moonstone Miso";
-  font-size: 3rem;
-  -webkit-font-kerning: normal;
-}
-.moon-divider-text {
-  font-family: "MuseoSans 700 Italic";
-  font-size: 0.875rem;
+.moon-sub-header-text {
+  font-family: "MuseoSans 700";
+  font-size: 1.25rem;
   color: #4b4b4b;
+}
+.moon-header-sub-title-below {
+  font-family: "MuseoSans 300";
+  font-size: 1.125rem;
 }
 .moon-body-text {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-body-text a:link {
   color: #cf0652;
@@ -465,14 +459,14 @@ html {
   text-decoration: none;
 }
 .moon-body-large-text {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
+  font-size: 1.5rem;
+  line-height: 2rem;
 }
 .moon-bold-text {
   font-family: "MuseoSans 900";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-bold-text a:link {
   color: #cf0652;
@@ -495,7 +489,7 @@ html {
 }
 .moon-large-button-text {
   font-family: "Moonstone Miso Bold";
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   -webkit-font-kerning: normal;
 }
 .moon-small-button-text {
@@ -507,6 +501,23 @@ html {
   font-family: "Moonstone Icons";
   font-size: 3rem;
   color: #ffffff;
+}
+.moon-popup-header-text,
+.moon-dialog-title {
+  font-family: "Moonstone Miso";
+  font-size: 3rem;
+  -webkit-font-kerning: normal;
+}
+.moon-dialog-sub-title {
+  font-size: 1.125rem;
+}
+.moon-dialog-content {
+  font-size: 1.25rem;
+}
+.moon-divider-text {
+  font-family: "MuseoSans 700 Italic";
+  font-size: 1rem;
+  color: #4b4b4b;
 }
 .enyo-locale-non-latin .moon,
 .enyo-locale-non-latin .moon input,
@@ -1123,7 +1134,7 @@ html {
 /* Item.css */
 .moon-item {
   font-family: "MuseoSans 700";
-  font-size: 1.25rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
   line-height: 1.2em;
   padding: 0.5rem;
@@ -1437,9 +1448,9 @@ html {
 }
 .moon-expandable-list-item-client .moon-item {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-expandable-list-item-client .moon-item a:link {
   color: #cf0652;
@@ -1509,8 +1520,8 @@ html {
 /* Current Value */
 .moon-expandable-picker-current-value {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
-  line-height: 1.375rem;
+  font-size: 1.375rem;
+  line-height: 1.625rem;
   color: #4b4b4b;
   margin: 0rem;
 }
@@ -1687,9 +1698,9 @@ html {
 }
 .moon-gridlist-imageitem .sub-caption {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-gridlist-imageitem .sub-caption a:link {
   color: #cf0652;
@@ -2452,7 +2463,7 @@ html {
   border: 0;
   cursor: pointer;
   background: transparent;
-  height: 4.125rem;
+  height: 4.875rem;
   width: 12.5rem;
   color: #4b4b4b;
   resize: none;
@@ -2624,9 +2635,9 @@ html {
 /* Text */
 .moon-labeledtextitem .text {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   text-transform: none;
   margin: 0rem;
   padding: 0rem;
@@ -3725,9 +3736,6 @@ html {
 .moon-dialog-title {
   margin-bottom: 0.5rem;
 }
-.moon-dialog-sub-title {
-  font-size: 1rem;
-}
 .moon-dialog-client-wrapper {
   min-height: 4.5rem;
 }
@@ -4003,7 +4011,7 @@ html {
 }
 .moon-video-transport-slider-popup-label {
   font-family: "Moonstone Miso Bold";
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   -webkit-font-kerning: normal;
   white-space: nowrap;
   color: #4b4b4b;
@@ -4450,9 +4458,9 @@ html {
 }
 .moon-video-player-info-subsubtitle {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   font-style: italic;
   color: #ffffff;
   display: inline-block;
@@ -4484,9 +4492,9 @@ html {
 }
 .moon-video-player-info-description {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   color: #ffffff;
   white-space: normal;
   margin-bottom: 1rem;

--- a/css/moonstone-rules.less
+++ b/css/moonstone-rules.less
@@ -36,7 +36,7 @@ html {
 	font-style: normal;
 	letter-spacing: normal;
 	padding: @moon-app-keepout;
-	color: @moon-sub-header-text-color;
+	color: @moon-text-color;
 	background-color: @moon-background-color;
 }
 

--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -4,8 +4,8 @@
 }
 
 // mixin classes for create the moontone text classes
-.moon-sub-header-text-base (@font-size, @font-color) {
-	font-family: @moon-sub-header-font-family;
+.moon-text-base (@font-size, @font-color: @moon-text-color) {
+	font-family: @moon-font-family;
 	font-size: @font-size;
 	color: @font-color;
 }
@@ -38,25 +38,19 @@
 .moon-header-text {
 	font-family: @moon-header-font-family;
 	font-size: @moon-header-font-size;
-	.font-kerning
-}
-.moon-sub-header-text {
-	.moon-sub-header-text-base (@moon-sub-header-font-size, @moon-sub-header-text-color);
+	.font-kerning;
 }
 .moon-super-header-text {
 	font-family: @moon-super-header-font-family;
 	font-size: @moon-super-header-font-size;
 	-webkit-font-kerning: normal;
 }
-.moon-popup-header-text {
-	font-family: @moon-popup-header-font-family;
-	font-size: @moon-popup-header-font-size;
-	-webkit-font-kerning: normal;
+.moon-sub-header-text {
+	.moon-text-base (@moon-sub-header-font-size);
 }
-.moon-divider-text {
-	font-family: @moon-divider-font-family;
-	font-size: @moon-divider-font-size;
-	color: @moon-divider-text-color;
+.moon-header-sub-title-below {
+	font-family: @moon-sub-header-below-font-family;
+	font-size: @moon-sub-header-below-font-size;
 }
 .moon-body-text {
 	font-family: @moon-body-font-family;
@@ -99,6 +93,23 @@
 	font-family: @moon-icon-font-family;
 	font-size: @moon-icon-font-size;
 	color: @moon-icon-color;
+}
+.moon-popup-header-text,
+.moon-dialog-title {
+	font-family: @moon-popup-header-font-family;
+	font-size: @moon-popup-header-font-size;
+	-webkit-font-kerning: normal;
+}
+.moon-dialog-sub-title {
+	font-size: @moon-popup-sub-header-font-size;
+}
+.moon-dialog-content {
+	font-size: @moon-popup-content-font-size;
+}
+.moon-divider-text {
+	font-family: @moon-divider-font-family;
+	font-size: @moon-divider-font-size;
+	color: @moon-divider-text-color;
 }
 
 .enyo-locale-non-latin {

--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -7,6 +7,7 @@
 @moon-white: #ffffff;
 
 @moon-background-color: @moon-black;
+@moon-text-color: #a6a6a6;
 @moon-header-sub-title-color: #a6a6a6;
 @moon-sub-header-text-color: #a6a6a6;
 @moon-divider-text-color: #a6a6a6;

--- a/css/moonstone-variables-light.less
+++ b/css/moonstone-variables-light.less
@@ -7,14 +7,15 @@
 @moon-white: #ffffff;
 
 @moon-background-color: @moon-light-gray;
-@moon-header-sub-title-color: #a6a6a6;
+@moon-text-color: @moon-dark-gray;
+@moon-header-sub-title-color: @moon-dark-gray;
 @moon-sub-header-text-color: @moon-dark-gray;
-@moon-divider-text-color: #4b4b4b;
-@moon-sup-header-text-color: #4b4b4b;
-@moon-header-text-color: #4b4b4b;
-@moon-header-border-color: #4b4b4b;
-@moon-header-bottom-border-color: #4b4b4b;
-@moon-body-text-color: #4b4b4b;
+@moon-divider-text-color: @moon-dark-gray;
+@moon-sup-header-text-color: @moon-dark-gray;
+@moon-header-text-color: @moon-dark-gray;
+@moon-header-border-color: @moon-dark-gray;
+@moon-header-bottom-border-color: @moon-dark-gray;
+@moon-body-text-color: @moon-dark-gray;
 @moon-spotlight-text-color: @moon-white;
 @moon-spotlight-background-color: @moon-accent;
 @moon-spotlight-border-color: @moon-accent;

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -53,16 +53,20 @@
 @moon-superscript-text-size:        24px;
 @moon-large-text-size:              48px;
 @moon-pre-text-size:                24px;
-@moon-popup-header-font-size:       72px;
-@moon-sub-header-font-size:         30px;
-@moon-super-header-font-size:       33px;
-@moon-body-font-size:               27px;
-@moon-divider-font-size:            21px;
-@moon-button-large-font-size:       33px;
-@moon-button-small-font-size:       27px;
 @moon-header-font-size:             126px;
-@moon-small-header-font-size:   	60px;
-@moon-small-header-sub-header-font-size:   	27px;
+@moon-super-header-font-size:       33px;
+@moon-sub-header-font-size:         30px;
+@moon-sub-header-below-font-size:   27px;
+@moon-small-header-font-size:       60px;
+@moon-small-header-sub-header-font-size:   @moon-sub-header-below-font-size;
+@moon-body-font-size:               33px;
+@moon-item-font-size:               33px;
+@moon-popup-header-font-size:       72px;
+@moon-popup-sub-header-font-size:   27px;
+@moon-popup-content-font-size:   	30px;
+@moon-divider-font-size:            24px;
+@moon-button-large-font-size:       36px;
+@moon-button-small-font-size:       27px;
 @moon-clock-minute-font-size:       60px;
 @moon-clock-text-font-size:         54px;
 @moon-clock-meridiem-font-size:     24px;
@@ -104,17 +108,18 @@
 @moon-non-latin-medium-header-line-height: 1.5em;
 @moon-non-latin-small-header-line-height: 1.5em;
 
-@moon-popup-header-font-family: "Moonstone Miso";
+@moon-popup-header-font-family: @moon-header-font-family;
 @moon-popup-header-font-weight: normal;
 @moon-popup-header-letter-spacing: normal;
 @moon-popup-header-font-style: normal;
 @moon-popup-header-line-height: normal;
 
-@moon-sub-header-font-family: "MuseoSans 700";
+@moon-sub-header-font-family: @moon-font-family;
 @moon-sub-header-font-weight: normal;
 @moon-sub-header-letter-spacing: 0;
 @moon-sub-header-font-style: normal;
 @moon-sub-header-line-height: 2em;
+@moon-sub-header-below-font-family: @moon-font-family-light;
 
 @moon-super-header-font-family: "Moonstone Miso";
 @moon-super-header-font-weight: normal;

--- a/source/Header.js
+++ b/source/Header.js
@@ -284,7 +284,7 @@
 				]}
 			]},
 			{name: 'titleBelow', kind: 'moon.MarqueeText', classes: 'moon-sub-header-text moon-header-title-below'},
-			{name: 'subTitleBelow', kind: 'moon.MarqueeText', classes: 'moon-body-text moon-header-sub-title-below'},
+			{name: 'subTitleBelow', kind: 'moon.MarqueeText', classes: 'moon-sub-header-text moon-header-sub-title-below'},
 			{name: 'client', classes: 'moon-hspacing moon-header-client'},
 			{name: 'animator', kind: 'enyo.StyleAnimator', onComplete: 'animationComplete'}
 		],


### PR DESCRIPTION
* Renamed the `.moon-sub-header-text-base` to `.moon-text-base` to be more geneic and universal. It now also respects the standard text color if none is provided.
* Rearranged some rules for better, more logical inheritance.
* Reassigned some static strings to logical related variables, not just because they have the same value, but because the two elements should have matching styles.
* Header now uses better class names for its subtitles.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>