### PR TITLE
ENYO-1441 : modify resolution update routine for removing old resolution classes

### DIFF
--- a/source/moon-resolution.js
+++ b/source/moon-resolution.js
@@ -6,8 +6,11 @@
 		screenTypeObject,
 		oldScreenType;
 
-	var getScreenTypeObject = function (type) {
+	var getScreenTypeObject = function (type, ignoreCache) {
 		type = type || screenType;
+		if (type == screenType && !ignoreCache && screenTypeObject) {
+			return screenTypeObject;
+		}
 		var types = scope.moon.ri.screenTypes;
 		return types.filter(function (elem) {
 			return (type == elem.name);
@@ -195,7 +198,7 @@
 		init: function () {
 			oldScreenType = screenType;
 			screenType = this.getScreenType();
-			screenTypeObject = getScreenTypeObject();
+			screenTypeObject = getScreenTypeObject(screenType, true);
 			this.updateScreenTypeOnBody();
 			enyo.dom.unitToPixelFactors.rem = scope.moon.getUnitToPixelFactors();
 			riRatio = this.getRiRatio();

--- a/source/moon-resolution.js
+++ b/source/moon-resolution.js
@@ -6,7 +6,7 @@
 		screenTypeObject,
 		oldScreenType;
 
-	var getScreenTypeObject = function (type, ignoreCache) {
+	var getScreenTypeObject = function (type) {
 		type = type || screenType;
 		if (screenTypeObject && screenTypeObject.name == type) {
 			return screenTypeObject;

--- a/source/moon-resolution.js
+++ b/source/moon-resolution.js
@@ -8,7 +8,7 @@
 
 	var getScreenTypeObject = function (type, ignoreCache) {
 		type = type || screenType;
-		if (type == screenType && !ignoreCache && screenTypeObject) {
+		if (screenTypeObject && screenTypeObject.name == type) {
 			return screenTypeObject;
 		}
 		var types = scope.moon.ri.screenTypes;
@@ -198,7 +198,7 @@
 		init: function () {
 			oldScreenType = screenType;
 			screenType = this.getScreenType();
-			screenTypeObject = getScreenTypeObject(screenType, true);
+			screenTypeObject = getScreenTypeObject();
 			this.updateScreenTypeOnBody();
 			enyo.dom.unitToPixelFactors.rem = scope.moon.getUnitToPixelFactors();
 			riRatio = this.getRiRatio();

--- a/source/moon-resolution.js
+++ b/source/moon-resolution.js
@@ -3,13 +3,11 @@
 	var baseScreenType = 'fhd',
 		riRatio,
 		screenType,
-		screenTypeObject;
+		screenTypeObject,
+		oldScreenType;
 
 	var getScreenTypeObject = function (type) {
 		type = type || screenType;
-		if (type == screenType && screenTypeObject) {
-			return screenTypeObject;
-		}
 		var types = scope.moon.ri.screenTypes;
 		return types.filter(function (elem) {
 			return (type == elem.name);
@@ -69,6 +67,14 @@
 
 		updateScreenTypeOnBody: function (type) {
 			type = type || screenType;
+			if (oldScreenType) {
+				enyo.dom.removeClass(document.body, 'moon-res-' + oldScreenType.toLowerCase());
+				enyo.dom.removeClass(document.body, 'enyo-res-' + oldScreenType.toLowerCase());
+				var oldScrObj = getScreenTypeObject(oldScreenType);
+				if (oldScrObj.aspectRatioName) {
+					enyo.dom.removeClass(document.body, 'enyo-aspect-ratio-' + oldScrObj.aspectRatioName.toLowerCase());
+				}
+			}
 			if (type) {
 				enyo.dom.addBodyClass('moon-res-' + type.toLowerCase());
 				enyo.dom.addBodyClass('enyo-res-' + type.toLowerCase());
@@ -187,6 +193,7 @@
 		},
 
 		init: function () {
+			oldScreenType = screenType;
 			screenType = this.getScreenType();
 			screenTypeObject = getScreenTypeObject();
 			this.updateScreenTypeOnBody();


### PR DESCRIPTION
## issue
moon.ri.init() function needs a line for removing ScreenTypeOnBody
moon.ri.getScreenTypeObject always return old screenTypeObject if there is no parameter

## fix
added oldScreenType variable for for checking and removing old resolution classes.
and removed caching routine in getScreenTypeObject function.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com