### PR TITLE
ENYO-1287: Transition from moon.ri.scale to enyo.ri.scale.

### DIFF
--- a/source/BreadcrumbArranger.js
+++ b/source/BreadcrumbArranger.js
@@ -218,7 +218,7 @@
 		*/
 		calculateXPos: function (panelIndex, index, containerWidth, joinedPanels) {
 			var breadcrumbEdge = this.getBreadcrumbEdge(index),
-				breadcrumbWidth = moon.ri.scale(this.breadcrumbWidth),
+				breadcrumbWidth = enyo.ri.scale(this.breadcrumbWidth),
 				panels = this.container.getPanels(),
 				xPos,
 				i,
@@ -419,7 +419,7 @@
 				if (xPos < 0) {
 					// lets check if its fully off.
 					var containerPadding = this.getContainerPadding();
-					if (xPos <= ((moon.ri.scale(this.breadcrumbWidth) - containerPadding.left) * -1)) {
+					if (xPos <= ((enyo.ri.scale(this.breadcrumbWidth) - containerPadding.left) * -1)) {
 						// Its visible portion is, so lets nudge it off entirely so it can't be
 						// highlighted using just its non-visible edge
 						xPos -= containerPadding.right;
@@ -439,7 +439,7 @@
 			var transitionPosition = this.container.transitionPositions[panelIndex + '.' + activeIndex];
 			var screenEdge = this.container.panelCoverRatio == 1 ? this.getBreadcrumbEdge(panelIndex) : 0;
 			if (transitionPosition < 0) {
-				return transitionPosition + moon.ri.scale(this.breadcrumbWidth) <= screenEdge;
+				return transitionPosition + enyo.ri.scale(this.breadcrumbWidth) <= screenEdge;
 			} else {
 				return transitionPosition >= this.containerBounds.width;
 			}
@@ -458,7 +458,7 @@
 		calcBreadcrumbEdges: function () {
 			this.breadcrumbEdges = [];
 			for (var i = 0, panel; (panel = this.container.getPanels()[i]); i++) {
-				this.breadcrumbEdges[i] = (i === 0) ? 0 : moon.ri.scale(this.breadcrumbWidth);
+				this.breadcrumbEdges[i] = (i === 0) ? 0 : enyo.ri.scale(this.breadcrumbWidth);
 			}
 		},
 
@@ -486,7 +486,7 @@
 				leftMargin += containerPadding.left + containerPadding.right;
 			}
 			if (this.container.showFirstBreadcrumb && index !== 0) {
-				leftMargin += moon.ri.scale(this.breadcrumbWidth);
+				leftMargin += enyo.ri.scale(this.breadcrumbWidth);
 			}
 			return leftMargin;
 		},

--- a/source/DataGridList.js
+++ b/source/DataGridList.js
@@ -76,9 +76,9 @@
 				sup.apply(this, arguments);
 
 				// scale px values for current resolution
-				this.spacing = moon.ri.scale(this.spacing);
-				this.minWidth = moon.ri.scale(this.minWidth);
-				this.minHeight = moon.ri.scale(this.minHeight);
+				this.spacing = enyo.ri.scale(this.spacing);
+				this.minWidth = enyo.ri.scale(this.minWidth);
+				this.minHeight = enyo.ri.scale(this.minHeight);
 			};
 		}),
 

