### PR TITLE
ENYO-1529: in moon.Slider, value of knob is changing by left or right key during draging status

### DIFF
--- a/source/Slider.js
+++ b/source/Slider.js
@@ -837,7 +837,7 @@
 		* @private
 		*/
 		spotLeft: function(sender, e) {
-			if (this.selected) {
+			if (this.selected && !this.dragging) {
 				// If in the process of animating, work from the previously set value
 				var v = this.getValue() - (this.increment || 1);
 
@@ -850,7 +850,7 @@
 		* @private
 		*/
 		spotRight: function(sender, e) {
-			if (this.selected) {
+			if (this.selected && !this.dragging) {
 				var v = this.getValue() + (this.increment || 1);
 
 				this.set('value',v);


### PR DESCRIPTION


## Issue

This issue is found on SmartShare app and we have DEV tracker issue.
In photo view, when trying zoom in or out with magic remote and trying input left or right key on normal remote, knob is moving beyond slider bar.

Step to reproduce
1. Open moon.Slider example,
2. with magic remote or mouse, focus on first slider and moving left or right and don't release magic remote or mouse.
3. with normal remote, press ok to enable selection. After that. you can release the magic remote or mouse. But if you do not release mouse or magic remote, you can reproduce better.
4. click left or right button, then you can see the disabled slider's knob is moving

## FIx

The reason why the knob is moving by left or right key is the selection mode is enabled even if this.dragging is true.
So, If I does not release mouse and click ok button, then the dragging status is true and also selection mode is enabled.
By the selection mode, we can change knob value by left or right key.
We can fix this issue, only allow knob to be moved by left or right key when dragging mode is false.
So, we can separate selection mode with normal remote from dragging mode with mouse or magic remote.

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung2.lee@lge.com