### PR TITLE
ENYO-1107:  ignoring tap events before video starts

### DIFF
--- a/css/VideoPlayer.less
+++ b/css/VideoPlayer.less
@@ -3,6 +3,21 @@
 	display: inline-block;
 	background-color: @moon-video-player-bg-color;
 }
+// Base set of styling for scrim to prevent receiving user input while spinner is showing
+.moon-video-player:after {
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+}
+// Adding the content property here, instead of above, means that this element will only appear in
+// the DOM during ".spinner-showing". This was altered to improve performance.
+// Pseudo-elements without a content property cannot receive styling.
+.moon-video-player.spinner-showing:after {
+	content: '';
+}
+
 .moon-video-player:not(.enyo-fullscreen) {
 	margin: 0 @moon-spotlight-outset;
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4070,6 +4070,16 @@ html {
   display: inline-block;
   background-color: #000000;
 }
+.moon-video-player:after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+.moon-video-player.spinner-showing:after {
+  content: '';
+}
 .moon-video-player:not(.enyo-fullscreen) {
   margin: 0 0.5rem;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4070,6 +4070,16 @@ html {
   display: inline-block;
   background-color: #000000;
 }
+.moon-video-player:after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+.moon-video-player.spinner-showing:after {
+  content: '';
+}
 .moon-video-player:not(.enyo-fullscreen) {
   margin: 0 0.5rem;
 }

--- a/samples/VideoPlayerSample.js
+++ b/samples/VideoPlayerSample.js
@@ -8,9 +8,9 @@ enyo.kind({
 			name: "player",
 			kind: "moon.VideoPlayer",
 			sources: [
-				{src: "http://media.w3.org/2010/05/bunny/movsie.mp4", type: "video/mp4"},
-				{src: "http://media.w3.org/2010/05/bunny/movsie.ogv", type: "video/ogg"},
-				{src: "http://media.w3.org/2010/05/sintel/traisler.webm", type: "video/webm"}
+				{src: "http://media.w3.org/2010/05/bunny/movie.mp4", type: "video/mp4"},
+				{src: "http://media.w3.org/2010/05/bunny/movie.ogv", type: "video/ogg"},
+				{src: "http://media.w3.org/2010/05/sintel/trailer.webm", type: "video/webm"}
 			],
 			poster: "$lib/moonstone/samples/assets/video-poster.png",
 			autoplay:true,
@@ -92,9 +92,9 @@ enyo.kind({
 		this.$.player.unload();
 		// We can set source by sources array
 		this.sources = [
-			{src: "http://media.w3.org/2010/05/bunny/movsie.mp4", type: "video/mp4"},
-			{src: "http://media.w3.org/2010/05/bunny/movsie.ogv", type: "video/ogg"},
-			{src: "http://media.w3.org/2010/05/sintel/trasiler.webm", type: "video/webm"}
+			{src: "http://media.w3.org/2010/05/bunny/movie.mp4", type: "video/mp4"},
+			{src: "http://media.w3.org/2010/05/bunny/movie.ogv", type: "video/ogg"},
+			{src: "http://media.w3.org/2010/05/sintel/trailer.webm", type: "video/webm"}
 		];
 		this.$.player.setSources(this.sources);
 	}

--- a/samples/VideoPlayerSample.js
+++ b/samples/VideoPlayerSample.js
@@ -8,9 +8,9 @@ enyo.kind({
 			name: "player",
 			kind: "moon.VideoPlayer",
 			sources: [
-				{src: "http://media.w3.org/2010/05/bunny/movie.mp4", type: "video/mp4"},
-				{src: "http://media.w3.org/2010/05/bunny/movie.ogv", type: "video/ogg"},
-				{src: "http://media.w3.org/2010/05/sintel/trailer.webm", type: "video/webm"}
+				{src: "http://media.w3.org/2010/05/bunny/movsie.mp4", type: "video/mp4"},
+				{src: "http://media.w3.org/2010/05/bunny/movsie.ogv", type: "video/ogg"},
+				{src: "http://media.w3.org/2010/05/sintel/traisler.webm", type: "video/webm"}
 			],
 			poster: "$lib/moonstone/samples/assets/video-poster.png",
 			autoplay:true,
@@ -92,9 +92,9 @@ enyo.kind({
 		this.$.player.unload();
 		// We can set source by sources array
 		this.sources = [
-			{src: "http://media.w3.org/2010/05/bunny/movie.mp4", type: "video/mp4"},
-			{src: "http://media.w3.org/2010/05/bunny/movie.ogv", type: "video/ogg"},
-			{src: "http://media.w3.org/2010/05/sintel/trailer.webm", type: "video/webm"}
+			{src: "http://media.w3.org/2010/05/bunny/movsie.mp4", type: "video/mp4"},
+			{src: "http://media.w3.org/2010/05/bunny/movsie.ogv", type: "video/ogg"},
+			{src: "http://media.w3.org/2010/05/sintel/trasiler.webm", type: "video/webm"}
 		];
 		this.$.player.setSources(this.sources);
 	}

--- a/source/VideoPlayer.js
+++ b/source/VideoPlayer.js
@@ -1833,8 +1833,10 @@
 		updateSpinner: function() {
 			var spinner = this.$.spinner;
 			if (this.autoShowSpinner && this._isPlaying && !this._canPlay && !this._errorCode) {
+				this.addClass("spinner-showing");
 				spinner.start();
 			} else if (spinner.getShowing()) {
+				this.removeClass("spinner-showing");
 				spinner.stop();
 			}
 		},


### PR DESCRIPTION
### Issue

There was a Q issue about ignoring tap events while the video is loading. @mediachild felt that ignoring the tap event before the video starts is reasonable behavior, so opening a PR to add this behavior to the framework.

### Fix

Similar to the technique used in Panels.less, add an :after scrim which blocks the tap while a particular class ('spinner-showing') is applied