### PR TITLE
DRD-8143: Fix full screen video player layout when enters from inline pl...

### DIFF
--- a/css/VideoPlayer.less
+++ b/css/VideoPlayer.less
@@ -89,3 +89,8 @@
 		position: static;
 	}
 }
+:-webkit-full-screen-ancestor:not(iframe) {
+	overflow: visible;
+	padding: 0 !important;
+	margin: 0 !important;
+}

--- a/css/VideoPlayer.less
+++ b/css/VideoPlayer.less
@@ -121,3 +121,11 @@
 	width: 100% !important;
 	height: 100% !important;
 }
+:full-screen-ancestor:not(iframe) {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}

--- a/css/VideoPlayer.less
+++ b/css/VideoPlayer.less
@@ -90,7 +90,10 @@
 	}
 }
 :-webkit-full-screen-ancestor:not(iframe) {
-	overflow: visible;
+	position: absolute !important;
+	overflow: visible !important;
 	padding: 0 !important;
 	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
 }

--- a/css/VideoPlayer.less
+++ b/css/VideoPlayer.less
@@ -97,3 +97,27 @@
 	width: 100% !important;
 	height: 100% !important;
 }
+:-moz-full-screen-ancestor:not(iframe) {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}
+:-ms-full-screen-ancestor:not(iframe) {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}
+:-o-full-screen-ancestor:not(iframe) {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4198,6 +4198,14 @@ html {
   width: 100% !important;
   height: 100% !important;
 }
+:full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
 .moon-video-inline {
   padding-bottom: 3.5rem;
 }

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4166,6 +4166,38 @@ html {
 :full-screen.moon-video-player .moon-video-player-video {
   position: static;
 }
+:-webkit-full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+:-moz-full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+:-ms-full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+:-o-full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
 .moon-video-inline {
   padding-bottom: 3.5rem;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4198,6 +4198,14 @@ html {
   width: 100% !important;
   height: 100% !important;
 }
+:full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
 .moon-video-inline {
   padding-bottom: 3.5rem;
 }

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4166,6 +4166,38 @@ html {
 :full-screen.moon-video-player .moon-video-player-video {
   position: static;
 }
+:-webkit-full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+:-moz-full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+:-ms-full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+:-o-full-screen-ancestor:not(iframe) {
+  position: absolute !important;
+  overflow: visible !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
 .moon-video-inline {
   padding-bottom: 3.5rem;
 }


### PR DESCRIPTION
...ayer

### Issue:
- The fullscreen video player layout is broken when enters from inline player.
- This can be reproduced only when we use inline player inside of panels. Because webkit fullscreen is affected by the layout of parent node.

### Fix:
- Clear overflow, padding and margin of all the ancestor when it is full screen.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com