### PR TITLE
Enyo-1171 Add webkit keycode of backspace for keyboard

### DIFF
--- a/lib/History/History.js
+++ b/lib/History/History.js
@@ -324,7 +324,11 @@ var History = module.exports = kind.singleton({
 	* @private
 	*/
 	remoteBackKeyHandler: function (inSender, inEvent) {
-		if (inEvent.keySymbol == 'back' && this._currentObj && this._currentObj.getShowing()) {
+		// In keymap.js, we assigned specific keycode to 'back' string.
+		// It is only for back key button of remote controller with webOS environment.
+		// But more generally, we can use back space key of keyboard.
+		// 8 is webkit keycode of back space key.
+		if ((inEvent.keySymbol == 'back' || inEvent.keyCode === 8) && this._currentObj && this._currentObj.getShowing()) {
 			this._callBackKeyHandler();
 			this.ignorePopState();
 		}


### PR DESCRIPTION
Issue
------
HistorySample does not work when we use USB keyboard

Cause
--------
keymap.js did not have keycode for back space key in keyboard

Fix
----
Add keycode into keymap.js

Note
------
'0x8' is webkit keycode of backspace key. It is not reserved from any other keys of remote controller yet. However we'd better get confirm from Architect.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com