### PR TITLE
ENYO-458: Added theme classes to redefine any container to any theme.

### DIFF
--- a/css/Button-color.less
+++ b/css/Button-color.less
@@ -1,0 +1,66 @@
+/* Button */
+.moon-button {
+	background-color: @moon-button-background-color;
+	color: @moon-button-text-color;
+
+	&.active,
+	&.pressed,
+	&.spotlight.pressed,
+	&.spotlight:active {
+		border-color: @moon-spotlight-border-color;
+		background-color: @moon-button-background-color;
+		color: @moon-button-text-color;
+	}
+
+	&.spotlight {
+		background-color: @moon-spotlight-border-color;
+		color: @moon-spotlight-text-color;
+	}
+
+	// 'Selected+Focus' state
+	&.active.spotlight:not(.contextual-popup-button) {
+		border-color: @moon-active-spotlight-border-color;
+		background-color: @moon-spotlight-border-color;
+		color: @moon-spotlight-text-color;
+
+		&:active,
+		&.pressed {
+			border-color: @moon-spotlight-border-color;
+		}
+	}
+
+	&[disabled] {
+		color: @moon-button-disabled-text-color;
+		background-color: @moon-button-disabled-bg-color;
+	}
+}
+
+.moon-neutral .moon-button {
+	color: @moon-neutral-button-text-color;
+	background-color: @moon-neutral-button-bg-color;
+
+	&.spotlight {
+		background-color: @moon-spotlight-color;
+
+		* {
+			color: @moon-spotlight-text-color;
+		}
+	}
+
+	&.active,
+	&.pressed,
+	&.spotlight.pressed,
+	&.spotlight:active {
+		border-color: @moon-spotlight-border-color;
+		background-color: @moon-neutral-button-bg-color;
+
+		* {
+			color: @moon-neutral-button-text-color;
+		}
+	}
+
+	&[disabled] {
+		color: @moon-neutral-button-disabled-text-color;
+		background-color: @moon-neutral-button-disabled-bg-color;
+	}
+}

--- a/css/FormCheckbox-color.less
+++ b/css/FormCheckbox-color.less
@@ -1,0 +1,22 @@
+/* FormCheckbox.css */
+
+.moon-item.moon-formcheckbox-item {
+	background: none;
+
+	.moon-checkbox {
+		background-color: @moon-form-checkbox-bg-color;
+	}
+}
+
+.moon-formcheckbox-item.spotlight {
+	.moon-checkbox {
+		background-color: @moon-spotlight-color;
+	}
+	.moon-checkbox-item-label-wrapper {
+		color: @moon-sub-header-text-color;
+	}
+}
+
+.moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
+	color: @moon-white;
+}

--- a/css/Header-color.less
+++ b/css/Header-color.less
@@ -1,0 +1,11 @@
+.moon-header {
+	color: @moon-header-text-color;
+	border-top-color: @moon-header-border-color;
+	border-bottom-color: @moon-header-bottom-border-color;
+}
+
+// neutral
+.moon-neutral .moon-header {
+	border-top-color: @moon-neutral-border-color;
+	border-bottom-color: @moon-neutral-border-color;
+}

--- a/css/Icon-color.less
+++ b/css/Icon-color.less
@@ -1,0 +1,8 @@
+/* Icon.css */
+.moon-icon, .moon-icon-toggle {
+	color: @moon-icon-font-color;
+}
+
+.spotlight .moon-icon {
+	color: @moon-spotlight-text-color;
+}