--- a/source/Header.js
+++ b/source/Header.js
@@ -472,7 +472,7 @@
 					100: [{
 						control: this,
 						properties: {
-							'height': enyo.dom.unit(moon.ri.scale(260), 'rem')
+							'height': enyo.dom.unit(enyo.ri.scale(260), 'rem')
 						}
 					}, {
 						control: this.$.titleWrapper,
@@ -612,7 +612,7 @@
 				// Measure client area's width + 40px of spacing
 				client = this.$.client ? this.$.client.hasNode() : null,
 				clientWidth = client ? client.offsetWidth : null,
-				clientSpace = enyo.dom.unit(clientWidth + moon.ri.scale(36), 'rem'),
+				clientSpace = enyo.dom.unit(clientWidth + enyo.ri.scale(36), 'rem'),
 				rtl = this.rtl;
 
 			if (client) {

--- a/source/ListActions.js
+++ b/source/ListActions.js
@@ -499,7 +499,7 @@
 		unStackMeUp: function() {
 			var containerHeight, optionGroup, i;
 			if (this.standardHeight) {
-				this.$.drawer.applyStyle('height', enyo.dom.unit( moon.ri.scale(this.standardHeight), 'rem'));
+				this.$.drawer.applyStyle('height', enyo.dom.unit( enyo.ri.scale(this.standardHeight), 'rem'));
 			}
 			containerHeight = this.getContainerBounds().height;
 

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -437,8 +437,8 @@
 		* @private
 		*/
 		updatePopupOffset: function() {
-			// console.log("updatePopupOffset:", this.getPopupHeight(), this.getPopupOffset(), moon.ri.scale(this.getPopupHeight() + this.getPopupOffset() + 5));
-			this.$.popup.applyStyle('top', enyo.dom.unit(-(moon.ri.scale(this.getPopupHeight() + this.getPopupOffset() + 5)), 'rem'));
+			// console.log("updatePopupOffset:", this.getPopupHeight(), this.getPopupOffset(), enyo.ri.scale(this.getPopupHeight() + this.getPopupOffset() + 5));
+			this.$.popup.applyStyle('top', enyo.dom.unit(-(enyo.ri.scale(this.getPopupHeight() + this.getPopupOffset() + 5)), 'rem'));
 		},
 
 		/**
@@ -467,13 +467,13 @@
 		*/
 		updatePopupHeight: function() {
 			var h = this.getPopupHeight(),
-				hRem = moon.ri.scale(h);
+				hRem = enyo.ri.scale(h);
 
 			this.$.drawingLeft.setAttribute('height', hRem);
 			this.$.drawingRight.setAttribute('height', hRem);
-			this.$.popupLabel.applyStyle('height', enyo.dom.unit(moon.ri.scale(h - 7), 'rem'));
-			this.$.popup.applyStyle('height', enyo.dom.unit(moon.ri.scale(h), 'rem'));
-			this.$.popup.applyStyle('line-height', enyo.dom.unit(moon.ri.scale(h - 6), 'rem'));
+			this.$.popupLabel.applyStyle('height', enyo.dom.unit(enyo.ri.scale(h - 7), 'rem'));
+			this.$.popup.applyStyle('height', enyo.dom.unit(enyo.ri.scale(h), 'rem'));
+			this.$.popup.applyStyle('line-height', enyo.dom.unit(enyo.ri.scale(h - 6), 'rem'));
 		},
 
 		/**
@@ -882,20 +882,20 @@
 		*/
 		drawToCanvas: function(bgColor) {
 			bgColor = bgColor  || enyo.dom.getComputedStyleValue(this.$.knob.hasNode(), 'background-color');
-			var h = moon.ri.scale( this.getPopupHeight()+1 ), // height total
-				hb = h - moon.ri.scale(8), // height bubble
+			var h = enyo.ri.scale( this.getPopupHeight()+1 ), // height total
+				hb = h - enyo.ri.scale(8), // height bubble
 				hbc = (hb)/2, // height of bubble's center
-				wre = moon.ri.scale(26), // width's edge
+				wre = enyo.ri.scale(26), // width's edge
 				r = hbc, // radius is half the bubble height
-				bcr = moon.ri.scale(50), // bottom curve radius 50
+				bcr = enyo.ri.scale(50), // bottom curve radius 50
 				bcy = hb + bcr, //calculate the height of the center of the circle plus the radius to get the y coordinate of the circle to draw the bottom irregular arc
 				lw = 1, // line width that will be tucked under the neighboring dom element's edge
 
 				ctxLeft = this.$.drawingLeft.hasNode().getContext('2d'),
 				ctxRight = this.$.drawingRight.hasNode().getContext('2d');
 
-			this.$.drawingLeft.setAttribute('width', moon.ri.scale( this.popupLeftCanvasWidth) );
-			this.$.drawingRight.setAttribute('width', moon.ri.scale( this.popupRightCanvasWidth) );
+			this.$.drawingLeft.setAttribute('width', enyo.ri.scale( this.popupLeftCanvasWidth) );
+			this.$.drawingRight.setAttribute('width', enyo.ri.scale( this.popupRightCanvasWidth) );
 
 			// Set styles. Default color is knob's color
 			ctxLeft.fillStyle = bgColor;


### PR DESCRIPTION
### Issue
We had initially created the resolution-independent support methods in the moon namespace and have since moved these methods to the enyo namespace.

### Fix
Convert calls to `moon.ri.scale` to `enyo.ri.scale`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>