### PR TITLE
when disabling moon history, back button should function

### DIFF
--- a/lib/History/History.js
+++ b/lib/History/History.js
@@ -281,7 +281,7 @@ var History = module.exports = kind.singleton({
 
 		switch (state) {
 		case 'empty':
-			if (!history.state || history.state.currentObjId == 'historyMaster') {
+			if (this.enableBackHistoryAPI && (!history.state || history.state.currentObjId == 'historyMaster')) {
 				this._initHistoryState();
 			}
 			break;


### PR DESCRIPTION
Keeps moon.History from hooking the back button when historyAPI is disabled.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson <derek.anderson@lge.com>