--- a/css/IconButton-color.less
+++ b/css/IconButton-color.less
@@ -1,0 +1,32 @@
+/* IconButton.css */
+.moon-icon-button {
+	color: @moon-icon-button-font-color;
+	background-color: @moon-icon-button-bg-color;
+
+	&.hover:hover:not(.disabled),
+	&.spotlight {
+		color: @moon-spotlight-text-color;
+		background-color: @moon-icon-button-spotlight-bg-color;
+	}
+
+	&.active:not(.spotlight),
+	&:active,
+	&.pressed,
+	&.hover:hover:not(.disabled):active {
+		color: @moon-icon-button-font-color;
+		background-color: @moon-icon-button-active-bg-color;
+		border-color: @moon-icon-button-active-border-color;
+	}
+
+	// 'Selected+Focus' state
+	&.active.spotlight:not(.contextual-popup-button) {
+		border-color: @moon-active-spotlight-border-color;
+		background-color: @moon-icon-button-spotlight-bg-color;
+		color: @moon-spotlight-text-color;
+
+		&:active,
+		&.pressed {
+			border-color: @moon-icon-button-active-border-color;
+		}
+	}
+}

--- a/css/Item-color.less
+++ b/css/Item-color.less
@@ -1,0 +1,13 @@
+/* Item.css */
+.moon-item {
+	.moon-sub-header-text;
+
+	&.spotlight {
+		background-color: @moon-accent;
+		color: @moon-white;
+	}
+}
+
+.enyo-locale-non-latin .moon-item {
+	.enyo-locale-non-latin .moon-sub-header-text;
+}

--- a/css/Panel-color.less
+++ b/css/Panel-color.less
@@ -1,0 +1,44 @@
+.moon-panel-small-header {
+	color: @moon-header-text-color;
+}
+
+.spotlight .moon-panel-small-header {
+	color:@moon-spotlight-text-color;
+}
+.moon-panel-small-header-title-above {
+	color: @moon-header-text-color;
+	border-top-color: @moon-spotlight-text-color;
+}
+.spotlight .moon-panel-small-header-title-above {
+	color: @moon-spotlight-text-color;
+}
+
+.moon-panel .moon-panel-small-header-wrapper.spotlight {
+	background: @moon-accent;
+	color: @moon-white;
+}
+
+/* Activity Panels Overrides */
+.moon-panels.activity {
+	.moon-panel-small-header-title-above {
+		border-top-color: @moon-header-border-color;
+	}
+	.moon-panel-small-header,
+	.moon-panel-small-header-title-above {
+		color: @moon-header-text-color;
+	}
+	.moon-panel-small-header-wrapper.spotlight {
+		.moon-panel-small-header,
+		.moon-panel-small-header-title-above {
+			color: @moon-white;
+		}
+	}
+}
+
+/* AlwaysViewing Overrides */
+.moon-panels.always-viewing {
+	.moon-panel-small-header,
+	.moon-panel-small-header-title-above {
+		color: @moon-white;
+	}
+}

--- a/css/Panels-color.less
+++ b/css/Panels-color.less
@@ -1,0 +1,21 @@
+/* Scrim */
+.moon-panels.activity .moon-panels-panel-scrim {
+	background-color: @moon-panels-scrim-activity-bg-color;
+}
+
+.moon-panels.always-viewing .moon-panels-panel-scrim {
+	background-color: @moon-panels-scrim-always-viewing-bg-color;
+}
+
+/* Show/Hide Handle */
+.moon-panels-handle {
+
+	&:before {
+		background-color: @moon-panels-handle-bg-color;
+		color: @moon-spotlight-text-color;
+	}
+
+	&.spotlight:before {
+		background-color: @moon-panels-spot-fg-color;
+	}
+}

--- a/css/Spinner-color.less
+++ b/css/Spinner-color.less
@@ -1,0 +1,16 @@
+/* Spinner.css */
+
+.moon-spinner {
+	color: @moon-spinner-text-color;
+	background-color: @moon-spinner-background-color;
+
+	.moon-spinner-ball1 {
+		color: @moon-spinner-ball1-color;
+	}
+	.moon-spinner-ball2 {
+		color: @moon-spinner-ball2-color;
+	}
+	.moon-spinner-ball3 {
+		color: @moon-spinner-ball3-color;
+	}
+}

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4851,3 +4851,258 @@ html {
   margin-top: 0.875rem;
   margin-bottom: 1.75rem;
 }
