### PR TITLE
ENYO-1327: Radius is incorrect in the text Inputs

### DIFF
--- a/lib/InputDecorator/InputDecorator.less
+++ b/lib/InputDecorator/InputDecorator.less
@@ -30,7 +30,7 @@
 
 .moon-input-decorator:not(.moon-input-header-input-decorator) {
 	padding: 12px 30px;
-	border-radius: 30px;
+	border-radius: 1008px;
 }
 
 .moon-textarea-decorator {


### PR DESCRIPTION
### Issue
The end radius of the input field (moon.InputDecorator) is not a proper half circle.

### Fix
The border circle of the moon.InputDecorator is achieved by border-radius css property. The value of border-radius was 30px earlier and is been replaced by 1008px in solve this issue.

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com