### PR TITLE
ENYO-1289: Stop datalist scroller on collection changed

### DIFF
--- a/source/DataList.js
+++ b/source/DataList.js
@@ -493,6 +493,19 @@
 		moon.DataList.delegates.horizontal = enyo.clone(moon.DataList.delegates.horizontal);
 		var exts = {
 			/**
+			* Overriding refresh() to stop scroller and stop scrolling.
+			*
+			* @method
+			* @private
+			*/
+			refresh: enyo.inherit(function (sup) {
+				return function (list) {
+					sup.apply(this, arguments);
+					list.$.scroller.stop();
+				};
+			}),
+
+			/**
 			* Overriding scrollToControl() to specify Moonstone-specific scroller options.
 			* No need to call the super method, so we don't wrap in enyo.inherit().
 			*


### PR DESCRIPTION
Issue:
If the moon.datalist having a long list and while scrolling this list, if the collection is chaned then the dalalist items are not displayed.

Fix:
Add refresh() function into DataList and Stop the DataList scroller to remove the scrolling if the collection is changed