### PR TITLE
ENYO-1311 : Time picker: make it optional to display bottom text (rank: 19)

### DIFF
--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -369,7 +369,7 @@
 			* @default true
 			* @public
 			*/
-			bottomTextEnable: true
+			showBottomText: true
 		},
 
 		/**
@@ -464,7 +464,7 @@
 						this
 					);
 
-					if(this.bottomTextEnable){
+					if(this.showBottomText){
 						this.$.hourWrapper.createComponent({name: 'hourLabel', content: this.hourText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
 					}
 					break;
@@ -477,7 +477,7 @@
 						this
 					);
 
-					if(this.bottomTextEnable){
+					if(this.showBottomText){
 						this.$.minuteWrapper.createComponent({name: 'minuteLabel', content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
 					}
 					break;
@@ -489,8 +489,8 @@
 							]}
 						);
 
-						if(this.bottomTextEnable){
-						this.$.meridiemWrapper.createComponent({name: 'meridiemLabel', content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'});
+						if(this.showBottomText){
+						this.$.meridiemWrapper.createComponent({name: 'meridiemLabel', content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
 						}
 					}
 					break;
@@ -675,6 +675,25 @@
 		*/
 		meridiemTextChanged: function (inOldvalue, inNewValue) {
 			this.$.meridiemLabel.setContent(inNewValue);
+		},
+
+		/**
+		* @private
+		*/
+		showBottomTextChanged: function (inOldvalue, inNewValue) {
+			if(inOldvalue===true && inNewValue===false){
+				this.$.hourLabel.destroy();
+				this.$.minuteLabel.destroy();
+				this.$.meridiemLabel.destroy();
+			}
+			else if(inOldvalue===false && inNewValue===true){
+				this.$.hourWrapper.createComponent({name: 'hourLabel', content: this.hourText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+				this.$.minuteWrapper.createComponent({name: 'minuteLabel', content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+				this.$.meridiemWrapper.createComponent({name: 'meridiemLabel', content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'});
+				this.$.hourWrapper.render();
+				this.$.minuteWrapper.render();
+				this.$.meridiemWrapper.render();
+			}
 		}
 	});
 

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -360,7 +360,16 @@
 			* @default false
 			* @public
 			*/
-			hoursZeroPadded: false
+			hoursZeroPadded: false,
+			
+			/**
+			* When `true`, bottom text will be displayed
+			*
+			* @type {Boolean}
+			* @default true
+			* @public
+			*/
+			bottomTextEnable: true
 		},
 
 		/**
@@ -449,31 +458,40 @@
 				case 'k':
 					this.wrapComponent(
 						{name: 'timeWrapper', classes: 'moon-time-picker-wrap'},
-						{classes: 'moon-date-picker-wrap', components:[
-							{kind: 'moon.HourPicker', name:'hour', formatter: this.hourFormatter || this, value: valueHours, onChange: 'hourPickerChanged'},
-							{name: 'hourLabel', content: this.hourText, classes: 'moon-date-picker-label moon-divider-text'}
+						{name: 'hourWrapper', classes: 'moon-date-picker-wrap', components:[
+							{kind: 'moon.HourPicker', name:'hour', formatter: this.hourFormatter || this, value: valueHours, onChange: 'hourPickerChanged'}						
 						]},
 						this
 					);
+
+					if(this.bottomTextEnable){
+						this.$.hourWrapper.createComponent({name: 'hourLabel', content: this.hourText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+					}
 					break;
 				case 'm':
 					this.wrapComponent(
 						{name: 'timeWrapper', classes: 'moon-time-picker-wrap'},
-						{classes: 'moon-date-picker-wrap', components:[
-							{kind: 'moon.MinutePicker', name:'minute', formatter: this.minuteFormatter || this, value: valueMinutes, onChange: 'minutePickerChanged'},
-							{name: 'minuteLabel', content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}
+						{name: 'minuteWrapper', classes: 'moon-date-picker-wrap', components:[
+							{kind: 'moon.MinutePicker', name:'minute', formatter: this.minuteFormatter || this, value: valueMinutes, onChange: 'minutePickerChanged'}
 						]},
 						this
 					);
+
+					if(this.bottomTextEnable){
+						this.$.minuteWrapper.createComponent({name: 'minuteLabel', content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+					}
 					break;
 				case 'a':
 					if (this.meridiemEnable === true) {
 						this.createComponent(
-							{classes: 'moon-date-picker-wrap', components:[
-								{kind:'moon.MeridiemPicker', name:'meridiem', classes:'moon-date-picker-field', value: valueHours > 12 ? 1 : 0, meridiems: this.meridiems || ['am','pm'], onChange: 'meridiemPickerChanged'},
-								{name: 'meridiemLabel', content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'}
+							{name: 'meridiemWrapper', classes: 'moon-date-picker-wrap', components:[
+								{kind:'moon.MeridiemPicker', name:'meridiem', classes:'moon-date-picker-field', value: valueHours > 12 ? 1 : 0, meridiems: this.meridiems || ['am','pm'], onChange: 'meridiemPickerChanged'}
 							]}
 						);
+
+						if(this.bottomTextEnable){
+						this.$.meridiemWrapper.createComponent({name: 'meridiemLabel', content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'});
+						}
 					}
 					break;
 				default:


### PR DESCRIPTION
## Issue

There is a requirement to make bottom text of Time Picker be displayed optionally in Dreadlocks.

## Solution

For the requirement, I added published property "bottomTextEnable" whose default value is true.
Also, I made changes in setupPickers func.
 - "current" : creates both picker and bottomText -> "modified" : creates picker first and then only when bottomTextEnable is true, creates bottomText.

DCO-1.1-Signed-Off-By: Suhyung Lee suhyung2.lee@lge.com