### PR TITLE
[2.6.0-pre.4-dev -> 2.6.0-dev] LightPanels updates and refinement.

### DIFF
--- a/lib/LightPanel/LightPanel.js
+++ b/lib/LightPanel/LightPanel.js
@@ -141,26 +141,16 @@ module.exports = kind(
 	deactivated: function () {},
 
 	/**
-	* Determines whether or not we should perform post-transition work.
-	*
-	* @return {Boolean} - If `true`, we should not run the
-	*	{@link enyo.LightPanels#postTransition} method.
-	* @public
-	*/
-	shouldSkipPostTransition: function () {
-		return this._skipPostTransition;
-	},
-
-	/**
 	* This overridable method is called after a transition.
 	*
 	* @public
 	*/
 	postTransition: function () {
-		this.createComponents(this.clientComponents);
-		this.$.client.render();
-		this.$.client.addClass('populated');
-		this._skipPostTransition = true;
+		if (!this.$.client.children.length) {
+			this.createComponents(this.clientComponents);
+			this.$.client.render();
+			this.$.client.addClass('populated');
+		}
 
 		if (!Spotlight.getCurrent()) {
 			Spotlight.spot(this);


### PR DESCRIPTION
"Cherry-picking" changes to `moon.LightPanel` from `2.6.0-pre.4-dev` to `2.6.0-dev`. This PR is related to and dependent upon https://github.com/enyojs/enyo/pull/1140.