### PR TITLE
ENYO-1172 :  Display text with a scrim over images in an image grid (new rank: 2)

### DIFF
--- a/css/TextOverlaySupport.less
+++ b/css/TextOverlaySupport.less
@@ -35,6 +35,19 @@
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
   overflow: hidden;
+  word-wrap: break-word;
+}
+
+.moon-text-overlay-upperText-length1 {
+  -webkit-line-clamp: 1;
+}
+
+.moon-text-overlay-upperText-length2 {
+  -webkit-line-clamp: 2;
+}
+
+.moon-text-overlay-upperText-length3 {
+  -webkit-line-clamp: 3;
 }
 
 .moon-text-overlay-bottomText {

--- a/css/TextOverlaySupport.less
+++ b/css/TextOverlaySupport.less
@@ -1,0 +1,49 @@
+.moon-text-overlay-support .moon-text-overlay-support-scrim{
+  visibility: hidden;
+}
+
+.moon-text-overlay-support.spotlight .moon-text-overlay-support-scrim{
+  visibility: visible;
+}
+
+.moon-text-overlay-support-scrim {
+  background: @moon-text-overlay-support-scrim-background-color;
+}
+
+.moon-text-overlay-support-scrim-center {
+  margin: auto;
+  width: 100%;
+  display: table;
+  table-layout: fixed;
+}
+
+.moon-text-overlay-support-scrim-center > * {
+  position: relative;
+  display: block; 
+  text-align: center;
+  width: @moon-text-overlay-support-text-width;
+  padding-left: @moon-text-overlay-support-text-padding-leftRight;
+  padding-right: @moon-text-overlay-support-text-padding-leftRight;
+  font-family: @moon-upperTextOverlay-font-family;
+  font-size: @moon-text-overlay-support-upperText-font-size;
+  line-height: @moon-text-overlay-support-upperText-line-height;
+
+}
+
+.moon-text-overlay-upperText {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.moon-text-overlay-bottomText {
+  font-family: @moon-bottomTextOverlay-font-family;
+  font-size: @moon-text-overlay-support-bottomText-font-size;
+  line-height: @moon-text-overlay-support-bottomText-line-height;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  color: @moon-text-overlay-support-bottomText-color;
+  margin-top: @moon-text-overlay-support-bottomText-margin-top;
+}

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -5065,6 +5065,48 @@ html {
 .moon-light-panel.transitioning:after {
   content: '';
 }
+.moon-text-overlay-support .moon-text-overlay-support-scrim {
+  visibility: hidden;
+}
+.moon-text-overlay-support.spotlight .moon-text-overlay-support-scrim {
+  visibility: visible;
+}
+.moon-text-overlay-support-scrim {
+  background: rgba(0, 0, 0, 0.5);
+}
+.moon-text-overlay-support-scrim-center {
+  margin: auto;
+  width: 100%;
+  display: table;
+  table-layout: fixed;
+}
+.moon-text-overlay-support-scrim-center > * {
+  position: relative;
+  display: block;
+  text-align: center;
+  width: 72%;
+  padding-left: 14%;
+  padding-right: 14%;
+  font-family: "MuseoSans 500";
+  font-size: 1rem;
+  line-height: 1.125rem;
+}
+.moon-text-overlay-upperText {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.moon-text-overlay-bottomText {
+  font-family: "Moonstone Miso Bold";
+  font-size: 2rem;
+  line-height: 2rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.3);
+  margin-top: 1px;
+}
 /* Put this at the end because we want these to take precedence over others */
 .moon-neutral {
   background-color: #686868;

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -5096,6 +5096,16 @@ html {
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
   overflow: hidden;
+  word-wrap: break-word;
+}
+.moon-text-overlay-upperText-length1 {
+  -webkit-line-clamp: 1;
+}
+.moon-text-overlay-upperText-length2 {
+  -webkit-line-clamp: 2;
+}
+.moon-text-overlay-upperText-length3 {
+  -webkit-line-clamp: 3;
 }
 .moon-text-overlay-bottomText {
   font-family: "Moonstone Miso Bold";

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -5065,6 +5065,48 @@ html {
 .moon-light-panel.transitioning:after {
   content: '';
 }
+.moon-text-overlay-support .moon-text-overlay-support-scrim {
+  visibility: hidden;
+}
+.moon-text-overlay-support.spotlight .moon-text-overlay-support-scrim {
+  visibility: visible;
+}
+.moon-text-overlay-support-scrim {
+  background: rgba(0, 0, 0, 0.5);
+}
+.moon-text-overlay-support-scrim-center {
+  margin: auto;
+  width: 100%;
+  display: table;
+  table-layout: fixed;
+}
+.moon-text-overlay-support-scrim-center > * {
+  position: relative;
+  display: block;
+  text-align: center;
+  width: 72%;
+  padding-left: 14%;
+  padding-right: 14%;
+  font-family: "MuseoSans 500";
+  font-size: 1rem;
+  line-height: 1.125rem;
+}
+.moon-text-overlay-upperText {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.moon-text-overlay-bottomText {
+  font-family: "Moonstone Miso Bold";
+  font-size: 2rem;
+  line-height: 2rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.3);
+  margin-top: 1px;
+}
 /* Put this at the end because we want these to take precedence over others */
 .moon-neutral {
   background-color: #686868;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -5096,6 +5096,16 @@ html {
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
   overflow: hidden;
+  word-wrap: break-word;
+}
+.moon-text-overlay-upperText-length1 {
+  -webkit-line-clamp: 1;
+}
+.moon-text-overlay-upperText-length2 {
+  -webkit-line-clamp: 2;
+}
+.moon-text-overlay-upperText-length3 {
+  -webkit-line-clamp: 3;
 }
 .moon-text-overlay-bottomText {
   font-family: "Moonstone Miso Bold";

--- a/css/moonstone-rules.less
+++ b/css/moonstone-rules.less
@@ -147,6 +147,7 @@ html {
 @import "BodyText.less";
 @import "VideoFullScreenToggleButton.less";
 @import "LightPanel.less";
+@import "TextOverlaySupport.less";
 
 /* Put this at the end because we want these to take precedence over others */
 .moon-neutral {

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -150,6 +150,9 @@
 
 @accordion-sub-menu-line-height: 1.7em;
 
+@moon-upperTextOverlay-font-family: "MuseoSans 500";
+@moon-bottomTextOverlay-font-family: "Moonstone Miso Bold";
+
 // Drawer
 // ---------------------------------------
 @moon-drawers-activator-bar-height: 24px;
@@ -364,3 +367,17 @@
 // ----------------------------------------
 @moon-progress-button-bar-border-radius: @moon-button-border-radius;
 @moon-progress-button-border-width: @moon-button-border-width;
+
+// TextOverLay Support
+// ----------------------------------------
+@moon-text-overlay-support-scrim-background-color: rgba(0, 0, 0, 0.5);
+@moon-text-overlay-support-text-width: 72%;
+@moon-text-overlay-support-text-padding-leftRight: 14%;
+@moon-text-overlay-support-upperText-font-size: 24px;
+@moon-text-overlay-support-upperText-line-height: 27px;
+@moon-text-overlay-support-upperText-color: rgba(255, 255, 255, 0.7);
+@moon-text-overlay-support-upperText-margin-bottom: 2px;
+@moon-text-overlay-support-bottomText-font-size: 48px;
+@moon-text-overlay-support-bottomText-line-height: 48px;
+@moon-text-overlay-support-bottomText-color: rgba(255, 255, 255, 0.3);
+@moon-text-overlay-support-bottomText-margin-top: 1px;

--- a/samples/DataGridListSampleWithTextOverLay.html
+++ b/samples/DataGridListSampleWithTextOverLay.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+	<title>DataGridList Sample</title>
+	<!-- -->
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+	<!-- Less.js (uncomment for client-side rendering of less stylesheets; leave commented to use only CSS)
+	<script src="../../../enyo/tools/minifier/node_modules/less/dist/less-1.7.0.min.js"></script>
+	<script src="../../../enyo/tools/minifier/node_modules/less-plugin-resolution-independence/lib/resolution-independence.js"></script>
+		<script>
+			;(function(){
+				var less = window.less || {};
+				var ri = new enyoLessRiPlugin();
+				less.plugins = [ri];
+				window.less = less;
+			}())
+		</script> -->
+	<!-- -->
+	<script src="../../../enyo/enyo.js" type="text/javascript"></script>
+	<script src="../../layout/package.js" type="text/javascript"></script>
+	<script src="../../moonstone/package.js" type="text/javascript"></script>
+	<script src="../../spotlight/package.js" type="text/javascript"></script>
+	<!-- -->
+	<script src="DataGridListSampleWithTextOverLay.js" type="text/javascript"></script>
+	<!-- -->
+</head>
+<body>
+	<script type="text/javascript">
+		new moon.sample.DataGridListSample().renderInto(document.body);
+	</script>
+</body>
+</html>

--- a/samples/DataGridListSampleWithTextOverLay.js
+++ b/samples/DataGridListSampleWithTextOverLay.js
@@ -1,0 +1,115 @@
+enyo.kind({
+	name: "moon.sample.DataGridListSample",
+	kind: "moon.Panels",
+	pattern: "activity",
+	classes: "moon enyo-fit enyo-unselectable",
+	components: [
+		{kind: "moon.Panel", classes:"moon-6h", title:"Menu", components: [
+			{kind:"moon.Item", content:"Scroll"},
+			{kind:"moon.Item", content:"the"},
+			{kind:"moon.Item", content:"Data Grid List"},
+			{kind:"moon.Item", content:"to"},
+			{kind:"moon.Item", content:"the"},
+			{kind:"moon.Item", content:"Right!"}
+		]},
+		{kind: "moon.Panel", joinToPrev: true, title:"Data Grid List", headerComponents: [
+			{kind: "moon.ToggleButton", content:"Selection", name:"selectionToggle"},
+			{kind: "moon.ContextualPopupDecorator", components: [
+				{kind: "moon.ContextualPopupButton", content:"Selection Type"},
+				{kind: "moon.ContextualPopup", classes:"moon-4h", components: [
+					{kind: "moon.RadioItemGroup", name: "selectionTypeGroup", components: [
+						{content: "Single", value: "single", selected: true},
+						{content: "Multiple", value: "multi"},
+						{content: "Group", value: "group"}
+					]}
+				]}
+			]},
+			{kind: "moon.Button", content:"Refresh", ontap:"refreshItems"},
+			{kind: "moon.ContextualPopupDecorator", components: [
+				{kind: "moon.ContextualPopupButton", content:"Popup List"},
+				{kind: "moon.ContextualPopup", classes:"moon-6h moon-8v", components: [
+					{kind:"moon.DataList", components: [
+						{kind:"moon.CheckboxItem", bindings: [
+							{from:".model.text", to:".content"},
+							{from:".model.selected", to: ".checked", oneWay: false}
+						]}
+					]}
+				]}
+			]}
+		], components: [
+			{name: "gridList", fit: true, spacing: 20, minWidth: 180, minHeight: 180, kind: "moon.DataGridList", scrollerOptions: { kind: "moon.Scroller", vertical:"scroll", horizontal: "hidden", spotlightPagingControls: true }, components: [
+				{ kind: "moon.sample.GridSampleItem" }
+			]}
+		]}
+	],
+	bindings: [
+		{from: ".collection", to: ".$.dataList.collection"},
+		{from: ".collection", to: ".$.gridList.collection"},
+		{from: ".$.selectionTypeGroup.active", to: ".$.gridList.selectionType",
+			transform: function (selected) {
+				return selected && selected.value;
+			}
+		},
+		{from: ".$.selectionToggle.value", to: ".$.gridList.selection", oneWay: false}
+	],
+	create: function () {
+		this.inherited(arguments);
+		// we set the collection that will fire the binding and add it to the list
+		this.set("collection", new enyo.Collection(this.generateRecords()));
+	},
+	generateRecords: function () {
+		var records = [],
+			idx     = this.modelIndex || 0;
+		for (; records.length < 500; ++idx) {
+			var title = (idx % 8 === 0) ? " with long title" : "";
+			var subTitle = (idx % 8 === 0) ? "Lorem ipsum dolor sit amet" : "Subtitle";
+			records.push({
+				selected: false,
+				text: "Item " + idx + title,
+				id:idx,
+				// If showS is false, then, textOverlayScrim will be hide
+				show:false,
+				url: "http://placehold.it/300x300/" + Math.floor(Math.random()*0x1000000).toString(16) + "/ffffff&text=Image " + idx
+			});
+
+		}
+		// If showS is true, then, textOverlayScrim will be hide
+		// user can set true or false, because it is publised property
+		records[1].show=true;
+		// update our internal index so it will always generate unique values
+		this.modelIndex = idx;
+		return records;
+	},
+	refreshItems: function () {
+		// we fetch our collection reference
+		var collection = this.get("collection");
+		// we now remove all of the current records from the collection
+		collection.remove(collection.models);
+		// and we insert all new records that will update the list
+		collection.add(this.generateRecords());
+	}
+});
+
+enyo.kind({
+	name: "moon.sample.GridSampleItem",
+	kind: "moon.GridListImageItem",
+	// moon.TextOverlaySupport is mixin
+	mixins: ["moon.TextOverlaySupport", "moon.SelectionOverlaySupport"],
+	// user can set how many lines are displayed
+	overlayTextLineNum: 2,
+	// user can set marquee is used or not
+	// if useOverlayTextMarquee is set true, overlayTextLineNum property is ignored
+	useOverlayTextMarquee: true,
+	// user can set useSpotlightOverlayText is used or not
+	// useSpotlightOverlayText propery makes only spotlighed item be shown
+	// if useSpotlightOverlayText is set true, then showScrim property is ignored
+	useSpotlightOverlayText: true,
+	bindings: [
+	// overlayText, overlaySubText, showScrim is published property
+	// so user can use these properties for binding
+		{from: ".model.text", to: ".overlayText"},
+		{from: ".model.id", to: ".overlaySubText"},
+		{from: ".model.show", to: ".showScrim"},
+		{from: ".model.url", to: ".source"}
+	]
+});

--- a/samples/DataGridListSampleWithTextOverLay.js
+++ b/samples/DataGridListSampleWithTextOverLay.js
@@ -95,14 +95,14 @@ enyo.kind({
 	// moon.TextOverlaySupport is mixin
 	mixins: ["moon.TextOverlaySupport", "moon.SelectionOverlaySupport"],
 	// user can set how many lines are displayed
-	overlayTextLineNum: 2,
+	overlayTextLineNum: 1,
 	// user can set marquee is used or not
 	// if useOverlayTextMarquee is set true, overlayTextLineNum property is ignored
-	useOverlayTextMarquee: true,
+	useOverlayTextMarquee: false,
 	// user can set useSpotlightOverlayText is used or not
 	// useSpotlightOverlayText propery makes only spotlighed item be shown
 	// if useSpotlightOverlayText is set true, then showScrim property is ignored
-	useSpotlightOverlayText: true,
+	useSpotlightOverlayText: false,
 	bindings: [
 	// overlayText, overlaySubText, showScrim is published property
 	// so user can use these properties for binding

--- a/samples/DataGridListSampleWithTextOverLay.js
+++ b/samples/DataGridListSampleWithTextOverLay.js
@@ -62,7 +62,6 @@ enyo.kind({
 			idx     = this.modelIndex || 0;
 		for (; records.length < 500; ++idx) {
 			var title = (idx % 8 === 0) ? " with long title" : "";
-			var subTitle = (idx % 8 === 0) ? "Lorem ipsum dolor sit amet" : "Subtitle";
 			records.push({
 				selected: false,
 				text: "Item " + idx + title,

--- a/source/TextOverlaySupport.js
+++ b/source/TextOverlaySupport.js
@@ -63,8 +63,9 @@
 
 			//to handle not marquee case
 			//apply '-webkit-line-clamp' with this.overlayTextLineNum user provids
-			this._textTag === undefined && this.$.overlayText.applyStyle('-webkit-line-clamp', this.overlayTextLineNum+ ' !important');
-
+			if(this._textTag === undefined){
+				this.$.overlayText.applyStyle('-webkit-line-clamp', this.overlayTextLineNum+ " !important");
+			}
 			////to handle spotlightOverlayText
 			this.addRemoveClass('moon-text-overlay-support', this.useSpotlightOverlayText);
 			
@@ -87,7 +88,9 @@
 
 	showScrimChanged: function () {	
 		//only if this.useSpotlightOverlayText is false
-		this.useSpotlightOverlayText===false && this.$.textScrim.applyStyle('visibility', this.showScrim ? 'visible' : 'hidden');
+		if(this.useSpotlightOverlayText===false){
+			this.$.textScrim.applyStyle('visibility', this.showScrim ? 'visible' : 'hidden');
+		}
 	}
 };
 })(enyo, this);

--- a/source/TextOverlaySupport.js
+++ b/source/TextOverlaySupport.js
@@ -1,0 +1,93 @@
+(function (enyo, scope) {
+
+	moon.TextOverlaySupport = {
+
+	name: 'moon.TextOverlay',
+
+	/**
+	* @private
+	*/
+	_textTag: undefined,
+	_textClass: 'moon-text-overlay-upperText',
+
+	published: {
+
+		/**
+		* upper text in scrim
+		*
+		* @name moon.TextOverlaySupport#overlayText
+		* @type {String}
+		* @default ''
+		* @public
+		*/
+		overlayText: '',
+
+		/**
+		* bottom text in scrim
+		*
+		* @name moon.TextOverlaySupport#overlaySubText
+		* @type {String}
+		* @default ''
+		* @public
+		*/
+		overlaySubText: '',
+
+		/**
+		* When `true`, the overlay scrim will be shown
+		*
+		* @name moon.TextOverlaySupport#showScrim
+		* @type {Boolean}
+		* @default ''
+		* @public
+		*/
+
+		showScrim: ''
+	},
+
+	/**
+	* @private
+	*/
+	create: enyo.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			
+			//to handle upperText is marquee or not
+			this.useOverlayTextMarqueeChanged();	
+
+			this.createComponent({name:'textScrim', classes: 'enyo-fit moon-text-overlay-support-scrim', components: [
+				{name:'overlayTextContainer', classes: 'enyo-fit moon-text-overlay-support-scrim-center', components: [
+					{name:'overlayText', kind: this._textTag,  classes: this._textClass},
+					{name:'overlaySubText', classes:'moon-text-overlay-bottomText'}]
+				}
+			]});
+
+			//to handle not marquee case
+			//apply '-webkit-line-clamp' with this.overlayTextLineNum user provids
+			this._textTag === undefined && this.$.overlayText.applyStyle('-webkit-line-clamp', this.overlayTextLineNum+ ' !important');
+
+			////to handle spotlightOverlayText
+			this.addRemoveClass('moon-text-overlay-support', this.useSpotlightOverlayText);
+			
+		};
+	}),
+	
+	useOverlayTextMarqueeChanged: function(){
+		//to handle upperText is marquee or not
+		this._textTag = this.useOverlayTextMarquee ? 'moon.MarqueeText' : undefined;
+		this._textClass = this.useOverlayTextMarquee ?  undefined : 'moon-text-overlay-upperText';
+	},
+
+	overlayTextChanged: function () {
+			this.$.overlayText.setContent( this.overlayText );
+	},
+
+	overlaySubTextChanged: function () {
+			this.$.overlaySubText.setContent( this.overlaySubText );
+	},
+
+	showScrimChanged: function () {	
+		//only if this.useSpotlightOverlayText is false
+		this.useSpotlightOverlayText===false && this.$.textScrim.applyStyle('visibility', this.showScrim ? 'visible' : 'hidden');
+	}
+};
+})(enyo, this);

--- a/source/TextOverlaySupport.js
+++ b/source/TextOverlaySupport.js
@@ -64,7 +64,7 @@
 			//to handle not marquee case
 			//apply '-webkit-line-clamp' with this.overlayTextLineNum user provids
 			if(this._textTag === undefined){
-				this.$.overlayText.applyStyle('-webkit-line-clamp', this.overlayTextLineNum+ " !important");
+				this.$.overlayText.addClass('moon-text-overlay-upperText-length'+this.overlayTextLineNum);
 			}
 			////to handle spotlightOverlayText
 			this.addRemoveClass('moon-text-overlay-support', this.useSpotlightOverlayText);

--- a/source/package.js
+++ b/source/package.js
@@ -86,5 +86,6 @@ enyo.depends(
 	'ExpandableText.js',
 	'keymap.js',
 	'History.js',
+	'TextOverlaySupport.js',
 	'moon-container-init.js'
 );


### PR DESCRIPTION
## Issue

There is a requirement to display text with a scrim in Dreadlocks.
Display text with a scrim over images in an image grid. This could display by default or hide/show on hover.

## Solution

##### 1. For the requirement, I added TextOverlaySupport.less file.

##### 2. Also, I made TextOverlaySupport.js.

 - I made published property for "overlayText" / "overlaySubText" / "showScrim" which user can set anytime.
 - and user can set "useOverlayTextMarquee" property to choose usage of marquee or not at creation time.
 - If marquee is not used, then '-webkit-line-clamp' style will be applied with "overlayTextLineNum" property set by user.

 - Also, to handle show/hide, I added showScrimChanged.
 - Also, to handle showing scrim only when hover status, "moon-text-overlay-support" class will be applied or not according to "useSpotlightOverlayText" property.

##### 3. for demo, I added "DataGridListSampleWithTextOverLay.html and DataGridListSampleWithTextOverLay.js".
 - this sample is modified version of DataGridListSample but I modified minHeight of gridList.
 - Also, modified records.push function in generateRecords function to show show/hide set is working.
 - and, put some property in "moon.sample.GridSampleItem" kind to show the requirements are working.

##### 4. If you want to check, you can modify, "overlayTextLineNum" / "useOverlayTextMarquee" / "useSpotlightOverlayText" / "show" properties

DCO-1.1-Signed-Off-By: Suhyung Lee suhyung2.lee@lge.com