### PR TITLE
ENYO-1138: Client area of scroller is shaking when expandable picker is ...

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -728,7 +728,7 @@
 				this.scrollBounds = this._getScrollBounds();
 				this.setupBounds();
 				this.scrollBounds = null;
-				if ((showVertical || showHorizontal) && (originator.showing)) {
+				if ((showVertical || showHorizontal) && (originator.getAbsoluteShowing())) {
 					this.animateToControl(originator, event.scrollFullPage, event.scrollInPointerMode || false);
 					if ((showVertical && this.$.scrollMath.bottomBoundary) || (showHorizontal && this.$.scrollMath.rightBoundary)) {
 						this.alertThumbs();


### PR DESCRIPTION
...hidden

### Issue ###

If customized picker which doesn't inherits but contain expandable picker in components block is hidden before `drawerAnimationEnd` is handled, client area of the scroller shakes a bit.

### Fix ###

We check whether `originator.showing` is set to true or not but in this case originator is expandablePicker, not customized one. Therefore the 'showing' value is true even though it is actually hidden. To check visibility correctly, we need to use `getAbsoluteShowing()`.

Enyo-DCO-1.1-Signed-off-by: Hunkyo Jung <hunkyo.jung@lge.com>