### PR TITLE
ENYO-1368: Enlarge scroll thumb minimum height from 20 to 40 (2.5-upkeep)

### DIFF
--- a/source/Thumb.js
+++ b/source/Thumb.js
@@ -46,7 +46,7 @@
 		/**
 		* @private
 		*/
-		minSize: 20,
+		minSize: 40,
 
 		/**
 		* @private


### PR DESCRIPTION
Cherry-picking the changes from https://github.com/enyojs/moonstone/pull/2067 into `2.5-upkeep`, creating a PR for tracking purposes.