### PR TITLE
ENYO-1335: Date Picker : Passing undefined params stops application

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -194,7 +194,7 @@
 					this.createComponent(
 						{classes: 'moon-date-picker-wrap', components:[
 							{kind:'moon.IntegerPicker', name:'day', classes:'moon-date-picker-field', wrap:true, digits:digits, min:1,
-							max:this.monthLength(values.fullYear, values.month), value: values.date, onChange: 'pickerChanged'},
+							max:values.maxDays, value: values.date, onChange: 'pickerChanged'},
 							{name: 'dayLabel', content: this.dayText, classes: 'moon-date-picker-label moon-divider-text'}
 						]});
 					break;
@@ -299,21 +299,26 @@
 		* @private
 		*/
 		calcPickerValues: function () {
-			var values = {};
+			var values = {
+				maxMonths: 12,
+				maxDays: 31
+			};
 			if (typeof ilib !== 'undefined') {
 				if (this.localeValue) {
 					values.fullYear = this.localeValue.getYears();
 					values.month = this.localeValue.getMonths();
 					values.date = this.localeValue.getDays();
 				}
-				values.maxMonths = this._tf.cal.getNumMonths(values.fullYear);
+				if (values.fullYear) {
+					values.maxMonths = this._tf.cal.getNumMonths(values.fullYear);
+					values.maxDays = this.monthLength(values.fullYear, values.month);
+				}
 			} else {
 				if (this.value) {
 					values.fullYear = this.value.getFullYear();
 					values.month = this.value.getMonth()+1;
 					values.date = this.value.getDate();
 				}
-				values.maxMonths = 12;
 			}
 			return values;
 		},
@@ -340,12 +345,10 @@
 		* @private
 		*/
 		monthLength: function (inYear, inMonth) {
-			if (inYear && (inMonth === 0 || inMonth)) {
-				if (typeof ilib !== 'undefined') {
-					return this._tf.cal.getMonLength(inMonth, inYear);
-				} else {
-					return 32 - new Date(inYear, inMonth - 1, 32).getDate();
-				}
+			if (typeof ilib !== 'undefined') {
+				return this._tf.cal.getMonLength(inMonth, inYear);
+			} else {
+				return 32 - new Date(inYear, inMonth - 1, 32).getDate();
 			}
 		},
 

--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -305,12 +305,6 @@
 					values.fullYear = this.localeValue.getYears();
 					values.month = this.localeValue.getMonths();
 					values.date = this.localeValue.getDays();
-				} else {
-					// If date object is not instantiated from ilib, we use default value to avoid passing undefined params to iLib API
-					// Default values are based on unix time defined as the number of seconds that have elapsed since 1 Jan 1970
-					values.fullYear = 1970;
-					values.month = 1;
-					values.date = 1;
 				}
 				values.maxMonths = this._tf.cal.getNumMonths(values.fullYear);
 			} else {
@@ -346,13 +340,15 @@
 		* @private
 		*/
 		monthLength: function (inYear, inMonth) {
-			if (typeof ilib !== 'undefined') {
-				return this._tf.cal.getMonLength(inMonth, inYear);
-			} else {
-				return 32 - new Date(inYear, inMonth - 1, 32).getDate();
+			if (inYear && (inMonth == 0 || inMonth)) {
+				if (typeof ilib !== 'undefined') {
+					return this._tf.cal.getMonLength(inMonth, inYear);
+				} else {
+					return 32 - new Date(inYear, inMonth - 1, 32).getDate();
+				}
 			}
 		},
-
+		
 		/**
 		* @private
 		*/

--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -305,6 +305,12 @@
 					values.fullYear = this.localeValue.getYears();
 					values.month = this.localeValue.getMonths();
 					values.date = this.localeValue.getDays();
+				} else {
+					// If date object is not instantiated from ilib, we use default value to avoid passing undefined params to iLib API
+					// Default values are based on unix time defined as the number of seconds that have elapsed since 1 Jan 1970
+					values.fullYear = 1970;
+					values.month = 1;
+					values.date = 1;
 				}
 				values.maxMonths = this._tf.cal.getNumMonths(values.fullYear);
 			} else {

--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -340,7 +340,7 @@
 		* @private
 		*/
 		monthLength: function (inYear, inMonth) {
-			if (inYear && (inMonth == 0 || inMonth)) {
+			if (inYear && (inMonth === 0 || inMonth)) {
 				if (typeof ilib !== 'undefined') {
 					return this._tf.cal.getMonLength(inMonth, inYear);
 				} else {
@@ -348,7 +348,7 @@
 				}
 			}
 		},
-		
+
 		/**
 		* @private
 		*/


### PR DESCRIPTION
### Issue ###

At creation time of Date Picker, *value* is set to null so iLib date object cannot be instantiated from it. However picker calls iLib function to calculate maximum days by passing undefined values. Inside iLib API, there exist a code trying to manipulate undefined params and it causes undefined error.

### Fix ###

Before calling iLib API to get **monthLength**, we'll check if parameters to be passed like **inYear** and **inMonth** have proper values.

Enyo-DCO-1.1-Signed-off-by: Hunkyo Jung <hunkyo.jung@lge.com>