### PR TITLE
ENYO-1217: Only scroll to value if node does not exist.

### DIFF
--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -663,7 +663,10 @@
 		showingChangedHandler: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
-				if(this.showing) {
+
+				// Only force a scrolling to the item corresponding to the current value if it is
+				// not already displayed.
+				if (this.showing && !this.$.repeater.fetchRowNode(this.valueToIndex(this.get('value')))) {
 					this.scrollToValue();
 				}
 			};

--- a/source/IntegerPicker.js
+++ b/source/IntegerPicker.js
@@ -664,9 +664,9 @@
 			return function () {
 				sup.apply(this, arguments);
 
-				// Only force a scrolling to the item corresponding to the current value if it is
-				// not already displayed.
-				if (this.showing && !this.$.repeater.fetchRowNode(this.valueToIndex(this.get('value')))) {
+				// Only force a scroll to the item corresponding to the current value if it is not
+				// already displayed.
+				if (this.showing && !this.$.repeater.fetchRowNode(this.valueToIndex(this.value))) {
 					this.scrollToValue();
 				}
 			};


### PR DESCRIPTION
### Issue
We were currently scrolling into place the item corresponding to the current value of `moon.IntegerPicker`, when unhiding the picker control. This was originally done to scroll into view the appropriate item, if the value had been changed while the picker control was hidden. What is occurring in this case is that the scroll position is incorrect after unhiding because we are not providing a "previous" item to scroll from (which had previously occupied the space above the current item), when scrolling to the current item.

### Fix
One way to fix this would be to brute-force refresh the scroll bounds in this scenario where we are unhiding and subsequently scrolling to the current item. But to avoid any unnecessary scroll bounds calculations, I have instead modified the conditional such that we guard against scrolling to the current item, if the current item is already displayed. This allows the current, correct position of the current item to not be modified, while also accounting for the case where we are setting the value while the control is hidden. And because this is a flyweight repeater, we should be able to assume that if the current item displayed corresponds to our current value, it is necessarily in the correct, viewable position.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>