### PR TITLE
ENYO-519 : add moon.DayPicker component as a Dreadlocks UX requirements

### DIFF
--- a/samples/ExpandablePickerSample.js
+++ b/samples/ExpandablePickerSample.js
@@ -43,6 +43,7 @@ enyo.kind({
 						{kind: "moon.ExpandableIntegerPicker", noneText: "Not Selected", disabled:true, autoCollapse: true, content: "Disabled Integer Picker", value: 2, min: 1, max: 15, unit: "sec"},
 						{kind: "moon.DatePicker", noneText: "Pick a Date", content: "Date Picker"},
 						{kind: "moon.TimePicker", noneText: "Pick a Date", content: "Time Picker"},
+						{kind: "moon.DayPicker", noneText: "Pick a Day", content: "Day Picker"},
 						{kind: "moon.ExpandableInput", noneText: "Enter text", content: "Expandable Input", placeholder: "Enter text"},
 						{kind: "moon.ExpandableDataPicker", content: "Expandable Data Picker", noneText: "Nothing Selected", components: [
 							{bindings: [

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -1,0 +1,249 @@
+(function (enyo, scope) {
+	/**
+	* {@link moon.DayPicker}, which extends {@link moon.ExpandablePicker}, is
+	* a drop-down picker menu that solicits day of the week from the user.
+	*
+	* ```
+	* {kind: 'moon.DayPicker'}
+	* ```
+	*
+	* When the picker is minimized, the currently selected day are
+	* displayed as subtext below the picker label. And if the picker select every weekday,
+	* subtext will be changed 'Every Weekday' automatically.
+	*
+	* The content of representative value can be changed.
+	* ```
+	* {kind: 'moon.DayPicker', everyWeekdayText:'Weekdays', everyWeekendText:'Weekends', everyDayText:'Daily'}
+	* ```
+	*
+	* @class moon.DayPicker
+	* @extends moon.ExpandablePicker
+	* @ui
+	* @public
+	*/
+	enyo.kind(
+		/** @lends moon.DayPicker.prototype */ {
+
+		/**
+		* @private
+		*/
+		name: 'moon.DayPicker',
+
+		/**
+		* @private
+		*/
+		kind: 'moon.ExpandablePicker',
+
+		/**
+		* @private
+		*/
+		autoCollapseOnSelect: false,
+
+		/**
+		* @private
+		*/
+		multipleSelection: true,
+
+		/**
+		* @private
+		*/
+		content: moon.$L('Select days'),
+
+		/**
+		* @private
+		* @lends moon.DayPicker.prototype
+		*/
+		published: {
+
+			/**
+			* Text to be displayed when all of the day are selected.
+			*
+			* @type {String}
+			* @default 'Every Day'
+			* @public
+			*/
+			everyDayText: moon.$L('Every Day'),
+
+			/**
+			* Text to be displayed when all of the weekday are selected.
+			*
+			* @type {String}
+			* @default 'Every Weekday'
+			* @public
+			*/
+			everyWeekdayText: moon.$L('Every Weekday'),
+
+			/**
+			* Text to be displayed when all of the weekend are selected.
+			*
+			* @type {String}
+			* @default 'Every Weekend'
+			* @public
+			*/
+			everyWeekendText: moon.$L('Every Weekend'),
+
+			/**
+			* Text to be displayed as the current value if no item is currently selected.
+			*
+			* @type {String}
+			* @default 'Nothing selected'
+			* @public
+			*/
+			noneText: moon.$L('Nothing selected'),
+		},
+
+		/**
+		* @private
+		*/
+		firstDayOfWeek: 0,
+
+		/**
+		* @private
+		*/
+		weekEndStart: 6,
+
+		/**
+		* @private
+		*/
+		weekEndEnd: 0,
+
+		/**
+		* @private
+		*/
+		tools: [
+			{kind: 'enyo.Signals', onlocalechange: 'handleLocaleChangeEvent'}
+		],
+
+		/**
+		* @private
+		*/
+		daysComponents: [
+			{content: 'Sunday'},
+			{content: 'Monday'},
+			{content: 'Tuesday'},
+			{content: 'Wednesday'},
+			{content: 'Thursday'},
+			{content: 'Friday'},
+			{content: 'Saturday'}
+		],
+
+		/**
+		* @private
+		*/
+		days: ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'],
+
+		/**
+		* @private
+		*/
+		create: enyo.inherit(function (sup) {
+			return function() {
+				// super initialization
+				sup.apply(this, arguments);
+				this.createChrome(this.tools);
+				this.initILib();
+				this.createComponents(this.daysComponents);
+			};
+		}),
+
+		/**
+		* @private
+		*/
+		initILib: function () {
+			if (typeof ilib !== 'undefined') {
+				var df = new ilib.DateFmt({length: "full"});
+				var sdf = new ilib.DateFmt({length: "long"});
+				var li = new ilib.LocaleInfo(ilib.getLocale());
+				var daysFullName = df.getDaysOfWeek();
+				this.days = sdf.getDaysOfWeek();
+				this.firstDayOfWeek = li.getFirstDayOfWeek();
+				this.weekEndStart = li.getWeekEndStart();
+				this.weekEndEnd = li.getWeekEndEnd();
+
+				var index;
+				switch (this.firstDayOfWeek) {
+				case 0 :
+					for (index = 0; index < this.daysComponents.length; index++) {
+						this.daysComponents[index].content = daysFullName[index];
+					}
+					break;
+				case 1 :
+					for (index = 1; index < this.daysComponents.length; index++) {
+						this.daysComponents[index-1].content = daysFullName[index];
+					}
+					this.daysComponents[6].content = daysFullName[0];
+					this.days.push(this.days.shift());
+					this.weekEndStart = this.weekEndStart ? this.weekEndStart-1 : 6;
+					this.weekEndEnd = this.weekEndEnd ? this.weekEndEnd-1 : 6;
+					break;
+				}
+			}
+		},
+
+		/**
+		* @private
+		*/
+		handleLocaleChangeEvent: function () {
+			this.destroyClientControls();
+			this.initILib();
+			this.createComponents(this.daysComponents);
+			this.render();
+		},
+
+		/**
+		* @private
+		*/
+		multiSelectCurrentValue: function () {
+			var str = this.checkDays();
+			if (str){
+				return str;
+			}
+
+			for (var i=0; i < this.selectedIndex.length; i++) {
+				if (!str) {
+					str = this.days[this.selectedIndex[i]];
+				} else {
+					str = str + ', ' + this.days[this.selectedIndex[i]];
+				}
+			}
+			return str || this.getNoneText();
+		},
+
+		/**
+		* @private
+		*/
+		checkDays: function () {
+			var indexLength = this.selectedIndex.length;
+			var joinIndex = this.selectedIndex.join();
+			var hasWeekEnd = this.checkWeekEnd();
+
+			switch (indexLength) {
+			case 7 :
+				return this.everyDayText;
+			case 5 :
+				if (!hasWeekEnd) {
+					return this.everyWeekdayText;
+				}
+				break;
+			case 2 :
+				if (hasWeekEnd) {
+					return this.everyWeekendText;
+				}
+				break;
+			}
+		},
+
+		/**
+		* @private
+		*/
+		checkWeekEnd: function () {
+			var bWeekEndStart = this.selectedIndex.indexOf(this.weekEndStart);
+			var bWeekEndEnd = this.selectedIndex.indexOf(this.weekEndEnd);
+
+			if (bWeekEndStart >= 0 && bWeekEndEnd >= 0) {
+				return true;
+			} else if (bWeekEndStart == -1 && bWeekEndEnd == -1) {
+				return false;
+			}
+		}
+	});
+})(enyo, this);

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -219,12 +219,12 @@
 			case 7 :
 				return this.everyDayText;
 			case 5 :
-				if (!hasWeekEnd) {
+				if (hasWeekEnd === false) {
 					return this.everyWeekdayText;
 				}
 				break;
 			case 2 :
-				if (hasWeekEnd) {
+				if (hasWeekEnd === true) {
 					return this.everyWeekendText;
 				}
 				break;

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -95,11 +95,6 @@
 		/**
 		* @private
 		*/
-		firstDayOfWeek: 0,
-
-		/**
-		* @private
-		*/
 		weekEndStart: 6,
 
 		/**
@@ -155,12 +150,12 @@
 				var li = new ilib.LocaleInfo(ilib.getLocale());
 				var daysFullName = df.getDaysOfWeek();
 				this.days = sdf.getDaysOfWeek();
-				this.firstDayOfWeek = li.getFirstDayOfWeek();
+				var firstDayOfWeek = li.getFirstDayOfWeek();
 				this.weekEndStart = li.getWeekEndStart();
 				this.weekEndEnd = li.getWeekEndEnd();
 
 				var index;
-				switch (this.firstDayOfWeek) {
+				switch (firstDayOfWeek) {
 				case 0 :
 					for (index = 0; index < this.daysComponents.length; index++) {
 						this.daysComponents[index].content = daysFullName[index];

--- a/source/DayPicker.js
+++ b/source/DayPicker.js
@@ -89,7 +89,7 @@
 			* @default 'Nothing selected'
 			* @public
 			*/
-			noneText: moon.$L('Nothing selected'),
+			noneText: moon.$L('Nothing selected')
 		},
 
 		/**
@@ -213,7 +213,6 @@
 		*/
 		checkDays: function () {
 			var indexLength = this.selectedIndex.length;
-			var joinIndex = this.selectedIndex.join();
 			var hasWeekEnd = this.checkWeekEnd();
 
 			switch (indexLength) {

--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -243,7 +243,8 @@
 		},
 
 		/**
-		* @private
+		* 'multiSelectCurrentValue()' can be overridden by subkinds, such as moon.DayPicker
+		* @protected
 		*/
 		multiSelectCurrentValue: function () {
 			if (!this.multipleSelection) {

--- a/source/package.js
+++ b/source/package.js
@@ -35,6 +35,7 @@ enyo.depends(
 	'PagingControl.js',
 	'DateTimePickerBase.js',
 	'DatePicker.js',
+	'DayPicker.js',
 	'TimePicker.js',
 	'Input.js',
 	'InputDecorator.js',


### PR DESCRIPTION
### Issue
There is a requirement for supporting string overlay on Expandable picker in Dreadlocks.
(Especially, it target expandable picker which can select day of the week and shows representative value )

### Solution
For resolving the requirement, make a new kind which inherited from Expandable Picker and add features which are described in ENYO-519

This is copy of https://github.com/enyojs/moonstone/pull/1961

DCO-1.1-Signed-Off-By: Sungbae Cho sb.cho@lge.com