### PR TITLE
Enyo-1172  Display text with a scrim over images in an image grid (new r...

### DIFF
--- a/css/TextOverlaySupport.less
+++ b/css/TextOverlaySupport.less
@@ -1,0 +1,69 @@
+.moon-text-overlay-support-scrim{
+  background : rgba(0, 0, 0, 0.5);
+}
+
+.moon-text-overlay-support-scrim-center{
+  margin: auto;
+  width:100%;
+  display:table;
+  table-layout: fixed;
+}
+
+.moon-text-overlay-upperText{
+  text-align:center;
+  position: relative;
+  width: 72%;
+  padding-left: 14%;
+  padding-right: 14%;
+  display: block; 
+  display: -webkit-box;
+  font-family: "MuseoSans 500";
+  font-size: 24px;
+  line-height: 26px;
+  text-overflow: ellipsis; overflow: hidden;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom:2px;
+  -webkit-box-orient: vertical;
+}
+
+.moon-text-overlay-marquee{
+  text-align:center;
+  position: relative;
+  width: 72%;
+  padding-left: 14%;
+  padding-right: 14%;
+  display: block; 
+  font-family: "MuseoSans 500";
+  font-size: 24px;
+  line-height: 26px;
+  text-overflow: ellipsis; overflow: hidden;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom:2px;
+}
+
+.moon-text-overlay-bottomText{
+  text-align:center;
+  position: relative;
+  width: 72%;
+  padding-left: 14%;
+  padding-right: 14%;
+  display:block;
+  font-family: "Moon Miso Bold";
+  font-size: 48px;
+  line-height: 48px;
+  text-overflow: ellipsis; white-space: nowrap; overflow: hidden;
+  color: rgba(255, 255, 255, 0.3);
+  margin-top:1px;
+}
+
+.moon-text-overlay-support-line1{
+  -webkit-line-clamp: 1;
+} 
+
+.moon-text-overlay-support-line2{
+  -webkit-line-clamp: 2;
+} 
+
+.moon-text-overlay-support-line3{
+  -webkit-line-clamp: 3;
+} 

--- a/css/moonstone-rules.less
+++ b/css/moonstone-rules.less
@@ -146,6 +146,7 @@ html {
 @import "ExpandableText.less";
 @import "BodyText.less";
 @import "VideoFullScreenToggleButton.less";
+@import "TextOverlaySupport.less";
 
 /* Put this at the end because we want these to take precedence over others */
 .moon-neutral {

--- a/samples/DataGridListSample.js
+++ b/samples/DataGridListSample.js
@@ -37,7 +37,7 @@ enyo.kind({
 				]}
 			]}
 		], components: [
-			{name: "gridList", fit: true, spacing: 20, minWidth: 180, minHeight: 270, kind: "moon.DataGridList", scrollerOptions: { kind: "moon.Scroller", vertical:"scroll", horizontal: "hidden", spotlightPagingControls: true }, components: [
+			{name: "gridList", fit: true, spacing: 20, minWidth: 180, minHeight: 180, kind: "moon.DataGridList", scrollerOptions: { kind: "moon.Scroller", vertical:"scroll", horizontal: "hidden", spotlightPagingControls: true }, components: [
 				{ kind: "moon.sample.GridSampleItem" }
 			]}
 		]}
@@ -65,8 +65,9 @@ enyo.kind({
 			var subTitle = (idx % 8 === 0) ? "Lorem ipsum dolor sit amet" : "Subtitle";
 			records.push({
 				selected: false,
-				text: "Item " + idx + title,
+				text: "2013.05. " + idx + title,
 				subText: subTitle,
+				id: idx,
 				url: "http://placehold.it/300x300/" + Math.floor(Math.random()*0x1000000).toString(16) + "/ffffff&text=Image " + idx
 			});
 		}
@@ -87,9 +88,13 @@ enyo.kind({
 enyo.kind({
 	name: "moon.sample.GridSampleItem",
 	kind: "moon.GridListImageItem",
-	mixins: ["moon.SelectionOverlaySupport"],
-	selectionOverlayVerticalOffset: 35,
-	subCaption: "Sub Caption",
+	mixins: ["moon.TextOverlaySupport","moon.SelectionOverlaySupport"],
+	//can set how many line you want
+	overlaytextLineNum:3,
+	//can set marquee enable or not
+	useoverlaytextmarquee:false,
+	useCaption:false,
+	useSubCaption:false,
 	bindings: [
 		{from: ".model.text", to: ".caption"},
 		{from: ".model.subText", to: ".subCaption"},

--- a/source/TextOverlaySupport.js
+++ b/source/TextOverlaySupport.js
@@ -1,0 +1,51 @@
+(function (enyo, scope) {
+
+	moon.TextOverlaySupport = {
+
+	name: 'moon.TextOverlay',
+
+	create: enyo.inherit(function (sup) {
+			return function () {
+				sup.apply(this, arguments);
+				//for marquee mode, create components w/ moon.MarqueeText kind
+				if(this.useoverlaytextmarquee===true){
+					this.createChrome(this._textMarqueeScrim);
+
+				}
+				//for not marquee mode, create just div
+				else if(this.useoverlaytextmarquee===false){
+					this.createChrome(this._textScrim);
+				}
+				//for handling, one-line / two-line / three-line requirement
+				if(this.$.overLayText){
+					this.$.overLayText.addClass('moon-text-overlay-support-line'+this.overlaytextLineNum);
+				}
+			};
+		}),
+
+	bindings: [
+		{from: 'model.url', to: 'source'},
+		{from: 'model.text', to: '$.overLayText.content'},
+		{from: 'model.text', to: '$.overLayMarqueeText.content'},
+		{from: 'model.id', to: '$.overLaySubText.content'}
+	],
+
+	_textScrim: [
+		{name:'textScrim', classes: 'enyo-fit moon-text-overlay-support-scrim', components: [
+				{name:'overLayTextContainer', classes: 'enyo-fit moon-text-overlay-support-scrim-center', components: [
+					{name:'overLayText', classes:'moon-text-overlay-upperText'},
+					{name:'overLaySubText', classes:'moon-text-overlay-bottomText'}]
+				}	
+			]}	
+		],
+
+		_textMarqueeScrim: [
+		{name:'textMarqueeScrim', classes: 'enyo-fit moon-text-overlay-support-scrim', components: [
+				{name:'overLayTextContainer', classes: 'enyo-fit moon-text-overlay-support-scrim-center', components: [
+					{name:'overLayMarqueeText', kind: "moon.MarqueeText", classes:'moon-text-overlay-marquee'},
+					{name:'overLaySubText', classes:'moon-text-overlay-bottomText'}]
+				}	
+			]}	
+		]
+};
+})(enyo, this);

--- a/source/package.js
+++ b/source/package.js
@@ -86,5 +86,6 @@ enyo.depends(
 	'ExpandableText.js',
 	'keymap.js',
 	'History.js',
-	'moon-container-init.js'
+	'moon-container-init.js',
+	'TextOverlaySupport.js'
 );


### PR DESCRIPTION
...ank: 2)

### Issue

There is UX requirement for text with a scrim over images in an image grid

### Fix

 - add "TextOverlaySupport.js" : "moon.TextOverlay" kind can be used in DataGridList as mixin. This kind creates components(normal scrim / marquee-possible scrim)  in creation time. Enabling marquee and how many lines developer wants can be handled in this kind.
 - add "TextOverlaySupport.less" : less for background color / center-alignment / how many lines / marquee
 - modified "DataGridListSample.js" : for showing demo(changed 1. minHeight of gridList  / 2 .text and id of model in generateRecords func / 3. moon.sample.GridSampleItem kind)
 - modified "package.js" and "moonstone-rules.less" to import "TextOverlaySupport.js" and "TextOverlaySupport.less"

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung2.lee@lge.com