### PR TITLE
Fixes ENYO-1537

### DIFF
--- a/lib/PagingControl/PagingControl.js
+++ b/lib/PagingControl/PagingControl.js
@@ -2,7 +2,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
-	dev = require('enyo/dev'),
+	utils = require('enyo/utils'),
 	animation = require('enyo/animation');
 
 var
@@ -199,7 +199,7 @@ module.exports = kind(
 			return;
 		}
 
-		this.downTime = dev.bench();
+		this.downTime = utils.perfNow();
 		this.delta = this.initialDelta;
 	},
 
@@ -263,14 +263,14 @@ module.exports = kind(
 	startHoldJob: function() {
 		this.stopHoldJob();
 
-		var t0 = dev.bench(),
+		var t0 = utils.perfNow(),
 			t = 0
 		;
 
 		var fn = this.bindSafely(function() {
 			this.job = animation.requestAnimationFrame(fn);
 
-			t = (dev.bench() - t0)/1000;
+			t = (utils.perfNow() - t0)/1000;
 			this.delta = Math.min(this.maxDelta, this.delta + (0.1 * Math.pow(t, 1.1)));
 
 			this.doPaginateScroll({scrollDelta: this.delta});
@@ -292,7 +292,7 @@ module.exports = kind(
 	*/
 	sendPaginateEvent: function() {
 		var tapThreshold = 200,
-			timeElapsed = dev.bench() - this.downTime,
+			timeElapsed = utils.perfNow() - this.downTime,
 			delta = (timeElapsed <= tapThreshold) ? this.tapDelta : this.delta;
 
 		this.doPaginate({scrollDelta: delta});


### PR DESCRIPTION
## Issue
`enyo.bench()` was converted to `require('enyo/dev').bench()`

## Fix
Should have been `require('enyo/utils').perfNow()`

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)