### PR TITLE
ENYO-1368: Enlarge scroll thumb minimum height from 20 to 40

### DIFF
--- a/lib/ScrollThumb/ScrollThumb.js
+++ b/lib/ScrollThumb/ScrollThumb.js
@@ -52,7 +52,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	minSize: 20,
+	minSize: 40,
 
 	/**
 	* @private
@@ -152,7 +152,7 @@ module.exports = kind(
 
 	/**
 	* Override `show()` to give fade effect.
-	* 
+	*
 	* @private
 	*/
 	show: function () {


### PR DESCRIPTION
Cherry-picking the changes from https://github.com/enyojs/moonstone/pull/2076 into `2.6.0-dev`, creating a PR for tracking purposes.