### PR TITLE
ENYO-964 Prevent to back previous page in browser

### DIFF
--- a/source/History.js
+++ b/source/History.js
@@ -167,6 +167,19 @@
 				this.createChrome(this.lunaServiceComponents);
 				this._getAppID();
 			}
+
+			if (this.enableBackHistoryAPI) {
+				this._initHistoryState();
+			}
+		},
+
+		/**
+		* To prevent back to previous page in browser, we mark initial state.
+		*
+		* @private
+		*/
+		_initHistoryState: function () {
+			history.pushState({currentObjId: 'historyMaster'}, '', '');
 		},
 
 		/**
@@ -350,6 +363,9 @@
 
 			switch (state) {
 			case 'empty':
+				if (history.state.currentObjId == 'historyMaster') {
+					this._initHistoryState();
+				}
 				break;
 			case 'silence':
 			//Popstate event should be ignored on following 2 conditions.

--- a/source/History.js
+++ b/source/History.js
@@ -363,7 +363,7 @@
 
 			switch (state) {
 			case 'empty':
-				if (history.state.currentObjId == 'historyMaster') {
+				if (!history.state || history.state.currentObjId == 'historyMaster') {
 					this._initHistoryState();
 				}
 				break;


### PR DESCRIPTION
Issue
------
Pressing back key make it back to previous page in browser

Cause
-------
history.back() call without pushed history state will back to previous page. Natural behavior of history object.

Fix
----
Add a guidance state to prevent to back to previous page

updated from https://github.com/enyojs/moonstone/pull/2000 

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com