### PR TITLE
ENYO-1251: Prevent unnecessary collapsing of input.

### DIFF
--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -189,8 +189,10 @@
 		*/
 		inputBlur: function (sender, ev) {
 			var eventType = enyo.Spotlight.getLastEvent().type;
+			// TODO: adding a hacky workaround to prevent undesired collapse of the control when
+			// initiating a drag on the InputDecorator control on the TV
 			if (enyo.Spotlight.getPointerMode() && eventType !== 'onSpotlightFocus'
-				&& eventType !== 'mouseover' && ev.originator !== this.$.inputDecorator) {
+				&& eventType !== 'mouseover' && eventType !== 'dragstart') {
 				this.toggleActive();
 			}
 		},

--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -173,8 +173,8 @@
 		*
 		* @private
 		*/
-		inputFocus: function (inSender, inEvent) {
-			var direction = inEvent && inEvent.dir;
+		inputFocus: function (sender, ev) {
+			var direction = ev && ev.dir;
 			if (this.getOpen() && direction) {
 				this.focusInput();
 			}
@@ -187,9 +187,10 @@
 		*
 		* @private
 		*/
-		inputBlur: function (inSender, inEvent) {
+		inputBlur: function (sender, ev) {
 			var eventType = enyo.Spotlight.getLastEvent().type;
-			if (enyo.Spotlight.getPointerMode() && eventType !== 'onSpotlightFocus' && eventType !== 'mouseover') {
+			if (enyo.Spotlight.getPointerMode() && eventType !== 'onSpotlightFocus'
+				&& eventType !== 'mouseover' && ev.originator !== this.$.inputDecorator) {
 				this.toggleActive();
 			}
 		},
@@ -197,8 +198,8 @@
 		/**
 		* @private
 		*/
-		inputKeyUp: function (inSender, inEvent) {
-			if (inEvent.keyCode === 13) {
+		inputKeyUp: function (sender, ev) {
+			if (ev.keyCode === 13) {
 				this.closeDrawerAndHighlightHeader();
 			}
 		},
@@ -215,8 +216,8 @@
 		*
 		* @private
 		*/
-		spotlightDown: function (inSender, inEvent) {
-			if (inEvent.originator === this.$.headerWrapper && this.getOpen()) {
+		spotlightDown: function (sender, ev) {
+			if (ev.originator === this.$.headerWrapper && this.getOpen()) {
 				this.focusInput();
 			}
 		},
@@ -242,7 +243,7 @@
 		*
 		* @private
 		*/
-		inputDown: function (inSender, inEvent) {
+		inputDown: function (sender, ev) {
 			if (this.getLockBottom()) {
 				this.focusInput();
 			} else {

--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -190,9 +190,11 @@
 		inputBlur: function (sender, ev) {
 			var eventType = enyo.Spotlight.getLastEvent().type;
 			// TODO: adding a hacky workaround to prevent undesired collapse of the control when
-			// initiating a drag on the InputDecorator control on the TV
+			// initiating a drag on the InputDecorator control on the TV (guarding against both
+			// 'drag' and 'dragstart')
+			enyo.log(eventType);
 			if (enyo.Spotlight.getPointerMode() && eventType !== 'onSpotlightFocus'
-				&& eventType !== 'mouseover' && eventType !== 'dragstart') {
+				&& eventType !== 'mouseover' && eventType !== 'dragstart' && eventType !== 'drag') {
 				this.toggleActive();
 			}
 		},

--- a/source/ExpandableInput.js
+++ b/source/ExpandableInput.js
@@ -192,7 +192,6 @@
 			// TODO: adding a hacky workaround to prevent undesired collapse of the control when
 			// initiating a drag on the InputDecorator control on the TV (guarding against both
 			// 'drag' and 'dragstart')
-			enyo.log(eventType);
 			if (enyo.Spotlight.getPointerMode() && eventType !== 'onSpotlightFocus'
 				&& eventType !== 'mouseover' && eventType !== 'dragstart' && eventType !== 'drag') {
 				this.toggleActive();


### PR DESCRIPTION
It is same PR with https://github.com/enyojs/moonstone/pull/2046.
There is a request to apply @aarontam 's fix to 2.5-upkeep too.

### Issue
When initiating a drag on the `moon.InputDecorator` control, with the VKB visible, the drag ends due to what seems to be a `mouseout` event being fired. This causes the `moon.ExpandableInput` to collapse in response to an `onSpotlightBlur` event being triggered by the `mouseout`, in addition to the `moon.InputDecorator` being focused in response to an `onSpotlightSelect`, also due to the `mouseout`.

### Fix
This fix attempts to address this behavior by preventing the collapse of the `moon.ExpandableInput` in this situation by guarding against collapsing when the previous event was `dragstart` or `drag`. Also took the liberty of converting parameter names to remove the `in` prefix.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>