### PR TITLE
ENYO-1292: ExpandableListItem: Lack of Padding displays in RTL

### DIFF
--- a/css/ExpandableListItem.less
+++ b/css/ExpandableListItem.less
@@ -27,6 +27,9 @@
 .moon-expandable-list-item-client.indented {
 	padding-left: @moon-item-indent + @moon-spotlight-outset;
 }
+.enyo-locale-right-to-left .moon-expandable-list-item-header {
+	padding-right: @moon-spotlight-outset !important;
+}
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
 	padding-left: 0;
 	padding-right: @moon-item-indent + @moon-spotlight-outset;

--- a/css/ExpandableListItem.less
+++ b/css/ExpandableListItem.less
@@ -27,8 +27,8 @@
 .moon-expandable-list-item-client.indented {
 	padding-left: @moon-item-indent + @moon-spotlight-outset;
 }
-.enyo-locale-right-to-left .moon-expandable-list-item-header {
-	padding-right: @moon-spotlight-outset !important;
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-item-header {
+	padding-right: @moon-spotlight-outset;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
 	padding-left: 0;

--- a/css/ExpandableListItem.less
+++ b/css/ExpandableListItem.less
@@ -27,7 +27,7 @@
 .moon-expandable-list-item-client.indented {
 	padding-left: @moon-item-indent + @moon-spotlight-outset;
 }
-.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-item-header {
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
 	padding-right: @moon-spotlight-outset;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {

--- a/css/ExpandableListItem.less
+++ b/css/ExpandableListItem.less
@@ -31,7 +31,7 @@
 	}
 }
 .enyo-locale-right-to-left {
-	.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
+	.moon-expandable-list-item-header.moon-expandable-list-header {
 		padding-right: @moon-spotlight-outset;
 	}
 	.moon-expandable-list-item-client.indented {

--- a/css/ExpandableListItem.less
+++ b/css/ExpandableListItem.less
@@ -1,16 +1,17 @@
 /* ExpandableListItem Header*/
 .moon-expandable-list-item-header {
-  margin-bottom: 0px;
-  box-sizing: border-box;
-  max-width: 100%;
-}
-.moon-expandable-list-header.moon-expandable-picker-header:after {
-  top: @moon-spotlight-outset + 3;
+	margin-bottom: 0px;
+	box-sizing: border-box;
+	max-width: 100%;
+
+	&.moon-expandable-list-header:after {
+		top: @moon-spotlight-outset + 3;
+	}
 }
 
 /* Client Items */
 .moon-expandable-list-item.open .moon-expandable-list-item-client {
-  margin-bottom: 12px;
+	margin-bottom: 12px;
 }
 .moon-expandable-list-item-client .moon-item {
 	.moon-body-text;
@@ -18,19 +19,23 @@
 .enyo-locale-non-latin .moon-expandable-list-item-client .moon-item {
 	.enyo-locale-non-latin .moon-body-text;
 }
-.moon-expandable-list-item-client .moon-item.spotlight {
-	color: @moon-white;
+.moon-expandable-list-item-client {
+	.moon-item.spotlight {
+		color: @moon-white;
+	}
+	.moon-item:last-child {
+		margin-bottom: 0px;
+	}
+	&.indented {
+		padding-left: @moon-item-indent + @moon-spotlight-outset;
+	}
 }
-.moon-expandable-list-item-client .moon-item:last-child {
-	margin-bottom: 0px;
-}
-.moon-expandable-list-item-client.indented {
-	padding-left: @moon-item-indent + @moon-spotlight-outset;
-}
-.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
-	padding-right: @moon-spotlight-outset;
-}
-.enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
-	padding-left: 0;
-	padding-right: @moon-item-indent + @moon-spotlight-outset;
+.enyo-locale-right-to-left {
+	.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
+		padding-right: @moon-spotlight-outset;
+	}
+	.moon-expandable-list-item-client.indented {
+		padding-left: 0;
+		padding-right: @moon-item-indent + @moon-spotlight-outset;
+	}
 }

--- a/css/ExpandablePicker.less
+++ b/css/ExpandablePicker.less
@@ -21,7 +21,7 @@
 
 .enyo-locale-right-to-left .moon-expandable-picker-header {
 	padding-left: @moon-spotlight-outset + 30px;
-	padding-right: 0;
+	padding-right: @moon-spotlight-outset;
 
 	&:after{
 		left: @moon-spotlight-outset + 1px;

--- a/css/ExpandablePicker.less
+++ b/css/ExpandablePicker.less
@@ -21,7 +21,7 @@
 
 .enyo-locale-right-to-left .moon-expandable-picker-header {
 	padding-left: @moon-spotlight-outset + 30px;
-	padding-right: @moon-spotlight-outset;
+	padding-right: 0;
 
 	&:after{
 		left: @moon-spotlight-outset + 1px;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1499,7 +1499,7 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
-.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-item-header {
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
   padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1499,7 +1499,7 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
-.enyo-locale-right-to-left .enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
   padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1456,7 +1456,7 @@ html {
   box-sizing: border-box;
   max-width: 100%;
 }
-.moon-expandable-list-header.moon-expandable-picker-header:after {
+.moon-expandable-list-item-header.moon-expandable-list-header:after {
   top: 0.625rem;
 }
 /* Client Items */
@@ -1499,7 +1499,7 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
-.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
+.enyo-locale-right-to-left .enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
   padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1524,7 +1524,7 @@ html {
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header {
   padding-left: 1.75rem;
-  padding-right: 0;
+  padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header:after {
   left: 0.54167rem;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1499,8 +1499,8 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
-.enyo-locale-right-to-left .moon-expandable-list-item-header {
-  padding-right: 0.5rem !important;
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-item-header {
+  padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
   padding-left: 0;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1499,6 +1499,9 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
+.enyo-locale-right-to-left .moon-expandable-list-item-header {
+  padding-right: 0.5rem !important;
+}
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
   padding-left: 0;
   padding-right: 2rem;
@@ -1524,7 +1527,7 @@ html {
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header {
   padding-left: 1.75rem;
-  padding-right: 0.5rem;
+  padding-right: 0;
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header:after {
   left: 0.54167rem;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1499,7 +1499,7 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
-.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-item-header {
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
   padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1499,7 +1499,7 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
-.enyo-locale-right-to-left .enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
   padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1456,7 +1456,7 @@ html {
   box-sizing: border-box;
   max-width: 100%;
 }
-.moon-expandable-list-header.moon-expandable-picker-header:after {
+.moon-expandable-list-item-header.moon-expandable-list-header:after {
   top: 0.625rem;
 }
 /* Client Items */
@@ -1499,7 +1499,7 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
-.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
+.enyo-locale-right-to-left .enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
   padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1524,7 +1524,7 @@ html {
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header {
   padding-left: 1.75rem;
-  padding-right: 0;
+  padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header:after {
   left: 0.54167rem;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1499,8 +1499,8 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
-.enyo-locale-right-to-left .moon-expandable-list-item-header {
-  padding-right: 0.5rem !important;
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-item-header {
+  padding-right: 0.5rem;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
   padding-left: 0;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -1499,6 +1499,9 @@ html {
 .moon-expandable-list-item-client.indented {
   padding-left: 2rem;
 }
+.enyo-locale-right-to-left .moon-expandable-list-item-header {
+  padding-right: 0.5rem !important;
+}
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
   padding-left: 0;
   padding-right: 2rem;
@@ -1524,7 +1527,7 @@ html {
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header {
   padding-left: 1.75rem;
-  padding-right: 0.5rem;
+  padding-right: 0;
 }
 .enyo-locale-right-to-left .moon-expandable-picker-header:after {
   left: 0.54167rem;

--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -190,7 +190,7 @@
 		components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 			// widths (webkit bug)
-			{name: 'headerContainer', classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+			{name: 'headerContainer', kind: 'moon.Item', classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 				{name: 'header', kind: 'moon.MarqueeText'}
 			]},
 			{name: 'drawer', kind: 'moon.ExpandableListDrawer', resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [


### PR DESCRIPTION
### Issue:
Lack of padding displays to the right edge of the expandable list item header when in RTL mode

### Fix:
The right padding for expandable picker header was changed from 0px to @moon-spotlight-outset 

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com