### PR TITLE
ENYO-1438: make css of videoPlayer's iconButton like REW/FF be effective only when icon is enabled.

### DIFF
--- a/css/VideoControlFullscreen.less
+++ b/css/VideoControlFullscreen.less
@@ -109,12 +109,12 @@
 .moon-icon-button.moon-icon-video-more-controls-font-style {
   font-size: @moon-icon-arrowextendshrink-font-size;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled) {
 	background-position: 0 -(@moon-icon-button-size);
 	border: 0px;
 	background-color: transparent;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -6,6 +6,10 @@
 /* minifier to fall back to using CSS files in place of the same-name       */
 /* LESS file.                                                               */
 
+.moon-item-icon-tap-area-adjust.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
 html {
   font-size: 1rem;
   font-size: 24px;
@@ -184,7 +188,7 @@ html {
 /* ----- Moonstone (Icons) ------ */
 @font-face {
   font-family: "Moonstone Icons";
-  src: local("Moonstone "), url("../fonts/moonstone.ttf") format("truetype");
+  src: local("Moonstone"), url("../fonts/moonstone.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
@@ -375,7 +379,7 @@ html {
   direction: rtl;
 }
 .moon-divider-border {
-  border-bottom: 0.125rem solid #a6a6a6;
+  border-bottom: 0.125rem solid #595959;
 }
 .moon-neutral-divider-border {
   border-bottom: 0.125rem solid #ffffff;
@@ -422,31 +426,25 @@ html {
   -webkit-font-kerning: normal;
   font-kerning: normal;
 }
-.moon-sub-header-text {
-  font-family: "MuseoSans 700";
-  font-size: 1.25rem;
-  color: #a6a6a6;
-}
 .moon-super-header-text {
   font-family: "Moonstone Miso";
   font-size: 1.375rem;
   -webkit-font-kerning: normal;
 }
-.moon-popup-header-text {
-  font-family: "Moonstone Miso";
-  font-size: 3rem;
-  -webkit-font-kerning: normal;
-}
-.moon-divider-text {
-  font-family: "MuseoSans 700 Italic";
-  font-size: 0.875rem;
+.moon-sub-header-text {
+  font-family: "MuseoSans 700";
+  font-size: 1.25rem;
   color: #a6a6a6;
+}
+.moon-header-sub-title-below {
+  font-family: "MuseoSans 300";
+  font-size: 1.125rem;
 }
 .moon-body-text {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-body-text a:link {
   color: #cf0652;
@@ -465,14 +463,14 @@ html {
   text-decoration: none;
 }
 .moon-body-large-text {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
+  font-size: 1.5rem;
+  line-height: 2rem;
 }
 .moon-bold-text {
   font-family: "MuseoSans 900";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-bold-text a:link {
   color: #cf0652;
@@ -495,7 +493,7 @@ html {
 }
 .moon-large-button-text {
   font-family: "Moonstone Miso Bold";
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   -webkit-font-kerning: normal;
 }
 .moon-small-button-text {
@@ -507,6 +505,23 @@ html {
   font-family: "Moonstone Icons";
   font-size: 3rem;
   color: #ffffff;
+}
+.moon-popup-header-text,
+.moon-dialog-title {
+  font-family: "Moonstone Miso";
+  font-size: 3rem;
+  -webkit-font-kerning: normal;
+}
+.moon-dialog-sub-title {
+  font-size: 1.125rem;
+}
+.moon-dialog-content {
+  font-size: 1.25rem;
+}
+.moon-divider-text {
+  font-family: "MuseoSans 700 Italic";
+  font-size: 1rem;
+  color: #a6a6a6;
 }
 .enyo-locale-non-latin .moon,
 .enyo-locale-non-latin .moon input,
@@ -594,7 +609,7 @@ html {
   background-repeat: no-repeat;
   display: inline-block;
   vertical-align: middle;
-  margin: 0.5rem 0.5rem;
+  margin: 0.5rem;
   font-family: "Moonstone", "Moonstone Icons";
   font-size: 4rem;
   line-height: 2rem;
@@ -646,11 +661,11 @@ html {
 .moon-icon-button {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
-  color: #a6a6a6;
+  color: #cccccc;
   width: 3.5rem;
   height: 3.5rem;
   border-radius: 1.75rem;
-  background-color: #404040;
+  background-color: #4d4d4d;
   background-size: 3rem 6rem;
   border: 0.25rem solid transparent;
   background-position: center 0;
@@ -682,8 +697,8 @@ html {
 .moon-icon-button:active,
 .moon-icon-button.pressed,
 .moon-icon-button.hover:hover:not(.disabled):active {
-  color: #a6a6a6;
-  background-color: #404040;
+  color: #cccccc;
+  background-color: #4d4d4d;
   background-position: center 0;
   border-color: #cf0652;
 }
@@ -906,8 +921,12 @@ html {
 .spotlight .moon-checkbox[checked]:after {
   color: #ffffff;
 }
+.spotlight .moon-checkbox:not([checked]):not([disabled]) .moon-icon {
+  visibility: visible;
+  opacity: 0.3;
+}
 .moon-divider {
-  border-bottom: 0.125rem solid #a6a6a6;
+  border-bottom: 0.125rem solid #595959;
   margin: 0 0.5rem 1rem 0.5rem;
   padding-bottom: 0.125rem;
 }
@@ -947,7 +966,7 @@ html {
 }
 /* Right to left */
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox {
-  left: 0.625rem;
+  left: 0.375rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox-item-label-wrapper {
@@ -998,7 +1017,7 @@ html {
   width: 2.5rem;
   height: 1.25rem;
   line-height: 1.25rem;
-  background-color: #404040;
+  background-color: #4d4d4d;
   font-family: "Moonstone Icons";
   overflow: hidden;
   text-align: left;
@@ -1029,16 +1048,21 @@ html {
   color: #cf0652;
 }
 .moon-checkbox.moon-toggle-switch[disabled] {
-  background-color: #404040;
+  background-color: #4d4d4d;
 }
 .moon-checkbox.moon-toggle-switch[disabled] .moon-icon {
   color: #a6a6a6;
 }
-.moon-checkbox.moon-toggle-switch.animated .moon-icon {
-  -webkit-transition: background-color 0.2s, left 0.2s;
+.moon-checkbox.moon-toggle-switch.animated {
+  -webkit-transition: background-color 0.2s;
+  transition: background-color 0.2s;
 }
-.moon-checkbox.moon-toggle-switch.animated .moon-icon:after {
-  -webkit-transition: color 0.2s;
+.moon-checkbox.moon-toggle-switch.animated .moon-icon {
+  -webkit-transition: left 0.2s, color 0.2s;
+  transition: left 0.2s, color 0.2s;
+}
+.moon-toggle-item.spotlight .moon-checkbox.moon-toggle-switch .moon-icon {
+  opacity: 1;
 }
 .moon-toggle-item {
   display: block;
@@ -1117,7 +1141,7 @@ html {
 /* Item.css */
 .moon-item {
   font-family: "MuseoSans 700";
-  font-size: 1.25rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
   line-height: 1.2em;
   padding: 0.5rem;
@@ -1134,9 +1158,54 @@ html {
   cursor: default;
   opacity: 0.6;
 }
+.moon-item > .moon-icon:first-child.small > .small-icon-tap-area,
+.moon-item > .moon-icon:last-child.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
 .enyo-locale-non-latin .moon-item {
   font-family: "Moonstone LG Display Bold";
   font-size: 1.25rem;
+}
+/* ItemOverlay.less */
+.moon-item .moon-item-overlay {
+  float: left;
+}
+.moon-item .moon-item-overlay.right {
+  float: right;
+}
+.moon-item .moon-item-overlay.beginning .moon-icon:first-child.small > .small-icon-tap-area,
+.moon-item .moon-item-overlay.ending .moon-icon:last-child.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
+.moon-item .moon-item-overlay.beginning .moon-icon:first-child {
+  margin-left: 0;
+}
+.moon-item .moon-item-overlay.ending .moon-icon:last-child {
+  margin-right: 0;
+}
+.moon-item .moon-item-overlay .moon-icon {
+  margin-top: 0;
+  margin-bottom: 0;
+  vertical-align: top;
+}
+.moon-item:not(.spotlight) .moon-item-overlay.auto-hide {
+  display: none;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay {
+  float: right;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay.right {
+  float: left;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay.beginning .moon-icon:first-child {
+  margin-right: 0;
+  margin-left: 0.5rem;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay.ending .moon-icon:last-child {
+  margin-left: 0;
+  margin-right: 0.5rem;
 }
 /* SelectableItem.css */
 .moon-selectable-item.selected {
@@ -1169,7 +1238,7 @@ html {
   height: 3.5rem;
   line-height: 3rem;
   border-radius: 416.625rem;
-  background-color: #404040;
+  background-color: #4d4d4d;
   border: 0.25rem solid transparent;
   cursor: pointer;
   white-space: nowrap;
@@ -1179,7 +1248,7 @@ html {
   max-width: 12.5rem;
   padding: 0 0.75rem;
   margin: 0 0.5rem;
-  color: #a6a6a6;
+  color: #cccccc;
 }
 .moon-button > * {
   text-align: center;
@@ -1197,8 +1266,8 @@ html {
 .moon-button.spotlight.pressed,
 .moon-button.spotlight:active {
   border: 0.25rem solid #cf0652;
-  background-color: #404040;
-  color: #a6a6a6;
+  background-color: #4d4d4d;
+  color: #cccccc;
 }
 .moon-button.spotlight {
   background-color: #cf0652;
@@ -1396,9 +1465,9 @@ html {
 }
 .moon-expandable-list-item-client .moon-item {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-expandable-list-item-client .moon-item a:link {
   color: #cf0652;
@@ -1468,8 +1537,8 @@ html {
 /* Current Value */
 .moon-expandable-picker-current-value {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
-  line-height: 1.375rem;
+  font-size: 1.375rem;
+  line-height: 1.625rem;
   color: #a6a6a6;
   margin: 0rem;
 }
@@ -1507,7 +1576,7 @@ html {
 .moon-header {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
-  color: #a6a6a6;
+  color: #cccccc;
   height: 15rem;
   border-top: 0.125rem solid #505050;
   border-bottom: 0.25rem solid #404040;
@@ -1646,9 +1715,9 @@ html {
 }
 .moon-gridlist-imageitem .sub-caption {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-gridlist-imageitem .sub-caption a:link {
   color: #cf0652;
@@ -1880,6 +1949,12 @@ html {
 .moon-input::selection {
   color: #ffffff;
   background-color: #cf0652;
+}
+.moon-input[type=number] {
+  -moz-appearance: textfield;
+}
+.moon-input[type=number]:hover {
+  -moz-appearance: none;
 }
 .moon-input-decorator .moon-focused .moon-input {
   cursor: text;
@@ -2405,7 +2480,7 @@ html {
   border: 0;
   cursor: pointer;
   background: transparent;
-  height: 4.125rem;
+  height: 4.875rem;
   width: 12.5rem;
   color: #4b4b4b;
   resize: none;
@@ -2523,20 +2598,25 @@ html {
   width: 100%;
   height: 100%;
   -webkit-transform: translateZ(0) translateY(100%);
+  transform: translateZ(0) translateY(100%);
 }
 .moon-list-actions-drawer-client.open {
   -webkit-transform: translateZ(0) translateY(0);
+  tranform: translateZ(0) translateY(0);
 }
 .moon-list-actions-drawer-client.animated {
   -webkit-transition: -webkit-transform 0.225s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: transform 0.225s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 .moon-medium-header .moon-list-actions-drawer-client,
 .moon-small-header .moon-list-actions-drawer-client {
   -webkit-transform: translateZ(0) translateY(-100%);
+  transform: translateZ(0) translateY(-100%);
 }
 .moon-medium-header .moon-list-actions-drawer-client.open,
 .moon-small-header .moon-list-actions-drawer-client.open {
   -webkit-transform: translateZ(0) translateY(0);
+  transform: translateZ(0) translateY(0);
 }
 .moon-list-actions.stacked .enyo-fittable-rows-layout > * {
   height: auto !important;
@@ -2572,9 +2652,9 @@ html {
 /* Text */
 .moon-labeledtextitem .text {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   text-transform: none;
   margin: 0rem;
   padding: 0rem;
@@ -2754,6 +2834,130 @@ html {
     -webkit-transform: rotateZ(600deg);
   }
 }
+@keyframes spinBall {
+  0% {
+    transform: rotateZ(13deg);
+  }
+  /* Slow down toward the top */
+  15% {
+    transform: rotateZ(160deg);
+  }
+  25% {
+    transform: rotateZ(200deg);
+  }
+  30% {
+    transform: rotateZ(225deg);
+  }
+  /* Speed back up as the ball falls */
+  /* Impact at last ball */
+  33% {
+    transform: rotateZ(321deg);
+  }
+  39%,
+  67% {
+    transform: rotateZ(347deg);
+  }
+  /* Small bounce forward */
+  72% {
+    transform: rotateZ(383deg);
+  }
+  79%,
+  100% {
+    transform: rotateZ(373deg);
+  }
+}
+@keyframes spinBall2 {
+  /* Small bounce forward */
+  0% {
+    transform: rotateZ(347deg);
+  }
+  5% {
+    transform: rotateZ(383deg);
+  }
+  12%,
+  33% {
+    transform: rotateZ(373deg);
+  }
+  33.01% {
+    transform: rotateZ(13deg);
+  }
+  /* Slow down toward the top */
+  48% {
+    transform: rotateZ(160deg);
+  }
+  58% {
+    transform: rotateZ(200deg);
+  }
+  63% {
+    transform: rotateZ(225deg);
+  }
+  /* Speed back up as the ball falls */
+  /* Impact at last ball */
+  67% {
+    transform: rotateZ(321deg);
+  }
+  72%,
+  100% {
+    transform: rotateZ(347deg);
+  }
+}
+@keyframes spinBall3 {
+  /* Impact at last ball */
+  0%,
+  100% {
+    transform: rotateZ(321deg);
+  }
+  5%,
+  33% {
+    transform: rotateZ(347deg);
+  }
+  /* Small bounce forward */
+  38% {
+    transform: rotateZ(383deg);
+  }
+  45%,
+  66% {
+    transform: rotateZ(373deg);
+  }
+  66.01% {
+    transform: rotateZ(13deg);
+  }
+  /* Slow down toward the top */
+  81% {
+    transform: rotateZ(160deg);
+  }
+  91% {
+    transform: rotateZ(200deg);
+  }
+  97% {
+    transform: rotateZ(225deg);
+  }
+  /* Speed back up as the ball falls */
+}
+@keyframes propellerBall {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}
+@keyframes propellerBall2 {
+  0% {
+    transform: rotateZ(120deg);
+  }
+  100% {
+    transform: rotateZ(480deg);
+  }
+}
+@keyframes propellerBall3 {
+  0% {
+    transform: rotateZ(240deg);
+  }
+  100% {
+    transform: rotateZ(600deg);
+  }
+}
 .moon-spinner {
   min-height: 3rem;
   min-width: 3rem;
@@ -2791,6 +2995,7 @@ html {
 }
 .moon-spinner.running .moon-spinner-ball {
   -webkit-animation-play-state: running;
+  animation-play-state: running;
 }
 .moon-spinner .moon-spinner-ball-decorator {
   position: relative;
@@ -2804,12 +3009,15 @@ html {
   font-size: 90%;
   line-height: 0.4em;
   -webkit-animation: none 1.83s linear infinite;
+  animation: none 1.83s linear infinite;
   -webkit-animation-play-state: paused;
+  animation-play-state: paused;
   height: 15%;
   width: 15%;
   left: 42.5%;
   bottom: 15%;
   -webkit-transform-origin: center -133.33333333%;
+  transform-origin: center -133.33333333%;
 }
 .moon-spinner .moon-spinner-ball:after {
   content: "\0F0013";
@@ -2817,18 +3025,24 @@ html {
 }
 .moon-spinner .moon-spinner-ball1 {
   -webkit-animation-name: spinBall;
+  animation-name: spinBall;
   color: #69cdff;
   -webkit-transform: rotateZ(13deg);
+  transform: rotateZ(13deg);
 }
 .moon-spinner .moon-spinner-ball2 {
   -webkit-animation-name: spinBall2;
+  animation-name: spinBall2;
   color: #ff4a4a;
   -webkit-transform: rotateZ(347deg);
+  transform: rotateZ(347deg);
 }
 .moon-spinner .moon-spinner-ball3 {
   -webkit-animation-name: spinBall3;
+  animation-name: spinBall3;
   color: #ffb80d;
   -webkit-transform: rotateZ(321deg);
+  transform: rotateZ(321deg);
 }
 .moon-spinner .moon-spinner-client {
   float: left;
@@ -2914,7 +3128,7 @@ html {
 }
 .moon-panel-small-header {
   margin-top: 1rem;
-  color: #a6a6a6;
+  color: #cccccc;
   display: block;
   overflow: hidden;
   padding: 0rem;
@@ -2923,7 +3137,7 @@ html {
   color: #ffffff;
 }
 .moon-panel-small-header-title-above {
-  color: #a6a6a6;
+  color: #cccccc;
   border-top: 0.125rem solid #ffffff;
   padding-top: 0.25rem;
 }
@@ -2946,7 +3160,7 @@ html {
 }
 .moon-panels.activity .moon-panel-small-header,
 .moon-panels.activity .moon-panel-small-header-title-above {
-  color: #a6a6a6;
+  color: #cccccc;
 }
 .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header,
 .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header-title-above {
@@ -2995,12 +3209,48 @@ html {
     -webkit-transform: translateY(-100%);
   }
 }
+@keyframes panel-outer {
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+@keyframes panel-inner {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+@keyframes breadcrumb-outer {
+  0% {
+    transform: translateY(0%);
+  }
+  36%,
+  100% {
+    transform: translateY(100%);
+  }
+}
+@keyframes breadcrumb-inner {
+  0% {
+    transform: translateY(0%);
+  }
+  36%,
+  100% {
+    transform: translateY(-100%);
+  }
+}
 .moon-panel.moon-composite .moon-panel-viewport,
 .moon-panel.moon-composite .moon-panel-content-wrapper,
 .moon-panel.moon-composite .moon-panel-breadcrumb-viewport,
 .moon-panel.moon-composite .moon-panel-small-header-wrapper {
   -webkit-animation-fill-mode: both;
   -webkit-animation-timing-function: ease-in-out;
+  animation-fill-mode: both;
+  animation-timing-function: ease-in-out;
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   -o-transform: translateZ(0);
@@ -3017,24 +3267,29 @@ html {
 .moon-panel.growing .moon-panel-viewport,
 .moon-panel.shrinking .moon-panel-viewport {
   -webkit-animation-name: panel-outer;
+  animation-name: panel-outer;
 }
 .moon-panel.growing .moon-panel-breadcrumb-viewport,
 .moon-panel.shrinking .moon-panel-breadcrumb-viewport {
   -webkit-animation-name: breadcrumb-outer;
+  animation-name: breadcrumb-outer;
 }
 .moon-panel.growing .moon-panel-content-wrapper,
 .moon-panel.shrinking .moon-panel-content-wrapper {
   -webkit-animation-name: panel-inner;
+  animation-name: panel-inner;
 }
 .moon-panel.growing .moon-panel-small-header-wrapper,
 .moon-panel.shrinking .moon-panel-small-header-wrapper {
   -webkit-animation-name: breadcrumb-inner;
+  animation-name: breadcrumb-inner;
 }
 .moon-panel.growing .moon-panel-viewport,
 .moon-panel.growing .moon-panel-content-wrapper,
 .moon-panel.growing .moon-panel-breadcrumb-viewport,
 .moon-panel.growing .moon-panel-small-header-wrapper {
   -webkit-animation-duration: 0.4s;
+  animation-duration: 0.4s;
 }
 .moon-panel.shrinking .moon-panel-viewport,
 .moon-panel.shrinking .moon-panel-content-wrapper,
@@ -3042,18 +3297,24 @@ html {
 .moon-panel.shrinking .moon-panel-small-header-wrapper {
   -webkit-animation-duration: 0.5s;
   -webkit-animation-direction: reverse;
+  animation-duration: 0.5s;
+  animation-direction: reverse;
 }
 .moon-panel.shrunken .moon-panel-viewport {
   -webkit-transform: translateY(-101%);
+  transform: translateY(-101%);
 }
 .moon-panel.shrunken .moon-panel-content-wrapper {
   -webkit-transform: translateY(101%);
+  transform: translateY(101%);
 }
 .moon-panel:not(.shrunken) .moon-panel-breadcrumb-viewport {
   -webkit-transform: translateY(101%);
+  transform: translateY(101%);
 }
 .moon-panel:not(.shrunken) .moon-panel-small-header-wrapper {
   -webkit-transform: translateY(-101%);
+  transform: translateY(-101%);
 }
 /* Panels */
 .moon-panels.activity,
@@ -3146,7 +3407,9 @@ html {
   content: "\0F0003";
   color: #ffffff;
   -webkit-transform: translate3d(0, 0, 0);
-  transition: -webkit-transform 0.2s linear, opacity 0.2s linear;
+  transform: translate3d(0, 0, 0);
+  -webkit-transition: -webkit-transform 0.2s linear, opacity 0.2s linear;
+  transition: transform 0.2s linear, opacity 0.2s linear;
   opacity: 1;
   text-align: center;
 }
@@ -3156,6 +3419,7 @@ html {
 .moon-panels-handle.spotlight:before {
   background-color: #cf0652;
   -webkit-transform: translate3d(-5rem, 0, 0);
+  transform: translate3d(-5rem, 0, 0);
 }
 .moon-panels-handle.stashed:before {
   opacity: 0;
@@ -3288,7 +3552,7 @@ html {
   display: inline-block;
   box-sizing: border-box;
   line-height: 1em;
-  color: #a6a6a6;
+  color: #cccccc;
   width: 100%;
   text-overflow: ellipsis;
 }
@@ -3300,15 +3564,18 @@ html {
 .moon-input-header .moon-input.moon-header-title {
   position: static;
 }
-.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder {
-  color: #333333;
+.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder,
+.moon-input-header .moon-input.moon-header-title::-moz-placeholder {
+  color: #595959;
   margin-top: 0.5rem;
   line-height: 1.25em;
 }
-.enyo-locale-non-latin .moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder {
+.enyo-locale-non-latin .moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder,
+.enyo-locale-non-latin .moon-input-header .moon-input.moon-header-title::-moz-input-placeholder {
   line-height: 1.5em;
 }
-.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder {
+.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight .moon-input::-moz-input-placeholder {
   color: #ffffff;
 }
 .moon-input-header-input-decorator.spotlight > .moon-input {
@@ -3318,8 +3585,9 @@ html {
 .moon-input-header-input-decorator.spotlight.moon-focused > .moon-input {
   background: none;
 }
-.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder {
-  color: #333333;
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-moz-input-placeholder {
+  color: #595959;
 }
 .moon-drawer-partial-client {
   padding: 1.5rem 0.75rem 0.75rem;
@@ -3484,9 +3752,6 @@ html {
 }
 .moon-dialog-title {
   margin-bottom: 0.5rem;
-}
-.moon-dialog-sub-title {
-  font-size: 1rem;
 }
 .moon-dialog-client-wrapper {
   min-height: 4.5rem;
@@ -3763,7 +4028,7 @@ html {
 }
 .moon-video-transport-slider-popup-label {
   font-family: "Moonstone Miso Bold";
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   -webkit-font-kerning: normal;
   white-space: nowrap;
   color: #4b4b4b;
@@ -3826,6 +4091,16 @@ html {
   position: relative;
   display: inline-block;
   background-color: #000000;
+}
+.moon-video-player:after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+.moon-video-player.spinner-showing:after {
+  content: '';
 }
 .moon-video-player:not(.enyo-fullscreen) {
   margin: 0 0.5rem;
@@ -4065,23 +4340,23 @@ html {
 .moon-icon-button.moon-icon-video-more-controls-font-style {
   font-size: 4.5rem;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled) {
   background-position: 0 -3.5rem;
   border: 0rem;
   background-color: transparent;
   color: #cf0652;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active.moon-icon-video-round-controls-style {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled).moon-icon-video-round-controls-style {
   color: #ffffff;
   background-color: #cf0652;
 }
@@ -4168,9 +4443,6 @@ html {
 .enyo-locale-non-latin .moon-video-feedback-icon-right {
   margin-bottom: 0.125rem;
 }
-.enyo-locale-right-to-left .moon-video-player-feedback {
-  margin: 0 0 0 0.5rem;
-}
 .enyo-locale-right-to-left .moon-icon.moon-video-feedback-icon-left {
   margin: 0 0 0 0.5rem;
 }
@@ -4213,9 +4485,9 @@ html {
 }
 .moon-video-player-info-subsubtitle {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   font-style: italic;
   color: #ffffff;
   display: inline-block;
@@ -4247,9 +4519,9 @@ html {
 }
 .moon-video-player-info-description {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #a6a6a6;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   color: #ffffff;
   white-space: normal;
   margin-bottom: 1rem;
@@ -4400,6 +4672,7 @@ html {
   line-height: normal;
   color: #ffffff;
 }
+/* TODO: Clean up / reduce this file after new scroller implementation is completely integrated. */
 .moon-scroller-client-wrapper,
 .moon-scroller-viewport {
   box-sizing: border-box;
@@ -4508,6 +4781,28 @@ html {
   right: 0rem;
   width: 2.5rem;
 }
+.moon-scroller-hthumb,
+.moon-scroller-vthumb {
+  transition: opacity 0.1s linear;
+  -moz-transition: opacity 0.1s linear;
+  -webkit-transition: opacity 0.1s linear;
+}
+.moon-scroller-hthumb {
+  bottom: 1.16667rem;
+}
+.moon-scroller-vthumb {
+  right: 1.16667rem;
+}
+.moon-scroller-hthumb.hidden,
+.moon-scroller-vthumb.hidden {
+  opacity: 0;
+}
+.moon-scroller-client-wrapper .enyo-new-thumb {
+  background: #a6a6a6;
+}
+.moon-neutral .moon-scroller-client-wrapper .enyo-new-thumb {
+  background: #ffffff;
+}
 .moon-expandable-input .moon-input-decorator {
   width: 100%;
   box-sizing: border-box;
@@ -4611,31 +4906,38 @@ html {
 .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
   color: #ffffff;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim {
+.moon-selection-overlay-support-scrim {
+  display: none;
+}
+.selection-enabled .moon-selection-overlay-support-scrim {
   display: block;
+  z-index: 1000;
   text-align: center;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim .moon-icon {
-  position: absolute;
+.selection-enabled .moon-selection-overlay-support-scrim .moon-icon {
+  display: block;
   width: 2.5rem;
   height: 2.5rem;
   line-height: 2.5rem;
-  font-size: 3.375rem;
+  border: 0.25rem solid #000000;
+  background-color: white;
+  color: transparent;
+  -webkit-transform: translateX(-50%) translateY(-50%);
+  transform: translateX(-50%) translateY(-50%);
+  margin: 0;
+  border-radius: 50%;
+  position: absolute;
+  opacity: 0.5;
+}
+.selection-enabled .selected .moon-selection-overlay-support-scrim .moon-icon {
   color: #cf0652;
-  margin: -1.25rem 0 0 -1.25rem;
-  background-color: #ffffff;
-  border-radius: 1.25rem;
-  background-position: center 0.25rem;
+  border-color: #cf0652;
+  opacity: 1;
 }
-.moon-selection-overlay-support-scrim {
-  display: none;
-  z-index: 1000;
-}
-.enyo-locale-right-to-left .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim .moon-icon {
-  margin: -1.25rem -1.25rem 0 0;
-}
+/* TODO: Retire this file after new scroller implementation is completely integrated. */
 .moon-thumb {
   -webkit-transform-origin: 0rem 0rem;
+  transform-origin: 0rem 0rem;
   border: none;
   background: #a6a6a6;
   width: 0.125rem;
@@ -4644,22 +4946,6 @@ html {
 }
 .moon-neutral .moon-thumb {
   background: #ffffff;
-}
-.moon-scroller-hthumb,
-.moon-scroller-vthumb {
-  transition: opacity 0.1s linear;
-  -moz-transition: opacity 0.1s linear;
-  -webkit-transition: opacity 0.1s linear;
-}
-.moon-scroller-hthumb {
-  bottom: 1.16667rem;
-}
-.moon-scroller-vthumb {
-  right: 1.16667rem;
-}
-.moon-scroller-hthumb.hidden,
-.moon-scroller-vthumb.hidden {
-  opacity: 0;
 }
 .moon-image {
   display: inline-block;
@@ -4757,6 +5043,28 @@ html {
 .moon-icon-exitfullscreen.moon-icon-exitfullscreen-font-style {
   font-size: 4rem;
 }
+.moon-light-panel .client {
+  opacity: 0;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+}
+.moon-light-panel .client.populated {
+  opacity: 1;
+}
+.moon-light-panel:after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+.moon-light-panel.transitioning {
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+}
+.moon-light-panel.transitioning:after {
+  content: '';
+}
 /* Put this at the end because we want these to take precedence over others */
 .moon-neutral {
   background-color: #686868;
@@ -4850,265 +5158,4 @@ html {
 .moon-vspacing-l > .moon-formcheckbox-item {
   margin-top: 0.875rem;
   margin-bottom: 1.75rem;
-}
-.moon-theme-light {
-  /* Common classes applicable to multiple controls */
-  /* Text definitions */
-  color: #4b4b4b;
-  background-color: #ededed;
-  /* Icon.css */
-  /* IconButton.css */
-  /* Item.css */
-  /* Button */
-  /* Spinner.css */
-  /* Activity Panels Overrides */
-  /* AlwaysViewing Overrides */
-  /* Scrim */
-  /* Show/Hide Handle */
-  /* FormCheckbox.css */
-}
-.moon-theme-light .moon-divider-border {
-  border-bottom-color: #4b4b4b;
-}
-.moon-theme-light .moon-neutral-divider-border {
-  border-bottom-color: #ffffff;
-}
-.moon-theme-light .moon-sub-header-text {
-  font-family: "MuseoSans 700";
-  font-size: 1.25rem;
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-divider-text {
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-body-text {
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-body-text a:link {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-light .moon-body-text a:visited {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-light .moon-body-text a:hover {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-light .moon-body-text a:active {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-light .moon-bold-text {
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-bold-text a:link {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-light .moon-bold-text a:visited {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-light .moon-bold-text a:hover {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-light .moon-bold-text a:active {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-light .moon-icon-text {
-  color: #ffffff;
-}
-.moon-theme-light .moon-icon,
-.moon-theme-light .moon-icon-toggle {
-  color: #4b4b4b;
-}
-.moon-theme-light .spotlight .moon-icon {
-  color: #ffffff;
-}
-.moon-theme-light .moon-icon-button {
-  color: #999999;
-  background-color: #ffffff;
-}
-.moon-theme-light .moon-icon-button.hover:hover:not(.disabled),
-.moon-theme-light .moon-icon-button.spotlight {
-  color: #ffffff;
-  background-color: #cf0652;
-}
-.moon-theme-light .moon-icon-button.active:not(.spotlight),
-.moon-theme-light .moon-icon-button:active,
-.moon-theme-light .moon-icon-button.pressed,
-.moon-theme-light .moon-icon-button.hover:hover:not(.disabled):active {
-  color: #999999;
-  background-color: #ffffff;
-  border-color: #cf0652;
-}
-.moon-theme-light .moon-icon-button.active.spotlight:not(.contextual-popup-button) {
-  border-color: #ffffff;
-  background-color: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-light .moon-icon-button.active.spotlight:not(.contextual-popup-button):active,
-.moon-theme-light .moon-icon-button.active.spotlight:not(.contextual-popup-button).pressed {
-  border-color: #cf0652;
-}
-.moon-theme-light .moon-item {
-  font-family: "MuseoSans 700";
-  font-size: 1.25rem;
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-item.spotlight {
-  background-color: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-light .enyo-locale-non-latin .moon-item {
-  font-family: "Moonstone LG Display Bold";
-  font-size: 1.25rem;
-}
-.moon-theme-light .moon-button {
-  background-color: #ffffff;
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-button.active,
-.moon-theme-light .moon-button.pressed,
-.moon-theme-light .moon-button.spotlight.pressed,
-.moon-theme-light .moon-button.spotlight:active {
-  border-color: #cf0652;
-  background-color: #ffffff;
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-button.spotlight {
-  background-color: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-light .moon-button.active.spotlight:not(.contextual-popup-button) {
-  border-color: #ffffff;
-  background-color: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-light .moon-button.active.spotlight:not(.contextual-popup-button):active,
-.moon-theme-light .moon-button.active.spotlight:not(.contextual-popup-button).pressed {
-  border-color: #cf0652;
-}
-.moon-theme-light .moon-button[disabled] {
-  color: #b3b3b3;
-  background-color: #ffffff;
-}
-.moon-theme-light .moon-neutral .moon-button {
-  color: #4b4b4b;
-  background-color: #ffffff;
-}
-.moon-theme-light .moon-neutral .moon-button.spotlight {
-  background-color: #cf0652;
-}
-.moon-theme-light .moon-neutral .moon-button.spotlight * {
-  color: #ffffff;
-}
-.moon-theme-light .moon-neutral .moon-button.active,
-.moon-theme-light .moon-neutral .moon-button.pressed,
-.moon-theme-light .moon-neutral .moon-button.spotlight.pressed,
-.moon-theme-light .moon-neutral .moon-button.spotlight:active {
-  border-color: #cf0652;
-  background-color: #ffffff;
-}
-.moon-theme-light .moon-neutral .moon-button.active *,
-.moon-theme-light .moon-neutral .moon-button.pressed *,
-.moon-theme-light .moon-neutral .moon-button.spotlight.pressed *,
-.moon-theme-light .moon-neutral .moon-button.spotlight:active * {
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-neutral .moon-button[disabled] {
-  color: #b3b3b3;
-  background-color: #ffffff;
-}
-.moon-theme-light .moon-header {
-  color: #4b4b4b;
-  border-top-color: #4b4b4b;
-  border-bottom-color: #4b4b4b;
-}
-.moon-theme-light .moon-neutral .moon-header {
-  border-top-color: #ffffff;
-  border-bottom-color: #ffffff;
-}
-.moon-theme-light .moon-spinner {
-  color: #ffffff;
-  background-color: #4d4d4d;
-}
-.moon-theme-light .moon-spinner .moon-spinner-ball1 {
-  color: #69cdff;
-}
-.moon-theme-light .moon-spinner .moon-spinner-ball2 {
-  color: #ff4a4a;
-}
-.moon-theme-light .moon-spinner .moon-spinner-ball3 {
-  color: #ffb80d;
-}
-.moon-theme-light .moon-panel-small-header {
-  color: #4b4b4b;
-}
-.moon-theme-light .spotlight .moon-panel-small-header {
-  color: #ffffff;
-}
-.moon-theme-light .moon-panel-small-header-title-above {
-  color: #4b4b4b;
-  border-top-color: #ffffff;
-}
-.moon-theme-light .spotlight .moon-panel-small-header-title-above {
-  color: #ffffff;
-}
-.moon-theme-light .moon-panel .moon-panel-small-header-wrapper.spotlight {
-  background: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-light .moon-panels.activity .moon-panel-small-header-title-above {
-  border-top-color: #4b4b4b;
-}
-.moon-theme-light .moon-panels.activity .moon-panel-small-header,
-.moon-theme-light .moon-panels.activity .moon-panel-small-header-title-above {
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header,
-.moon-theme-light .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header-title-above {
-  color: #ffffff;
-}
-.moon-theme-light .moon-panels.always-viewing .moon-panel-small-header,
-.moon-theme-light .moon-panels.always-viewing .moon-panel-small-header-title-above {
-  color: #ffffff;
-}
-.moon-theme-light .moon-panels.activity .moon-panels-panel-scrim {
-  background-color: #ededed;
-}
-.moon-theme-light .moon-panels.always-viewing .moon-panels-panel-scrim {
-  background-color: #ededed;
-}
-.moon-theme-light .moon-panels-handle:before {
-  background-color: #4b4b4b;
-  color: #ffffff;
-}
-.moon-theme-light .moon-panels-handle.spotlight:before {
-  background-color: #cf0652;
-}
-.moon-theme-light .moon-item.moon-formcheckbox-item {
-  background: none;
-}
-.moon-theme-light .moon-item.moon-formcheckbox-item .moon-checkbox {
-  background-color: #ffffff;
-}
-.moon-theme-light .moon-formcheckbox-item.spotlight .moon-checkbox {
-  background-color: #cf0652;
-}
-.moon-theme-light .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
-  color: #4b4b4b;
-}
-.moon-theme-light .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
-  color: #ffffff;
-}
-.moon-theme-light .moon-thumb {
-  background: rgba(50, 50, 50, 0.8);
-}
-.moon-theme-light .moon-neutral .moon-thumb {
-  background: #ffffff;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -6,6 +6,10 @@
 /* minifier to fall back to using CSS files in place of the same-name       */
 /* LESS file.                                                               */
 
+.moon-item-icon-tap-area-adjust.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
 html {
   font-size: 1rem;
   font-size: 24px;
@@ -184,7 +188,7 @@ html {
 /* ----- Moonstone (Icons) ------ */
 @font-face {
   font-family: "Moonstone Icons";
-  src: local("Moonstone "), url("../fonts/moonstone.ttf") format("truetype");
+  src: local("Moonstone"), url("../fonts/moonstone.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
@@ -422,31 +426,25 @@ html {
   -webkit-font-kerning: normal;
   font-kerning: normal;
 }
-.moon-sub-header-text {
-  font-family: "MuseoSans 700";
-  font-size: 1.25rem;
-  color: #4b4b4b;
-}
 .moon-super-header-text {
   font-family: "Moonstone Miso";
   font-size: 1.375rem;
   -webkit-font-kerning: normal;
 }
-.moon-popup-header-text {
-  font-family: "Moonstone Miso";
-  font-size: 3rem;
-  -webkit-font-kerning: normal;
-}
-.moon-divider-text {
-  font-family: "MuseoSans 700 Italic";
-  font-size: 0.875rem;
+.moon-sub-header-text {
+  font-family: "MuseoSans 700";
+  font-size: 1.25rem;
   color: #4b4b4b;
+}
+.moon-header-sub-title-below {
+  font-family: "MuseoSans 300";
+  font-size: 1.125rem;
 }
 .moon-body-text {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-body-text a:link {
   color: #cf0652;
@@ -465,14 +463,14 @@ html {
   text-decoration: none;
 }
 .moon-body-large-text {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
+  font-size: 1.5rem;
+  line-height: 2rem;
 }
 .moon-bold-text {
   font-family: "MuseoSans 900";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-bold-text a:link {
   color: #cf0652;
@@ -495,7 +493,7 @@ html {
 }
 .moon-large-button-text {
   font-family: "Moonstone Miso Bold";
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   -webkit-font-kerning: normal;
 }
 .moon-small-button-text {
@@ -507,6 +505,23 @@ html {
   font-family: "Moonstone Icons";
   font-size: 3rem;
   color: #ffffff;
+}
+.moon-popup-header-text,
+.moon-dialog-title {
+  font-family: "Moonstone Miso";
+  font-size: 3rem;
+  -webkit-font-kerning: normal;
+}
+.moon-dialog-sub-title {
+  font-size: 1.125rem;
+}
+.moon-dialog-content {
+  font-size: 1.25rem;
+}
+.moon-divider-text {
+  font-family: "MuseoSans 700 Italic";
+  font-size: 1rem;
+  color: #4b4b4b;
 }
 .enyo-locale-non-latin .moon,
 .enyo-locale-non-latin .moon input,
@@ -594,7 +609,7 @@ html {
   background-repeat: no-repeat;
   display: inline-block;
   vertical-align: middle;
-  margin: 0.5rem 0.5rem;
+  margin: 0.5rem;
   font-family: "Moonstone", "Moonstone Icons";
   font-size: 4rem;
   line-height: 2rem;
@@ -906,6 +921,10 @@ html {
 .spotlight .moon-checkbox[checked]:after {
   color: #ffffff;
 }
+.spotlight .moon-checkbox:not([checked]):not([disabled]) .moon-icon {
+  visibility: visible;
+  opacity: 0.3;
+}
 .moon-divider {
   border-bottom: 0.125rem solid #4b4b4b;
   margin: 0 0.5rem 1rem 0.5rem;
@@ -947,7 +966,7 @@ html {
 }
 /* Right to left */
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox {
-  left: 0.625rem;
+  left: 0.375rem;
   right: auto;
 }
 .enyo-locale-right-to-left .moon-checkbox-item .moon-checkbox-item-label-wrapper {
@@ -1034,11 +1053,16 @@ html {
 .moon-checkbox.moon-toggle-switch[disabled] .moon-icon {
   color: #4b4b4b;
 }
-.moon-checkbox.moon-toggle-switch.animated .moon-icon {
-  -webkit-transition: background-color 0.2s, left 0.2s;
+.moon-checkbox.moon-toggle-switch.animated {
+  -webkit-transition: background-color 0.2s;
+  transition: background-color 0.2s;
 }
-.moon-checkbox.moon-toggle-switch.animated .moon-icon:after {
-  -webkit-transition: color 0.2s;
+.moon-checkbox.moon-toggle-switch.animated .moon-icon {
+  -webkit-transition: left 0.2s, color 0.2s;
+  transition: left 0.2s, color 0.2s;
+}
+.moon-toggle-item.spotlight .moon-checkbox.moon-toggle-switch .moon-icon {
+  opacity: 1;
 }
 .moon-toggle-item {
   display: block;
@@ -1117,7 +1141,7 @@ html {
 /* Item.css */
 .moon-item {
   font-family: "MuseoSans 700";
-  font-size: 1.25rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
   line-height: 1.2em;
   padding: 0.5rem;
@@ -1134,9 +1158,54 @@ html {
   cursor: default;
   opacity: 0.35;
 }
+.moon-item > .moon-icon:first-child.small > .small-icon-tap-area,
+.moon-item > .moon-icon:last-child.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
 .enyo-locale-non-latin .moon-item {
   font-family: "Moonstone LG Display Bold";
   font-size: 1.25rem;
+}
+/* ItemOverlay.less */
+.moon-item .moon-item-overlay {
+  float: left;
+}
+.moon-item .moon-item-overlay.right {
+  float: right;
+}
+.moon-item .moon-item-overlay.beginning .moon-icon:first-child.small > .small-icon-tap-area,
+.moon-item .moon-item-overlay.ending .moon-icon:last-child.small > .small-icon-tap-area {
+  left: -0.5rem;
+  right: -0.5rem;
+}
+.moon-item .moon-item-overlay.beginning .moon-icon:first-child {
+  margin-left: 0;
+}
+.moon-item .moon-item-overlay.ending .moon-icon:last-child {
+  margin-right: 0;
+}
+.moon-item .moon-item-overlay .moon-icon {
+  margin-top: 0;
+  margin-bottom: 0;
+  vertical-align: top;
+}
+.moon-item:not(.spotlight) .moon-item-overlay.auto-hide {
+  display: none;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay {
+  float: right;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay.right {
+  float: left;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay.beginning .moon-icon:first-child {
+  margin-right: 0;
+  margin-left: 0.5rem;
+}
+.enyo-locale-right-to-left .moon-item .moon-item-overlay.ending .moon-icon:last-child {
+  margin-left: 0;
+  margin-right: 0.5rem;
 }
 /* SelectableItem.css */
 .moon-selectable-item.selected {
@@ -1396,9 +1465,9 @@ html {
 }
 .moon-expandable-list-item-client .moon-item {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-expandable-list-item-client .moon-item a:link {
   color: #cf0652;
@@ -1468,8 +1537,8 @@ html {
 /* Current Value */
 .moon-expandable-picker-current-value {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
-  line-height: 1.375rem;
+  font-size: 1.375rem;
+  line-height: 1.625rem;
   color: #4b4b4b;
   margin: 0rem;
 }
@@ -1646,9 +1715,9 @@ html {
 }
 .moon-gridlist-imageitem .sub-caption {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
 }
 .moon-gridlist-imageitem .sub-caption a:link {
   color: #cf0652;
@@ -1880,6 +1949,12 @@ html {
 .moon-input::selection {
   color: #ffffff;
   background-color: #cf0652;
+}
+.moon-input[type=number] {
+  -moz-appearance: textfield;
+}
+.moon-input[type=number]:hover {
+  -moz-appearance: none;
 }
 .moon-input-decorator .moon-focused .moon-input {
   cursor: text;
@@ -2405,7 +2480,7 @@ html {
   border: 0;
   cursor: pointer;
   background: transparent;
-  height: 4.125rem;
+  height: 4.875rem;
   width: 12.5rem;
   color: #4b4b4b;
   resize: none;
@@ -2523,20 +2598,25 @@ html {
   width: 100%;
   height: 100%;
   -webkit-transform: translateZ(0) translateY(100%);
+  transform: translateZ(0) translateY(100%);
 }
 .moon-list-actions-drawer-client.open {
   -webkit-transform: translateZ(0) translateY(0);
+  tranform: translateZ(0) translateY(0);
 }
 .moon-list-actions-drawer-client.animated {
   -webkit-transition: -webkit-transform 0.225s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: transform 0.225s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 .moon-medium-header .moon-list-actions-drawer-client,
 .moon-small-header .moon-list-actions-drawer-client {
   -webkit-transform: translateZ(0) translateY(-100%);
+  transform: translateZ(0) translateY(-100%);
 }
 .moon-medium-header .moon-list-actions-drawer-client.open,
 .moon-small-header .moon-list-actions-drawer-client.open {
   -webkit-transform: translateZ(0) translateY(0);
+  transform: translateZ(0) translateY(0);
 }
 .moon-list-actions.stacked .enyo-fittable-rows-layout > * {
   height: auto !important;
@@ -2572,9 +2652,9 @@ html {
 /* Text */
 .moon-labeledtextitem .text {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   text-transform: none;
   margin: 0rem;
   padding: 0rem;
@@ -2754,6 +2834,130 @@ html {
     -webkit-transform: rotateZ(600deg);
   }
 }
+@keyframes spinBall {
+  0% {
+    transform: rotateZ(13deg);
+  }
+  /* Slow down toward the top */
+  15% {
+    transform: rotateZ(160deg);
+  }
+  25% {
+    transform: rotateZ(200deg);
+  }
+  30% {
+    transform: rotateZ(225deg);
+  }
+  /* Speed back up as the ball falls */
+  /* Impact at last ball */
+  33% {
+    transform: rotateZ(321deg);
+  }
+  39%,
+  67% {
+    transform: rotateZ(347deg);
+  }
+  /* Small bounce forward */
+  72% {
+    transform: rotateZ(383deg);
+  }
+  79%,
+  100% {
+    transform: rotateZ(373deg);
+  }
+}
+@keyframes spinBall2 {
+  /* Small bounce forward */
+  0% {
+    transform: rotateZ(347deg);
+  }
+  5% {
+    transform: rotateZ(383deg);
+  }
+  12%,
+  33% {
+    transform: rotateZ(373deg);
+  }
+  33.01% {
+    transform: rotateZ(13deg);
+  }
+  /* Slow down toward the top */
+  48% {
+    transform: rotateZ(160deg);
+  }
+  58% {
+    transform: rotateZ(200deg);
+  }
+  63% {
+    transform: rotateZ(225deg);
+  }
+  /* Speed back up as the ball falls */
+  /* Impact at last ball */
+  67% {
+    transform: rotateZ(321deg);
+  }
+  72%,
+  100% {
+    transform: rotateZ(347deg);
+  }
+}
+@keyframes spinBall3 {
+  /* Impact at last ball */
+  0%,
+  100% {
+    transform: rotateZ(321deg);
+  }
+  5%,
+  33% {
+    transform: rotateZ(347deg);
+  }
+  /* Small bounce forward */
+  38% {
+    transform: rotateZ(383deg);
+  }
+  45%,
+  66% {
+    transform: rotateZ(373deg);
+  }
+  66.01% {
+    transform: rotateZ(13deg);
+  }
+  /* Slow down toward the top */
+  81% {
+    transform: rotateZ(160deg);
+  }
+  91% {
+    transform: rotateZ(200deg);
+  }
+  97% {
+    transform: rotateZ(225deg);
+  }
+  /* Speed back up as the ball falls */
+}
+@keyframes propellerBall {
+  0% {
+    transform: rotateZ(0deg);
+  }
+  100% {
+    transform: rotateZ(360deg);
+  }
+}
+@keyframes propellerBall2 {
+  0% {
+    transform: rotateZ(120deg);
+  }
+  100% {
+    transform: rotateZ(480deg);
+  }
+}
+@keyframes propellerBall3 {
+  0% {
+    transform: rotateZ(240deg);
+  }
+  100% {
+    transform: rotateZ(600deg);
+  }
+}
 .moon-spinner {
   min-height: 3rem;
   min-width: 3rem;
@@ -2791,6 +2995,7 @@ html {
 }
 .moon-spinner.running .moon-spinner-ball {
   -webkit-animation-play-state: running;
+  animation-play-state: running;
 }
 .moon-spinner .moon-spinner-ball-decorator {
   position: relative;
@@ -2804,12 +3009,15 @@ html {
   font-size: 90%;
   line-height: 0.4em;
   -webkit-animation: none 1.83s linear infinite;
+  animation: none 1.83s linear infinite;
   -webkit-animation-play-state: paused;
+  animation-play-state: paused;
   height: 15%;
   width: 15%;
   left: 42.5%;
   bottom: 15%;
   -webkit-transform-origin: center -133.33333333%;
+  transform-origin: center -133.33333333%;
 }
 .moon-spinner .moon-spinner-ball:after {
   content: "\0F0013";
@@ -2817,18 +3025,24 @@ html {
 }
 .moon-spinner .moon-spinner-ball1 {
   -webkit-animation-name: spinBall;
+  animation-name: spinBall;
   color: #69cdff;
   -webkit-transform: rotateZ(13deg);
+  transform: rotateZ(13deg);
 }
 .moon-spinner .moon-spinner-ball2 {
   -webkit-animation-name: spinBall2;
+  animation-name: spinBall2;
   color: #ff4a4a;
   -webkit-transform: rotateZ(347deg);
+  transform: rotateZ(347deg);
 }
 .moon-spinner .moon-spinner-ball3 {
   -webkit-animation-name: spinBall3;
+  animation-name: spinBall3;
   color: #ffb80d;
   -webkit-transform: rotateZ(321deg);
+  transform: rotateZ(321deg);
 }
 .moon-spinner .moon-spinner-client {
   float: left;
@@ -2995,12 +3209,48 @@ html {
     -webkit-transform: translateY(-100%);
   }
 }
+@keyframes panel-outer {
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+@keyframes panel-inner {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+@keyframes breadcrumb-outer {
+  0% {
+    transform: translateY(0%);
+  }
+  36%,
+  100% {
+    transform: translateY(100%);
+  }
+}
+@keyframes breadcrumb-inner {
+  0% {
+    transform: translateY(0%);
+  }
+  36%,
+  100% {
+    transform: translateY(-100%);
+  }
+}
 .moon-panel.moon-composite .moon-panel-viewport,
 .moon-panel.moon-composite .moon-panel-content-wrapper,
 .moon-panel.moon-composite .moon-panel-breadcrumb-viewport,
 .moon-panel.moon-composite .moon-panel-small-header-wrapper {
   -webkit-animation-fill-mode: both;
   -webkit-animation-timing-function: ease-in-out;
+  animation-fill-mode: both;
+  animation-timing-function: ease-in-out;
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   -o-transform: translateZ(0);
@@ -3017,24 +3267,29 @@ html {
 .moon-panel.growing .moon-panel-viewport,
 .moon-panel.shrinking .moon-panel-viewport {
   -webkit-animation-name: panel-outer;
+  animation-name: panel-outer;
 }
 .moon-panel.growing .moon-panel-breadcrumb-viewport,
 .moon-panel.shrinking .moon-panel-breadcrumb-viewport {
   -webkit-animation-name: breadcrumb-outer;
+  animation-name: breadcrumb-outer;
 }
 .moon-panel.growing .moon-panel-content-wrapper,
 .moon-panel.shrinking .moon-panel-content-wrapper {
   -webkit-animation-name: panel-inner;
+  animation-name: panel-inner;
 }
 .moon-panel.growing .moon-panel-small-header-wrapper,
 .moon-panel.shrinking .moon-panel-small-header-wrapper {
   -webkit-animation-name: breadcrumb-inner;
+  animation-name: breadcrumb-inner;
 }
 .moon-panel.growing .moon-panel-viewport,
 .moon-panel.growing .moon-panel-content-wrapper,
 .moon-panel.growing .moon-panel-breadcrumb-viewport,
 .moon-panel.growing .moon-panel-small-header-wrapper {
   -webkit-animation-duration: 0.4s;
+  animation-duration: 0.4s;
 }
 .moon-panel.shrinking .moon-panel-viewport,
 .moon-panel.shrinking .moon-panel-content-wrapper,
@@ -3042,18 +3297,24 @@ html {
 .moon-panel.shrinking .moon-panel-small-header-wrapper {
   -webkit-animation-duration: 0.5s;
   -webkit-animation-direction: reverse;
+  animation-duration: 0.5s;
+  animation-direction: reverse;
 }
 .moon-panel.shrunken .moon-panel-viewport {
   -webkit-transform: translateY(-101%);
+  transform: translateY(-101%);
 }
 .moon-panel.shrunken .moon-panel-content-wrapper {
   -webkit-transform: translateY(101%);
+  transform: translateY(101%);
 }
 .moon-panel:not(.shrunken) .moon-panel-breadcrumb-viewport {
   -webkit-transform: translateY(101%);
+  transform: translateY(101%);
 }
 .moon-panel:not(.shrunken) .moon-panel-small-header-wrapper {
   -webkit-transform: translateY(-101%);
+  transform: translateY(-101%);
 }
 /* Panels */
 .moon-panels.activity,
@@ -3146,7 +3407,9 @@ html {
   content: "\0F0003";
   color: #ffffff;
   -webkit-transform: translate3d(0, 0, 0);
-  transition: -webkit-transform 0.2s linear, opacity 0.2s linear;
+  transform: translate3d(0, 0, 0);
+  -webkit-transition: -webkit-transform 0.2s linear, opacity 0.2s linear;
+  transition: transform 0.2s linear, opacity 0.2s linear;
   opacity: 1;
   text-align: center;
 }
@@ -3156,6 +3419,7 @@ html {
 .moon-panels-handle.spotlight:before {
   background-color: #cf0652;
   -webkit-transform: translate3d(-5rem, 0, 0);
+  transform: translate3d(-5rem, 0, 0);
 }
 .moon-panels-handle.stashed:before {
   opacity: 0;
@@ -3300,15 +3564,18 @@ html {
 .moon-input-header .moon-input.moon-header-title {
   position: static;
 }
-.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder {
+.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder,
+.moon-input-header .moon-input.moon-header-title::-moz-placeholder {
   color: #b1b1b1;
   margin-top: 0.5rem;
   line-height: 1.25em;
 }
-.enyo-locale-non-latin .moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder {
+.enyo-locale-non-latin .moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder,
+.enyo-locale-non-latin .moon-input-header .moon-input.moon-header-title::-moz-input-placeholder {
   line-height: 1.5em;
 }
-.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder {
+.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight .moon-input::-moz-input-placeholder {
   color: #ffffff;
 }
 .moon-input-header-input-decorator.spotlight > .moon-input {
@@ -3318,7 +3585,8 @@ html {
 .moon-input-header-input-decorator.spotlight.moon-focused > .moon-input {
   background: none;
 }
-.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder {
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder,
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-moz-input-placeholder {
   color: #b1b1b1;
 }
 .moon-drawer-partial-client {
@@ -3484,9 +3752,6 @@ html {
 }
 .moon-dialog-title {
   margin-bottom: 0.5rem;
-}
-.moon-dialog-sub-title {
-  font-size: 1rem;
 }
 .moon-dialog-client-wrapper {
   min-height: 4.5rem;
@@ -3763,7 +4028,7 @@ html {
 }
 .moon-video-transport-slider-popup-label {
   font-family: "Moonstone Miso Bold";
-  font-size: 1.375rem;
+  font-size: 1.5rem;
   -webkit-font-kerning: normal;
   white-space: nowrap;
   color: #4b4b4b;
@@ -3826,6 +4091,16 @@ html {
   position: relative;
   display: inline-block;
   background-color: #000000;
+}
+.moon-video-player:after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+.moon-video-player.spinner-showing:after {
+  content: '';
 }
 .moon-video-player:not(.enyo-fullscreen) {
   margin: 0 0.5rem;
@@ -4065,23 +4340,23 @@ html {
 .moon-icon-button.moon-icon-video-more-controls-font-style {
   font-size: 4.5rem;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled) {
   background-position: 0 -3.5rem;
   border: 0rem;
   background-color: transparent;
   color: #cf0652;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active.moon-icon-video-round-controls-style {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled).moon-icon-video-round-controls-style {
   color: #ffffff;
   background-color: #cf0652;
 }
@@ -4168,9 +4443,6 @@ html {
 .enyo-locale-non-latin .moon-video-feedback-icon-right {
   margin-bottom: 0.125rem;
 }
-.enyo-locale-right-to-left .moon-video-player-feedback {
-  margin: 0 0 0 0.5rem;
-}
 .enyo-locale-right-to-left .moon-icon.moon-video-feedback-icon-left {
   margin: 0 0 0 0.5rem;
 }
@@ -4213,9 +4485,9 @@ html {
 }
 .moon-video-player-info-subsubtitle {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   font-style: italic;
   color: #ffffff;
   display: inline-block;
@@ -4247,9 +4519,9 @@ html {
 }
 .moon-video-player-info-description {
   font-family: "MuseoSans 300";
-  font-size: 1.125rem;
+  font-size: 1.375rem;
   color: #4b4b4b;
-  line-height: 1.375rem;
+  line-height: 1.625rem;
   color: #ffffff;
   white-space: normal;
   margin-bottom: 1rem;
@@ -4400,6 +4672,7 @@ html {
   line-height: normal;
   color: #ffffff;
 }
+/* TODO: Clean up / reduce this file after new scroller implementation is completely integrated. */
 .moon-scroller-client-wrapper,
 .moon-scroller-viewport {
   box-sizing: border-box;
@@ -4508,6 +4781,28 @@ html {
   right: 0rem;
   width: 2.5rem;
 }
+.moon-scroller-hthumb,
+.moon-scroller-vthumb {
+  transition: opacity 0.1s linear;
+  -moz-transition: opacity 0.1s linear;
+  -webkit-transition: opacity 0.1s linear;
+}
+.moon-scroller-hthumb {
+  bottom: 1.16667rem;
+}
+.moon-scroller-vthumb {
+  right: 1.16667rem;
+}
+.moon-scroller-hthumb.hidden,
+.moon-scroller-vthumb.hidden {
+  opacity: 0;
+}
+.moon-scroller-client-wrapper .enyo-new-thumb {
+  background: rgba(50, 50, 50, 0.8);
+}
+.moon-neutral .moon-scroller-client-wrapper .enyo-new-thumb {
+  background: #ffffff;
+}
 .moon-expandable-input .moon-input-decorator {
   width: 100%;
   box-sizing: border-box;
@@ -4611,31 +4906,38 @@ html {
 .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
   color: #ffffff;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim {
+.moon-selection-overlay-support-scrim {
+  display: none;
+}
+.selection-enabled .moon-selection-overlay-support-scrim {
   display: block;
+  z-index: 1000;
   text-align: center;
 }
-.selection-enabled .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim .moon-icon {
-  position: absolute;
+.selection-enabled .moon-selection-overlay-support-scrim .moon-icon {
+  display: block;
   width: 2.5rem;
   height: 2.5rem;
   line-height: 2.5rem;
-  font-size: 3.375rem;
+  border: 0.25rem solid #000000;
+  background-color: white;
+  color: transparent;
+  -webkit-transform: translateX(-50%) translateY(-50%);
+  transform: translateX(-50%) translateY(-50%);
+  margin: 0;
+  border-radius: 50%;
+  position: absolute;
+  opacity: 0.5;
+}
+.selection-enabled .selected .moon-selection-overlay-support-scrim .moon-icon {
   color: #cf0652;
-  margin: -1.25rem 0 0 -1.25rem;
-  background-color: #ffffff;
-  border-radius: 1.25rem;
-  background-position: center 0.25rem;
+  border-color: #cf0652;
+  opacity: 1;
 }
-.moon-selection-overlay-support-scrim {
-  display: none;
-  z-index: 1000;
-}
-.enyo-locale-right-to-left .moon-selection-overlay-support.selected .moon-selection-overlay-support-scrim .moon-icon {
-  margin: -1.25rem -1.25rem 0 0;
-}
+/* TODO: Retire this file after new scroller implementation is completely integrated. */
 .moon-thumb {
   -webkit-transform-origin: 0rem 0rem;
+  transform-origin: 0rem 0rem;
   border: none;
   background: rgba(50, 50, 50, 0.8);
   width: 0.125rem;
@@ -4644,22 +4946,6 @@ html {
 }
 .moon-neutral .moon-thumb {
   background: #ffffff;
-}
-.moon-scroller-hthumb,
-.moon-scroller-vthumb {
-  transition: opacity 0.1s linear;
-  -moz-transition: opacity 0.1s linear;
-  -webkit-transition: opacity 0.1s linear;
-}
-.moon-scroller-hthumb {
-  bottom: 1.16667rem;
-}
-.moon-scroller-vthumb {
-  right: 1.16667rem;
-}
-.moon-scroller-hthumb.hidden,
-.moon-scroller-vthumb.hidden {
-  opacity: 0;
 }
 .moon-image {
   display: inline-block;
@@ -4757,6 +5043,28 @@ html {
 .moon-icon-exitfullscreen.moon-icon-exitfullscreen-font-style {
   font-size: 4rem;
 }
+.moon-light-panel .client {
+  opacity: 0;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+}
+.moon-light-panel .client.populated {
+  opacity: 1;
+}
+.moon-light-panel:after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+.moon-light-panel.transitioning {
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+}
+.moon-light-panel.transitioning:after {
+  content: '';
+}
 /* Put this at the end because we want these to take precedence over others */
 .moon-neutral {
   background-color: #686868;
@@ -4850,265 +5158,4 @@ html {
 .moon-vspacing-l > .moon-formcheckbox-item {
   margin-top: 0.875rem;
   margin-bottom: 1.75rem;
-}
-.moon-theme-dark {
-  /* Common classes applicable to multiple controls */
-  /* Text definitions */
-  color: #a6a6a6;
-  background-color: #000000;
-  /* Icon.css */
-  /* IconButton.css */
-  /* Item.css */
-  /* Button */
-  /* Spinner.css */
-  /* Activity Panels Overrides */
-  /* AlwaysViewing Overrides */
-  /* Scrim */
-  /* Show/Hide Handle */
-  /* FormCheckbox.css */
-}
-.moon-theme-dark .moon-divider-border {
-  border-bottom-color: #a6a6a6;
-}
-.moon-theme-dark .moon-neutral-divider-border {
-  border-bottom-color: #ffffff;
-}
-.moon-theme-dark .moon-sub-header-text {
-  font-family: "MuseoSans 700";
-  font-size: 1.25rem;
-  color: #a6a6a6;
-}
-.moon-theme-dark .moon-divider-text {
-  color: #a6a6a6;
-}
-.moon-theme-dark .moon-body-text {
-  color: #a6a6a6;
-}
-.moon-theme-dark .moon-body-text a:link {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-dark .moon-body-text a:visited {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-dark .moon-body-text a:hover {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-dark .moon-body-text a:active {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-dark .moon-bold-text {
-  color: #a6a6a6;
-}
-.moon-theme-dark .moon-bold-text a:link {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-dark .moon-bold-text a:visited {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-dark .moon-bold-text a:hover {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-dark .moon-bold-text a:active {
-  color: #cf0652;
-  text-decoration: none;
-}
-.moon-theme-dark .moon-icon-text {
-  color: #ffffff;
-}
-.moon-theme-dark .moon-icon,
-.moon-theme-dark .moon-icon-toggle {
-  color: #a6a6a6;
-}
-.moon-theme-dark .spotlight .moon-icon {
-  color: #ffffff;
-}
-.moon-theme-dark .moon-icon-button {
-  color: #a6a6a6;
-  background-color: #404040;
-}
-.moon-theme-dark .moon-icon-button.hover:hover:not(.disabled),
-.moon-theme-dark .moon-icon-button.spotlight {
-  color: #ffffff;
-  background-color: #cf0652;
-}
-.moon-theme-dark .moon-icon-button.active:not(.spotlight),
-.moon-theme-dark .moon-icon-button:active,
-.moon-theme-dark .moon-icon-button.pressed,
-.moon-theme-dark .moon-icon-button.hover:hover:not(.disabled):active {
-  color: #a6a6a6;
-  background-color: #404040;
-  border-color: #cf0652;
-}
-.moon-theme-dark .moon-icon-button.active.spotlight:not(.contextual-popup-button) {
-  border-color: #ffffff;
-  background-color: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-dark .moon-icon-button.active.spotlight:not(.contextual-popup-button):active,
-.moon-theme-dark .moon-icon-button.active.spotlight:not(.contextual-popup-button).pressed {
-  border-color: #cf0652;
-}
-.moon-theme-dark .moon-item {
-  font-family: "MuseoSans 700";
-  font-size: 1.25rem;
-  color: #a6a6a6;
-}
-.moon-theme-dark .moon-item.spotlight {
-  background-color: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-dark .enyo-locale-non-latin .moon-item {
-  font-family: "Moonstone LG Display Bold";
-  font-size: 1.25rem;
-}
-.moon-theme-dark .moon-button {
-  background-color: #404040;
-  color: #a6a6a6;
-}
-.moon-theme-dark .moon-button.active,
-.moon-theme-dark .moon-button.pressed,
-.moon-theme-dark .moon-button.spotlight.pressed,
-.moon-theme-dark .moon-button.spotlight:active {
-  border-color: #cf0652;
-  background-color: #404040;
-  color: #a6a6a6;
-}
-.moon-theme-dark .moon-button.spotlight {
-  background-color: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-dark .moon-button.active.spotlight:not(.contextual-popup-button) {
-  border-color: #ffffff;
-  background-color: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-dark .moon-button.active.spotlight:not(.contextual-popup-button):active,
-.moon-theme-dark .moon-button.active.spotlight:not(.contextual-popup-button).pressed {
-  border-color: #cf0652;
-}
-.moon-theme-dark .moon-button[disabled] {
-  color: #4d4d4d;
-  background-color: #262626;
-}
-.moon-theme-dark .moon-neutral .moon-button {
-  color: #4b4b4b;
-  background-color: #ffffff;
-}
-.moon-theme-dark .moon-neutral .moon-button.spotlight {
-  background-color: #cf0652;
-}
-.moon-theme-dark .moon-neutral .moon-button.spotlight * {
-  color: #ffffff;
-}
-.moon-theme-dark .moon-neutral .moon-button.active,
-.moon-theme-dark .moon-neutral .moon-button.pressed,
-.moon-theme-dark .moon-neutral .moon-button.spotlight.pressed,
-.moon-theme-dark .moon-neutral .moon-button.spotlight:active {
-  border-color: #cf0652;
-  background-color: #ffffff;
-}
-.moon-theme-dark .moon-neutral .moon-button.active *,
-.moon-theme-dark .moon-neutral .moon-button.pressed *,
-.moon-theme-dark .moon-neutral .moon-button.spotlight.pressed *,
-.moon-theme-dark .moon-neutral .moon-button.spotlight:active * {
-  color: #4b4b4b;
-}
-.moon-theme-dark .moon-neutral .moon-button[disabled] {
-  color: #b3b3b3;
-  background-color: #ffffff;
-}
-.moon-theme-dark .moon-header {
-  color: #a6a6a6;
-  border-top-color: #505050;
-  border-bottom-color: #404040;
-}
-.moon-theme-dark .moon-neutral .moon-header {
-  border-top-color: #ffffff;
-  border-bottom-color: #ffffff;
-}
-.moon-theme-dark .moon-spinner {
-  color: #ffffff;
-  background-color: #4d4d4d;
-}
-.moon-theme-dark .moon-spinner .moon-spinner-ball1 {
-  color: #69cdff;
-}
-.moon-theme-dark .moon-spinner .moon-spinner-ball2 {
-  color: #ff4a4a;
-}
-.moon-theme-dark .moon-spinner .moon-spinner-ball3 {
-  color: #ffb80d;
-}
-.moon-theme-dark .moon-panel-small-header {
-  color: #a6a6a6;
-}
-.moon-theme-dark .spotlight .moon-panel-small-header {
-  color: #ffffff;
-}
-.moon-theme-dark .moon-panel-small-header-title-above {
-  color: #a6a6a6;
-  border-top-color: #ffffff;
-}
-.moon-theme-dark .spotlight .moon-panel-small-header-title-above {
-  color: #ffffff;
-}
-.moon-theme-dark .moon-panel .moon-panel-small-header-wrapper.spotlight {
-  background: #cf0652;
-  color: #ffffff;
-}
-.moon-theme-dark .moon-panels.activity .moon-panel-small-header-title-above {
-  border-top-color: #505050;
-}
-.moon-theme-dark .moon-panels.activity .moon-panel-small-header,
-.moon-theme-dark .moon-panels.activity .moon-panel-small-header-title-above {
-  color: #a6a6a6;
-}
-.moon-theme-dark .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header,
-.moon-theme-dark .moon-panels.activity .moon-panel-small-header-wrapper.spotlight .moon-panel-small-header-title-above {
-  color: #ffffff;
-}
-.moon-theme-dark .moon-panels.always-viewing .moon-panel-small-header,
-.moon-theme-dark .moon-panels.always-viewing .moon-panel-small-header-title-above {
-  color: #ffffff;
-}
-.moon-theme-dark .moon-panels.activity .moon-panels-panel-scrim {
-  background-color: #000000;
-}
-.moon-theme-dark .moon-panels.always-viewing .moon-panels-panel-scrim {
-  background-color: rgba(0, 0, 0, 0.75);
-}
-.moon-theme-dark .moon-panels-handle:before {
-  background-color: #4b4b4b;
-  color: #ffffff;
-}
-.moon-theme-dark .moon-panels-handle.spotlight:before {
-  background-color: #cf0652;
-}
-.moon-theme-dark .moon-item.moon-formcheckbox-item {
-  background: none;
-}
-.moon-theme-dark .moon-item.moon-formcheckbox-item .moon-checkbox {
-  background-color: #404040;
-}
-.moon-theme-dark .moon-formcheckbox-item.spotlight .moon-checkbox {
-  background-color: #cf0652;
-}
-.moon-theme-dark .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
-  color: #a6a6a6;
-}
-.moon-theme-dark .moon-neutral .moon-formcheckbox-item.spotlight .moon-checkbox-item-label-wrapper {
-  color: #ffffff;
-}
-.moon-theme-dark .moon-thumb {
-  background: #a6a6a6;
-}
-.moon-theme-dark .moon-neutral .moon-thumb {
-  background: #ffffff;
 }


### PR DESCRIPTION
##Issue

There was a Q issue about disabled imageIcon like rewind or fastFoward in videoPlayer.
If disabled rewind or fastFoward image Icon in videoPlayer is clicked, then it is affected by css and changes its color to red.

##FIx

It is needed to make css effective only when icon is not disabled.
To do this, I added ":not(.disabled)" in VideoControlFullscreen.less.
So, when an icon is disabled, the css does not affect disabled icon.

This is copy of #2069 for 2.5-upkeep

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung2.lee@lge.com