### PR TITLE
ENYO-1226: ToggleItem is now the correct color on spotlight and animation restored

### DIFF
--- a/css/ToggleSwitch.less
+++ b/css/ToggleSwitch.less
@@ -43,13 +43,17 @@
 			color: @moon-checkbox-toggle-switch-color;
 		}
 	}
-	&.animated .moon-icon {
-		-webkit-transition: background-color 0.2s, left 0.2s;
-		transition: background-color 0.2s, left 0.2s;
+	&.animated {
+		-webkit-transition: background-color 0.2s;
+		transition: background-color 0.2s;
 
-		&:after {
-			-webkit-transition: color 0.2s;
-			transition: color 0.2s;
+		.moon-icon {
+			-webkit-transition: left 0.2s, color 0.2s;
+			transition: left 0.2s, color 0.2s;
 		}
 	}
+}
+.moon-toggle-item.spotlight .moon-checkbox.moon-toggle-switch .moon-icon {
+	// to override the ghost checkmark opacity rules, since this inherits its style from moon-checkbox
+	opacity: 1;
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1038,13 +1038,16 @@ html {
 .moon-checkbox.moon-toggle-switch[disabled] .moon-icon {
   color: #a6a6a6;
 }
-.moon-checkbox.moon-toggle-switch.animated .moon-icon {
-  -webkit-transition: background-color 0.2s, left 0.2s;
-  transition: background-color 0.2s, left 0.2s;
+.moon-checkbox.moon-toggle-switch.animated {
+  -webkit-transition: background-color 0.2s;
+  transition: background-color 0.2s;
 }
-.moon-checkbox.moon-toggle-switch.animated .moon-icon:after {
-  -webkit-transition: color 0.2s;
-  transition: color 0.2s;
+.moon-checkbox.moon-toggle-switch.animated .moon-icon {
+  -webkit-transition: left 0.2s, color 0.2s;
+  transition: left 0.2s, color 0.2s;
+}
+.moon-toggle-item.spotlight .moon-checkbox.moon-toggle-switch .moon-icon {
+  opacity: 1;
 }
 .moon-toggle-item {
   display: block;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1038,13 +1038,16 @@ html {
 .moon-checkbox.moon-toggle-switch[disabled] .moon-icon {
   color: #4b4b4b;
 }
-.moon-checkbox.moon-toggle-switch.animated .moon-icon {
-  -webkit-transition: background-color 0.2s, left 0.2s;
-  transition: background-color 0.2s, left 0.2s;
+.moon-checkbox.moon-toggle-switch.animated {
+  -webkit-transition: background-color 0.2s;
+  transition: background-color 0.2s;
 }
-.moon-checkbox.moon-toggle-switch.animated .moon-icon:after {
-  -webkit-transition: color 0.2s;
-  transition: color 0.2s;
+.moon-checkbox.moon-toggle-switch.animated .moon-icon {
+  -webkit-transition: left 0.2s, color 0.2s;
+  transition: left 0.2s, color 0.2s;
+}
+.moon-toggle-item.spotlight .moon-checkbox.moon-toggle-switch .moon-icon {
+  opacity: 1;
 }
 .moon-toggle-item {
   display: block;


### PR DESCRIPTION
The ghost checkmarks and moon.Icon refactor interfered with the inherited styles of the ToggleSwitch.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>