### PR TITLE
ENYO-1438: make css of videoPlayer's iconButton like REW/FF be effective only when icon is enabled.

### DIFF
--- a/css/VideoControlFullscreen.less
+++ b/css/VideoControlFullscreen.less
@@ -111,16 +111,17 @@
 }
 .moon-video-fullscreen-control {
 	.moon-icon.moon-icon-button {
+		&.disabled {
+			pointer-events: none;
+		}
 		&.active, &:active, &.pressed, &.spotlight, &.spotlight.pressed, &.spotlight:active {
-			&:not(.disabled) {
-				background-position: 0 -(@moon-icon-button-size);
-				border: 0px;
-				background-color: transparent;
-				color: @moon-accent;
-				&.moon-icon-video-round-controls-style {
-				  color: @moon-icon-video-round-controls-font-spotlight-color;
-				  background-color: @moon-accent;
-				}
+			background-position: 0 -(@moon-icon-button-size);
+			border: 0px;
+			background-color: transparent;
+			color: @moon-accent;
+			&.moon-icon-video-round-controls-style {
+				color: @moon-icon-video-round-controls-font-spotlight-color;
+				background-color: @moon-accent;
 			}
 		}
 	}

--- a/css/VideoControlFullscreen.less
+++ b/css/VideoControlFullscreen.less
@@ -109,19 +109,20 @@
 .moon-icon-button.moon-icon-video-more-controls-font-style {
   font-size: @moon-icon-arrowextendshrink-font-size;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled) {
-	background-position: 0 -(@moon-icon-button-size);
-	border: 0px;
-	background-color: transparent;
-	color: @moon-accent;
-	&.moon-icon-video-round-controls-style {
-	  color: @moon-icon-video-round-controls-font-spotlight-color;
-	  background-color: @moon-accent;
+.moon-video-fullscreen-control {
+	.moon-icon.moon-icon-button {
+		&.active, &:active, &.pressed, &.spotlight, &.spotlight.pressed, &.spotlight:active {
+			&:not(.disabled) {
+				background-position: 0 -(@moon-icon-button-size);
+				border: 0px;
+				background-color: transparent;
+				color: @moon-accent;
+				&.moon-icon-video-round-controls-style {
+				  color: @moon-icon-video-round-controls-font-spotlight-color;
+				  background-color: @moon-accent;
+				}
+			}
+		}
 	}
 }
 

--- a/css/VideoControlFullscreen.less
+++ b/css/VideoControlFullscreen.less
@@ -109,12 +109,12 @@
 .moon-icon-button.moon-icon-video-more-controls-font-style {
   font-size: @moon-icon-arrowextendshrink-font-size;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled) {
 	background-position: 0 -(@moon-icon-button-size);
 	border: 0px;
 	background-color: transparent;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4065,23 +4065,26 @@ html {
 .moon-icon-button.moon-icon-video-more-controls-font-style {
   font-size: 4.5rem;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled) {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.disabled {
+  pointer-events: none;
+}
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
   background-position: 0 -3.5rem;
   border: 0rem;
   background-color: transparent;
   color: #cf0652;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled).moon-icon-video-round-controls-style {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active.moon-icon-video-round-controls-style {
   color: #ffffff;
   background-color: #cf0652;
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4065,23 +4065,23 @@ html {
 .moon-icon-button.moon-icon-video-more-controls-font-style {
   font-size: 4.5rem;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled) {
   background-position: 0 -3.5rem;
   border: 0rem;
   background-color: transparent;
   color: #cf0652;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active.moon-icon-video-round-controls-style {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled).moon-icon-video-round-controls-style {
   color: #ffffff;
   background-color: #cf0652;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4065,23 +4065,26 @@ html {
 .moon-icon-button.moon-icon-video-more-controls-font-style {
   font-size: 4.5rem;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled),
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled) {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.disabled {
+  pointer-events: none;
+}
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
   background-position: 0 -3.5rem;
   border: 0rem;
   background-color: transparent;
   color: #cf0652;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled).moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled).moon-icon-video-round-controls-style {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed.moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active.moon-icon-video-round-controls-style {
   color: #ffffff;
   background-color: #cf0652;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4065,23 +4065,23 @@ html {
 .moon-icon-button.moon-icon-video-more-controls-font-style {
   font-size: 4.5rem;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled),
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled) {
   background-position: 0 -3.5rem;
   border: 0rem;
   background-color: transparent;
   color: #cf0652;
 }
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.active.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button:active.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed.moon-icon-video-round-controls-style,
-.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active.moon-icon-video-round-controls-style {
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.active:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button:active:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.pressed:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight.pressed:not(.disabled).moon-icon-video-round-controls-style,
+.moon-video-fullscreen-control .moon-icon.moon-icon-button.spotlight:active:not(.disabled).moon-icon-video-round-controls-style {
   color: #ffffff;
   background-color: #cf0652;
 }


### PR DESCRIPTION
##Issue

There was a Q issue about disabled imageIcon like rewind or fastFoward in videoPlayer.
If disabled rewind or fastFoward image Icon in videoPlayer is clicked, then it is affected by css and changes its color to red.

##FIx

It is needed to make css effective only when icon is not disabled.
To do this, I added ":not(.disabled)" in VideoControlFullscreen.less.
So, when an icon is disabled, the css does not affect disabled icon.

This is copy of #2069 for 2.5-upkeep

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung2.lee@lge.com