### PR TITLE
ENYO-1027: Moon.DatePiker-Reset Date Does not collapse Picker.

### DIFF
--- a/samples/DatePickerSample.js
+++ b/samples/DatePickerSample.js
@@ -84,6 +84,8 @@ enyo.kind({
 	},
 	resetTapped: function(inSender, inEvent) {
 		this.$.picker.set("value", null);
+		this.$.picker.refresh();
+		this.$.picker.setOpen(false);
 		return true;
 	}
 });


### PR DESCRIPTION
Issue: On tap of resetDate button date picker drawer is not getting
collapse.
Fix: as its the sample issue added the code to required functionality .

DCO-1.1-Signed-Off-By: Srinivas V srinivas.v@lge.com