+.moon-theme-light {
+  /* Common classes applicable to multiple controls */
+  /* Text definitions */
+  color: #4b4b4b;
+  background-color: #ededed;
+  /* Icon.css */
+  /* IconButton.css */
+  /* Item.css */
+  /* Button */
+  /* Spinner.css */
+  /* Activity Panels Overrides */
+  /* AlwaysViewing Overrides */
+  /* Scrim */
+  /* Show/Hide Handle */
+  /* FormCheckbox.css */
+}
+.moon-theme-light .moon-divider-border {
+  border-bottom-color: #4b4b4b;
+}
+.moon-theme-light .moon-neutral-divider-border {
+  border-bottom-color: #ffffff;
+}
+.moon-theme-light .moon-sub-header-text {
+  font-family: "MuseoSans 700";
+  font-size: 1.25rem;
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-divider-text {
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-body-text {
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-body-text a:link {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-light .moon-body-text a:visited {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-light .moon-body-text a:hover {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-light .moon-body-text a:active {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-light .moon-bold-text {
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-bold-text a:link {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-light .moon-bold-text a:visited {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-light .moon-bold-text a:hover {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-light .moon-bold-text a:active {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-light .moon-icon-text {
+  color: #ffffff;
+}
+.moon-theme-light .moon-icon,
+.moon-theme-light .moon-icon-toggle {
+  color: #4b4b4b;
+}
+.moon-theme-light .spotlight .moon-icon {
+  color: #ffffff;
+}
+.moon-theme-light .moon-icon-button {
+  color: #999999;
+  background-color: #ffffff;
+}
+.moon-theme-light .moon-icon-button.hover:hover:not(.disabled),
+.moon-theme-light .moon-icon-button.spotlight {
+  color: #ffffff;
+  background-color: #cf0652;
+}
+.moon-theme-light .moon-icon-button.active:not(.spotlight),
+.moon-theme-light .moon-icon-button:active,
+.moon-theme-light .moon-icon-button.pressed,
+.moon-theme-light .moon-icon-button.hover:hover:not(.disabled):active {
+  color: #999999;
+  background-color: #ffffff;
+  border-color: #cf0652;
+}
+.moon-theme-light .moon-icon-button.active.spotlight:not(.contextual-popup-button) {
+  border-color: #ffffff;
+  background-color: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-light .moon-icon-button.active.spotlight:not(.contextual-popup-button):active,
+.moon-theme-light .moon-icon-button.active.spotlight:not(.contextual-popup-button).pressed {
+  border-color: #cf0652;
+}
+.moon-theme-light .moon-item {
+  font-family: "MuseoSans 700";
+  font-size: 1.25rem;
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-item.spotlight {
+  background-color: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-light .enyo-locale-non-latin .moon-item {
+  font-family: "Moonstone LG Display Bold";
+  font-size: 1.25rem;
+}
+.moon-theme-light .moon-button {
+  background-color: #ffffff;
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-button.active,
+.moon-theme-light .moon-button.pressed,
+.moon-theme-light .moon-button.spotlight.pressed,
+.moon-theme-light .moon-button.spotlight:active {
+  border-color: #cf0652;
+  background-color: #ffffff;
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-button.spotlight {
+  background-color: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-light .moon-button.active.spotlight:not(.contextual-popup-button) {
+  border-color: #ffffff;
+  background-color: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-light .moon-button.active.spotlight:not(.contextual-popup-button):active,
+.moon-theme-light .moon-button.active.spotlight:not(.contextual-popup-button).pressed {
+  border-color: #cf0652;
+}
+.moon-theme-light .moon-button[disabled] {
+  color: #b3b3b3;
+  background-color: #ffffff;
+}
+.moon-theme-light .moon-neutral .moon-button {
+  color: #4b4b4b;
+  background-color: #ffffff;
+}
+.moon-theme-light .moon-neutral .moon-button.spotlight {
+  background-color: #cf0652;
+}
+.moon-theme-light .moon-neutral .moon-button.spotlight * {
+  color: #ffffff;
+}
+.moon-theme-light .moon-neutral .moon-button.active,
+.moon-theme-light .moon-neutral .moon-button.pressed,
+.moon-theme-light .moon-neutral .moon-button.spotlight.pressed,
+.moon-theme-light .moon-neutral .moon-button.spotlight:active {
+  border-color: #cf0652;
+  background-color: #ffffff;
+}
+.moon-theme-light .moon-neutral .moon-button.active *,
+.moon-theme-light .moon-neutral .moon-button.pressed *,
+.moon-theme-light .moon-neutral .moon-button.spotlight.pressed *,
+.moon-theme-light .moon-neutral .moon-button.spotlight:active * {
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-neutral .moon-button[disabled] {
+  color: #b3b3b3;
+  background-color: #ffffff;
+}
+.moon-theme-light .moon-header {
+  color: #4b4b4b;
+  border-top-color: #4b4b4b;
+  border-bottom-color: #4b4b4b;
+}
+.moon-theme-light .moon-neutral .moon-header {
+  border-top-color: #ffffff;
+  border-bottom-color: #ffffff;
+}
+.moon-theme-light .moon-spinner {
+  color: #ffffff;
+  background-color: #4d4d4d;
+}
+.moon-theme-light .moon-spinner .moon-spinner-ball1 {
+  color: #69cdff;
+}
+.moon-theme-light .moon-spinner .moon-spinner-ball2 {
+  color: #ff4a4a;
+}
+.moon-theme-light .moon-spinner .moon-spinner-ball3 {
+  color: #ffb80d;
+}
+.moon-theme-light .moon-panel-small-header {
+  color: #4b4b4b;
+}
+.moon-theme-light .spotlight .moon-panel-small-header {
+  color: #ffffff;
+}
+.moon-theme-light .moon-panel-small-header-title-above {
+  color: #4b4b4b;
+  border-top-color: #ffffff;
+}
+.moon-theme-light .spotlight .moon-panel-small-header-title-above {
+  color: #ffffff;
+}
+.moon-theme-light .moon-panel .moon-panel-small-header-wrapper.spotlight {
+  background: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-light .moon-panels.activity .moon-panel-small-header-title-above {
+  border-top-color: #4b4b4b;
+}
+.moon-theme-light .moon-panels.activity .moon-panel-small-header,
+.moon-theme-light .moon-panels.activity .moon-panel-small-header-title-above {
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header,
+.moon-theme-light .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header-title-above {
+  color: #ffffff;
+}
+.moon-theme-light .moon-panels.always-viewing .moon-panel-small-header,
+.moon-theme-light .moon-panels.always-viewing .moon-panel-small-header-title-above {
+  color: #ffffff;
+}
+.moon-theme-light .moon-panels.activity .moon-panels-panel-scrim {
+  background-color: #ededed;
+}
+.moon-theme-light .moon-panels.always-viewing .moon-panels-panel-scrim {
+  background-color: #ededed;
+}
+.moon-theme-light .moon-panels-handle:before {
+  background-color: #4b4b4b;
+  color: #ffffff;
+}
+.moon-theme-light .moon-panels-handle.spotlight:before {
+  background-color: #cf0652;
+}
+.moon-theme-light .moon-item.moon-formcheckbox-item {
+  background: none;
+}
+.moon-theme-light .moon-item.moon-formcheckbox-item .moon-checkbox {
+  background-color: #ffffff;
+}
+.moon-theme-light .moon-formcheckbox-item.spotlight .moon-checkbox {
+  background-color: #cf0652;
+}
+.moon-theme-light .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
+  color: #4b4b4b;
+}
+.moon-theme-light .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
+  color: #ffffff;
+}

--- a/css/moonstone-dark.less
+++ b/css/moonstone-dark.less
@@ -6,3 +6,23 @@
 
 // Moonstone rules defined here
 @import "moonstone-rules.less";
+
+.moon-theme-light {
+	@import "moonstone-variables-light.less";
+	@import "moonstone-rules-color.less";
+	@import "moonstone-text-color.less";
+
+	color: @moon-sub-header-text-color;
+	background-color: @moon-background-color;
+
+	// These should be in the same order as they are in moonstone-rules.less
+	@import "Icon-color.less";
+	@import "IconButton-color.less";
+	@import "Item-color.less";
+	@import "Button-color.less";
+	@import "Header-color.less";
+	@import "Spinner-color.less";
+	@import "Panel-color.less";
+	@import "Panels-color.less";
+	@import "FormCheckbox-color.less";
+}

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4851,3 +4851,258 @@ html {
   margin-top: 0.875rem;
   margin-bottom: 1.75rem;
 }
+.moon-theme-dark {
+  /* Common classes applicable to multiple controls */
+  /* Text definitions */
+  color: #a6a6a6;
+  background-color: #000000;
+  /* Icon.css */
+  /* IconButton.css */
+  /* Item.css */
+  /* Button */
+  /* Spinner.css */
+  /* Activity Panels Overrides */
+  /* AlwaysViewing Overrides */
+  /* Scrim */
+  /* Show/Hide Handle */
+  /* FormCheckbox.css */
+}
+.moon-theme-dark .moon-divider-border {
+  border-bottom-color: #a6a6a6;
+}
+.moon-theme-dark .moon-neutral-divider-border {
+  border-bottom-color: #ffffff;
+}
+.moon-theme-dark .moon-sub-header-text {
+  font-family: "MuseoSans 700";
+  font-size: 1.25rem;
+  color: #a6a6a6;
+}
+.moon-theme-dark .moon-divider-text {
+  color: #a6a6a6;
+}
+.moon-theme-dark .moon-body-text {
+  color: #a6a6a6;
+}
+.moon-theme-dark .moon-body-text a:link {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-dark .moon-body-text a:visited {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-dark .moon-body-text a:hover {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-dark .moon-body-text a:active {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-dark .moon-bold-text {
+  color: #a6a6a6;
+}
+.moon-theme-dark .moon-bold-text a:link {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-dark .moon-bold-text a:visited {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-dark .moon-bold-text a:hover {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-dark .moon-bold-text a:active {
+  color: #cf0652;
+  text-decoration: none;
+}
+.moon-theme-dark .moon-icon-text {
+  color: #ffffff;
+}
+.moon-theme-dark .moon-icon,
+.moon-theme-dark .moon-icon-toggle {
+  color: #a6a6a6;
+}
+.moon-theme-dark .spotlight .moon-icon {
+  color: #ffffff;
+}
+.moon-theme-dark .moon-icon-button {
+  color: #a6a6a6;
+  background-color: #404040;
+}
+.moon-theme-dark .moon-icon-button.hover:hover:not(.disabled),
+.moon-theme-dark .moon-icon-button.spotlight {
+  color: #ffffff;
+  background-color: #cf0652;
+}
+.moon-theme-dark .moon-icon-button.active:not(.spotlight),
+.moon-theme-dark .moon-icon-button:active,
+.moon-theme-dark .moon-icon-button.pressed,
+.moon-theme-dark .moon-icon-button.hover:hover:not(.disabled):active {
+  color: #a6a6a6;
+  background-color: #404040;
+  border-color: #cf0652;
+}
+.moon-theme-dark .moon-icon-button.active.spotlight:not(.contextual-popup-button) {
+  border-color: #ffffff;
+  background-color: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-dark .moon-icon-button.active.spotlight:not(.contextual-popup-button):active,
+.moon-theme-dark .moon-icon-button.active.spotlight:not(.contextual-popup-button).pressed {
+  border-color: #cf0652;
+}
+.moon-theme-dark .moon-item {
+  font-family: "MuseoSans 700";
+  font-size: 1.25rem;
+  color: #a6a6a6;
+}
+.moon-theme-dark .moon-item.spotlight {
+  background-color: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-dark .enyo-locale-non-latin .moon-item {
+  font-family: "Moonstone LG Display Bold";
+  font-size: 1.25rem;
+}
+.moon-theme-dark .moon-button {
+  background-color: #404040;
+  color: #a6a6a6;
+}
+.moon-theme-dark .moon-button.active,
+.moon-theme-dark .moon-button.pressed,
+.moon-theme-dark .moon-button.spotlight.pressed,
+.moon-theme-dark .moon-button.spotlight:active {
+  border-color: #cf0652;
+  background-color: #404040;
+  color: #a6a6a6;
+}
+.moon-theme-dark .moon-button.spotlight {
+  background-color: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-dark .moon-button.active.spotlight:not(.contextual-popup-button) {
+  border-color: #ffffff;
+  background-color: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-dark .moon-button.active.spotlight:not(.contextual-popup-button):active,
+.moon-theme-dark .moon-button.active.spotlight:not(.contextual-popup-button).pressed {
+  border-color: #cf0652;
+}
+.moon-theme-dark .moon-button[disabled] {
+  color: #4d4d4d;
+  background-color: #262626;
+}
+.moon-theme-dark .moon-neutral .moon-button {
+  color: #4b4b4b;
+  background-color: #ffffff;
+}
+.moon-theme-dark .moon-neutral .moon-button.spotlight {
+  background-color: #cf0652;
+}
+.moon-theme-dark .moon-neutral .moon-button.spotlight * {
+  color: #ffffff;
+}
+.moon-theme-dark .moon-neutral .moon-button.active,
+.moon-theme-dark .moon-neutral .moon-button.pressed,
+.moon-theme-dark .moon-neutral .moon-button.spotlight.pressed,
+.moon-theme-dark .moon-neutral .moon-button.spotlight:active {
+  border-color: #cf0652;
+  background-color: #ffffff;
+}
+.moon-theme-dark .moon-neutral .moon-button.active *,
+.moon-theme-dark .moon-neutral .moon-button.pressed *,
+.moon-theme-dark .moon-neutral .moon-button.spotlight.pressed *,
+.moon-theme-dark .moon-neutral .moon-button.spotlight:active * {
+  color: #4b4b4b;
+}
+.moon-theme-dark .moon-neutral .moon-button[disabled] {
+  color: #b3b3b3;
+  background-color: #ffffff;
+}
+.moon-theme-dark .moon-header {
+  color: #a6a6a6;
+  border-top-color: #505050;
+  border-bottom-color: #404040;
+}
+.moon-theme-dark .moon-neutral .moon-header {
+  border-top-color: #ffffff;
+  border-bottom-color: #ffffff;
+}
+.moon-theme-dark .moon-spinner {
+  color: #ffffff;
+  background-color: #4d4d4d;
+}
+.moon-theme-dark .moon-spinner .moon-spinner-ball1 {
+  color: #69cdff;
+}
+.moon-theme-dark .moon-spinner .moon-spinner-ball2 {
+  color: #ff4a4a;
+}
+.moon-theme-dark .moon-spinner .moon-spinner-ball3 {
+  color: #ffb80d;
+}
+.moon-theme-dark .moon-panel-small-header {
+  color: #a6a6a6;
+}
+.moon-theme-dark .spotlight .moon-panel-small-header {
+  color: #ffffff;
+}
+.moon-theme-dark .moon-panel-small-header-title-above {
+  color: #a6a6a6;
+  border-top-color: #ffffff;
+}
+.moon-theme-dark .spotlight .moon-panel-small-header-title-above {
+  color: #ffffff;
+}
+.moon-theme-dark .moon-panel .moon-panel-small-header-wrapper.spotlight {
+  background: #cf0652;
+  color: #ffffff;
+}
+.moon-theme-dark .moon-panels.activity .moon-panel-small-header-title-above {
+  border-top-color: #505050;
+}
+.moon-theme-dark .moon-panels.activity .moon-panel-small-header,
+.moon-theme-dark .moon-panels.activity .moon-panel-small-header-title-above {
+  color: #a6a6a6;
+}
+.moon-theme-dark .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header,
+.moon-theme-dark .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header-title-above {
+  color: #ffffff;
+}
+.moon-theme-dark .moon-panels.always-viewing .moon-panel-small-header,
+.moon-theme-dark .moon-panels.always-viewing .moon-panel-small-header-title-above {
+  color: #ffffff;
+}
+.moon-theme-dark .moon-panels.activity .moon-panels-panel-scrim {
+  background-color: #000000;
+}
+.moon-theme-dark .moon-panels.always-viewing .moon-panels-panel-scrim {
+  background-color: rgba(0, 0, 0, 0.75);
+}
+.moon-theme-dark .moon-panels-handle:before {
+  background-color: #4b4b4b;
+  color: #ffffff;
+}
+.moon-theme-dark .moon-panels-handle.spotlight:before {
+  background-color: #cf0652;
+}
+.moon-theme-dark .moon-item.moon-formcheckbox-item {
+  background: none;
+}
+.moon-theme-dark .moon-item.moon-formcheckbox-item .moon-checkbox {
+  background-color: #404040;
+}
+.moon-theme-dark .moon-formcheckbox-item.spotlight .moon-checkbox {
+  background-color: #cf0652;
+}
+.moon-theme-dark .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
+  color: #a6a6a6;
+}
+.moon-theme-dark .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
+  color: #ffffff;
+}

--- a/css/moonstone-light.less
+++ b/css/moonstone-light.less
@@ -6,3 +6,23 @@
 
 // Moonstone rules defined here
 @import "moonstone-rules.less";
+
+.moon-theme-dark {
+	@import "moonstone-variables-dark.less";
+	@import "moonstone-rules-color.less";
+	@import "moonstone-text-color.less";
+
+	color: @moon-sub-header-text-color;
+	background-color: @moon-background-color;
+
+	// These should be in the same order as they are in moonstone-rules.less
+	@import "Icon-color.less";
+	@import "IconButton-color.less";
+	@import "Item-color.less";
+	@import "Button-color.less";
+	@import "Header-color.less";
+	@import "Spinner-color.less";
+	@import "Panel-color.less";
+	@import "Panels-color.less";
+	@import "FormCheckbox-color.less";
+}

--- a/css/moonstone-rules-color.less
+++ b/css/moonstone-rules-color.less
@@ -1,0 +1,7 @@
+/* Common classes applicable to multiple controls */
+.moon-divider-border {
+	border-bottom-color: @moon-divider-border-color;
+}
+.moon-neutral-divider-border {
+	border-bottom-color: @moon-neutral-border-color;
+}

--- a/css/moonstone-text-color.less
+++ b/css/moonstone-text-color.less
@@ -1,0 +1,32 @@
+// mixin classes for create the moontone text classes
+.moon-sub-header-text-base (@font-size, @font-color) {
+	font-family: @moon-sub-header-font-family;
+	font-size: @font-size;
+	color: @font-color;
+}
+/* Text definitions */
+.moon-sub-header-text {
+	.moon-sub-header-text-base (@moon-sub-header-font-size, @moon-sub-header-text-color);
+}
+.moon-divider-text {
+	color: @moon-divider-text-color;
+}
+.moon-body-text {
+	color: @moon-body-text-color;
+
+	a:link {color: @moon-spotlight-color; text-decoration:none;}
+	a:visited {color: @moon-spotlight-color; text-decoration:none;}
+	a:hover {color: @moon-spotlight-color; text-decoration:none;}
+	a:active {color: @moon-spotlight-color; text-decoration:none;}
+}
+.moon-bold-text {
+	color: @moon-body-text-color;
+
+	a:link {color: @moon-spotlight-color; text-decoration:none;}
+	a:visited {color: @moon-spotlight-color; text-decoration:none;}
+	a:hover {color: @moon-spotlight-color; text-decoration:none;}
+	a:active {color: @moon-spotlight-color; text-decoration:none;}
+}
+.moon-icon-text {
+	color: @moon-icon-color;
+}


### PR DESCRIPTION
Simply apply `moon-theme-light` or `moon-theme-dark` to any container and have all child controls use the indicated theme.

(This initial version is an abbreviated set of controls specifically for Settings)

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>