### PR TITLE
ENYO-1292: ExpandableListItem: Lack of Padding displays in RTL

### DIFF
--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -166,7 +166,7 @@ module.exports = kind(
 	components: [
 		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 		// widths (webkit bug)
-		{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+		{name: 'headerContainer', kind: Item, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			{name: 'header', kind: MarqueeText}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [

--- a/lib/ExpandableListItem/ExpandableListItem.less
+++ b/lib/ExpandableListItem/ExpandableListItem.less
@@ -31,7 +31,7 @@
 	}
 }
 .enyo-locale-right-to-left {
-	.moon-expandable-picker-header.moon-expandable-list-item-header {
+	.moon-expandable-list-item-header.moon-expandable-list-header {
 		padding-right: @moon-spotlight-outset;
 	}
 	.moon-expandable-list-item-client.indented {

--- a/lib/ExpandableListItem/ExpandableListItem.less
+++ b/lib/ExpandableListItem/ExpandableListItem.less
@@ -1,16 +1,17 @@
 /* ExpandableListItem Header*/
 .moon-expandable-list-item-header {
-  margin-bottom: 0px;
-  box-sizing: border-box;
-  max-width: 100%;
-}
-.moon-expandable-list-header.moon-expandable-picker-header:after {
-  top: @moon-spotlight-outset + 3;
+	margin-bottom: 0px;
+	box-sizing: border-box;
+	max-width: 100%;
+
+	&.moon-expandable-list-header:after {
+		top: @moon-spotlight-outset + 3;
+	}
 }
 
 /* Client Items */
 .moon-expandable-list-item.open .moon-expandable-list-item-client {
-  margin-bottom: 12px;
+	margin-bottom: 12px;
 }
 .moon-expandable-list-item-client .moon-item {
 	.moon-body-text;
@@ -18,19 +19,23 @@
 .enyo-locale-non-latin .moon-expandable-list-item-client .moon-item {
 	.enyo-locale-non-latin .moon-body-text;
 }
-.moon-expandable-list-item-client .moon-item.spotlight {
-	color: @moon-white;
+.moon-expandable-list-item-client {
+	.moon-item.spotlight {
+		color: @moon-white;
+	}
+	.moon-item:last-child {
+		margin-bottom: 0px;
+	}
+	&.indented {
+		padding-left: @moon-item-indent + @moon-spotlight-outset;
+	}
 }
-.moon-expandable-list-item-client .moon-item:last-child {
-	margin-bottom: 0px;
-}
-.moon-expandable-list-item-client.indented {
-	padding-left: @moon-item-indent + @moon-spotlight-outset;
-}
-.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
-	padding-right: @moon-spotlight-outset;
-}
-.enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
-	padding-left: 0;
-	padding-right: @moon-item-indent + @moon-spotlight-outset;
+.enyo-locale-right-to-left {
+	.moon-expandable-picker-header.moon-expandable-list-item-header {
+		padding-right: @moon-spotlight-outset;
+	}
+	.moon-expandable-list-item-client.indented {
+		padding-left: 0;
+		padding-right: @moon-item-indent + @moon-spotlight-outset;
+	}
 }

--- a/lib/ExpandableListItem/ExpandableListItem.less
+++ b/lib/ExpandableListItem/ExpandableListItem.less
@@ -27,6 +27,9 @@
 .moon-expandable-list-item-client.indented {
 	padding-left: @moon-item-indent + @moon-spotlight-outset;
 }
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-item-header {
+	padding-right: @moon-spotlight-outset;
+}
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
 	padding-left: 0;
 	padding-right: @moon-item-indent + @moon-spotlight-outset;

--- a/lib/ExpandableListItem/ExpandableListItem.less
+++ b/lib/ExpandableListItem/ExpandableListItem.less
@@ -27,7 +27,7 @@
 .moon-expandable-list-item-client.indented {
 	padding-left: @moon-item-indent + @moon-spotlight-outset;
 }
-.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-item-header {
+.enyo-locale-right-to-left .moon-expandable-list-item-header.moon-expandable-list-header {
 	padding-right: @moon-spotlight-outset;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {


### PR DESCRIPTION
### Issue:

Lack of padding displays to the right edge of the expandable list item header when in RTL mode

### Fix:

The right padding for expandable picker header was changed from 0px to @moon-spotlight-outset

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com