### PR TITLE
ENYO-1368: Enlarge scroll thumb minimum height from 20 to 40

### DIFF
--- a/source/Thumb.js
+++ b/source/Thumb.js
@@ -46,7 +46,7 @@
 		/**
 		* @private
 		*/
-		minSize: 20,
+		minSize: 40,
 
 		/**
 		* @private


### PR DESCRIPTION
- Change minSize value of moon.ScrollThumb from 20 to 40

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com