### PR TITLE
ENYO-712-Unspottable popup does not dismiss on Enter fixed

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -209,6 +209,7 @@
 
 			if (this.tapCaptured) {
 				this.tapCaptured = false;
+				this.popupActivated = true;
 			} else {
 				this.popupActivated = false;
 			}
@@ -474,12 +475,9 @@
 		* @private
 		*/
 		capturedTap: function (inSender, inEvent) {
-			// If same activator tapped sequentially, we notice that this popup is already activeted.
-			if (inEvent.dispatchTarget.isDescendantOf(this.activator)) {
-				this.popupActivated = true;
+			// If same activator tapped sequentially, the state of the popup is remembered.
+			if (this.downEvent && this.downEvent.dispatchTarget.isDescendantOf(this.activator)) {
 				this.tapCaptured = true;
-			} else {
-				this.popupActivated = false;
 			}
 			this.inherited(arguments);
 		},

--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -206,7 +206,6 @@
 		and the dependent decorator code inorder to handle some special cases.
 		*/
 		hide: function(inSender, e) {
-
 			if (this.tapCaptured) {
 				this.tapCaptured = false;
 				this.popupActivated = true;

--- a/source/ContextualPopupDecorator.js
+++ b/source/ContextualPopupDecorator.js
@@ -67,8 +67,7 @@
 			if (inEvent.sentFromPopup && inEvent.sentFromPopup.isDescendantOf(this)) {
 				return;
 			}
-
-			this.requestHidePopup();
+			
 			if (inEvent.originator.active) {
 				this.activator = inEvent.originator;
 				// if this ContextualPopup is already activated


### PR DESCRIPTION
Issue raises because, handling events is not done properly. To close a
popup 2 events are being used. One from popup, other from popup
activator button's activated event. Dependency is removed on
"activatate" event. This fixes one more issue of popup not opening.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan P<rajyavardhan.p@lge.com>