### PR TITLE
ENYO-1138: Client area of scroller is shaking when expandable picker is hidden

### DIFF
--- a/lib/ScrollStrategy/ScrollStrategy.js
+++ b/lib/ScrollStrategy/ScrollStrategy.js
@@ -740,7 +740,7 @@ var MoonScrollStrategy = module.exports = kind(
 			this.scrollBounds = this._getScrollBounds();
 			this.setupBounds();
 			this.scrollBounds = null;
-			if ((showVertical || showHorizontal) && (originator.showing)) {
+			if ((showVertical || showHorizontal) && (originator.getAbsoluteShowing())) {
 				this.animateToControl(originator, event.scrollFullPage, event.scrollInPointerMode || false);
 				if ((showVertical && this.$.scrollMath.bottomBoundary) || (showHorizontal && this.$.scrollMath.rightBoundary)) {
 					this.alertThumbs();


### PR DESCRIPTION
Cherry-picking the changes from https://github.com/enyojs/moonstone/pull/2099 into `2.6.0-dev`, creating a PR for tracking purposes.