### PR TITLE
ENYO-1492: Allow for dynamic changing of the enableBackHistoryAPI property

### DIFF
--- a/source/History.js
+++ b/source/History.js
@@ -162,7 +162,6 @@
 		* @private
 		*/
 		init: function() {
-			scope.onpopstate = enyo.bind(this, function(inEvent) {this.popStateHandler();});
 			if (enyo.LunaService) {
 				this.createChrome(this.lunaServiceComponents);
 				this._getAppID();
@@ -171,6 +170,8 @@
 			if (this.enableBackHistoryAPI) {
 				this._initHistoryState();
 			}
+
+			this.enableBackHistoryAPIChanged();
 		},
 
 		/**
@@ -236,6 +237,17 @@
 		_getAppInfoHandler: function (inSender, inResponse) {
 			if(inResponse.appInfo !== undefined) {
 				this.enableBackHistoryAPI = !inResponse.appInfo.disableBackHistoryAPI;
+			}
+		},
+
+		/**
+		* @private
+		*/
+		enableBackHistoryAPIChanged: function () {
+			if (this.enableBackHistoryAPI) {
+				scope.onpopstate = enyo.bind(this, function() {this.popStateHandler();});
+			} else {
+				scope.onpopstate = null;
 			}
 		},
 


### PR DESCRIPTION
### Issue
There are cases where we would like to dynamically enable/disable the back history API. Currently this is set to a default of `true` and is updated accordingly based on an application flag.

### Fix
We implement a change handler for the `enableBackHistoryAPI` property.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>