### PR TITLE
ENYO-1225: ProgressButton: Full progress % does not display during transition

### DIFF
--- a/src/ProgressButton/ProgressButton.js
+++ b/src/ProgressButton/ProgressButton.js
@@ -230,7 +230,7 @@ module.exports = kind(
 				this.$.bar.applyStyle('-webkit-transform', 'translateX(-' + (100 + offset - progress) + '%)');
 			}
 		} else if (percent >= 100) {
-			this.updateProgressPercent(percent);
+			this.updateProgressPercent(100);
 			// Make it spottable again, now that it's finished.
 			this.$.bar.applyStyle('transform', null);
 			this.$.bar.applyStyle('-webkit-transform', null);

--- a/src/ProgressButton/ProgressButton.js
+++ b/src/ProgressButton/ProgressButton.js
@@ -230,6 +230,7 @@ module.exports = kind(
 				this.$.bar.applyStyle('-webkit-transform', 'translateX(-' + (100 + offset - progress) + '%)');
 			}
 		} else if (percent >= 100) {
+			this.updateProgressPercent(percent);
 			// Make it spottable again, now that it's finished.
 			this.$.bar.applyStyle('transform', null);
 			this.$.bar.applyStyle('-webkit-transform', null);


### PR DESCRIPTION
### Issue

In the progress button, full progress percentage (100%) never displays. Once reached the progress 90% it is unexpectedly transitions to 'launch'. But expected to show the progress 100% and then translate to 'launch'
### Fix

Called the 'updateProgressPercent()' function when the progress is greater than or equal to 100%

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com
