### PR TITLE
DRD-8143: Fix full screen video player layout when enters from inline pl...

### DIFF
--- a/lib/VideoPlayer/VideoPlayer.less
+++ b/lib/VideoPlayer/VideoPlayer.less
@@ -89,3 +89,43 @@
 		position: static;
 	}
 }
+:-webkit-full-screen-ancestor:not(iframe) {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}
+:-moz-full-screen-ancestor:not(iframe) {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}
+:-ms-full-screen-ancestor:not(iframe) {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}
+:-o-full-screen-ancestor:not(iframe) {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}
+:full-screen-ancestor:not(iframe) {
+	position: absolute !important;
+	overflow: visible !important;
+	padding: 0 !important;
+	margin: 0 !important;
+	width: 100% !important;
+	height: 100% !important;
+}


### PR DESCRIPTION
...ayer

Issue:
- The fullscreen video player layout is broken when enters from inline player.
- This can be reproduced only when we use inline player inside of panels. Because webkit fullscreen is affected by the layout of parent node.

Fix:
- Clear overflow, padding and margin of all the ancestor when it is full screen.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com