### PR TITLE
ENYO-1217: Update scroller boundaries when (re)rendering the repeater.

### DIFF
--- a/lib/IntegerPicker/IntegerPicker.js
+++ b/lib/IntegerPicker/IntegerPicker.js
@@ -485,6 +485,7 @@ module.exports = kind(
 		this.$.repeater.set('rowOffset', index);
 		this.$.repeater.set('count', count || 1);
 		this.$.repeater.render();
+		this.$.scroller.remeasure();
 	},
 
 	/**


### PR DESCRIPTION
### Issue
Due to some optimizations in `ScrollMath` we are now calculating the `maxY` value from the current scroll bounds and clamping to that value for the amount of vertical scrolling. In the case of `moon.IntegerPicker`, there is only one item rendered initially, and so outdated scroll bounds are utilized when scrolling to the next value.

### Fix
We now force a recalculation of the scroll boundaries when the flyweight repeater is re-rendered.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>