### PR TITLE
ENYO-1311 : Time picker: make it optional to display bottom text (rank: 19)

### DIFF
--- a/lib/TimePicker/TimePicker.js
+++ b/lib/TimePicker/TimePicker.js
@@ -364,7 +364,7 @@ var TimePicker = module.exports = kind(
 		* @default true
 		* @public
 		*/
-		showBottomText: true
+		showPickerLabels: true
 	},
 
 	/**
@@ -454,38 +454,41 @@ var TimePicker = module.exports = kind(
 				this.wrapComponent(
 					{name: 'timeWrapper', kind: Control, classes: 'moon-time-picker-wrap'},
 					{name: 'hourWrapper', kind: Control, classes: 'moon-date-picker-wrap', components:[
-						{name: 'hour', kind: HourPicker, formatter: this.hourFormatter || this, value: valueHours, onChange: 'hourPickerChanged'}
+						{name: 'hour', kind: HourPicker, formatter: this.hourFormatter || this, value: valueHours, onChange: 'hourPickerChanged'},
+						{name: 'hourLabel', kind: Control, content: this.hourText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true, showing: this.showPickerLabels}
 					]},
 					this
 				);
 				
-				if(this.showBottomText){
-						this.$.hourWrapper.createComponent({name: 'hourLabel', kind: Control, content: this.hourText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+				if(this.showPickerLabels === true){
+					this.$.hourLabel.show();
 				}
 				break;
 			case 'm':
 				this.wrapComponent(
 					{name: 'timeWrapper', kind: Control, classes: 'moon-time-picker-wrap'},
 					{name: 'minuteWrapper', classes: 'moon-date-picker-wrap', components:[
-						{name: 'minute', kind: MinutePicker, formatter: this.minuteFormatter || this, value: valueMinutes, onChange: 'minutePickerChanged'}
+						{name: 'minute', kind: MinutePicker, formatter: this.minuteFormatter || this, value: valueMinutes, onChange: 'minutePickerChanged'},
+						{name: 'minuteLabel', kind: Control, content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true, showing: this.showPickerLabels}
 					]},
 					this
 				);
 				
-				if(this.showBottomText){
-						this.$.minuteWrapper.createComponent({name: 'minuteLabel', kind: Control, content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+				if(this.showPickerLabels === true){
+					this.$.minuteLabel.show();
 				}
 				break;
 			case 'a':
 				if (this.meridiemEnable === true) {
 					this.createComponent(
 						{name: 'meridiemWrapper', kind: Control, classes: 'moon-date-picker-wrap', components:[
-							{name: 'meridiem', kind: MeridiemPicker, classes: 'moon-date-picker-field', value: valueHours > 12 ? 1 : 0, meridiems: this.meridiems || ['am','pm'], onChange: 'meridiemPickerChanged'}
+							{name: 'meridiem', kind: MeridiemPicker, classes: 'moon-date-picker-field', value: valueHours > 12 ? 1 : 0, meridiems: this.meridiems || ['am','pm'], onChange: 'meridiemPickerChanged'},
+							{name: 'meridiemLabel', kind: Control, content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true, showing: this.showPickerLabels}
 						]}
 					);
 					
-					if(this.showBottomText){
-						this.$.meridiemWrapper.createComponent({name: 'meridiemLabel', kind: Control, content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+					if(this.showPickerLabels === true){
+						this.$.meridiemLabel.show();
 					}
 				}
 				break;
@@ -666,20 +669,10 @@ var TimePicker = module.exports = kind(
 	/**
 	* @private
 	*/
-	showBottomTextChanged: function (inOldvalue, inNewValue) {
-		if(inOldvalue===true && inNewValue===false){
-			this.$.hourLabel.destroy();
-			this.$.minuteLabel.destroy();
-			this.$.meridiemLabel.destroy();
-		}
-		else if(inOldvalue===false && inNewValue===true){
-			this.$.hourWrapper.createComponent({name: 'hourLabel', kind: Control, content: this.hourText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
-			this.$.minuteWrapper.createComponent({name: 'minuteLabel', kind: Control, content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
-			this.$.meridiemWrapper.createComponent({name: 'meridiemLabel', kind: Control, content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
-			this.$.hourWrapper.render();
-			this.$.minuteWrapper.render();
-			this.$.meridiemWrapper.render();
-		}
+	showPickerLabelsChanged: function (inOldvalue, inNewValue) {
+		this.$.hourLabel.set('showing', this.showPickerLabels);
+		this.$.minuteLabel.set('showing', this.showPickerLabels);
+		this.$.meridiemLabel.set('showing', this.showPickerLabels);
  	}
 });
 

--- a/lib/TimePicker/TimePicker.js
+++ b/lib/TimePicker/TimePicker.js
@@ -455,41 +455,29 @@ var TimePicker = module.exports = kind(
 					{name: 'timeWrapper', kind: Control, classes: 'moon-time-picker-wrap'},
 					{kind: Control, classes: 'moon-date-picker-wrap', components:[
 						{name: 'hour', kind: HourPicker, formatter: this.hourFormatter || this, value: valueHours, onChange: 'hourPickerChanged'},
-						{name: 'hourLabel', kind: Control, content: this.hourText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true, showing: this.showPickerLabels}
+						{name: 'hourLabel', kind: Control, content: this.hourText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true}
 					]},
 					this
 				);
-				
-				if(this.showPickerLabels === true){
-					this.$.hourLabel.show();
-				}
 				break;
 			case 'm':
 				this.wrapComponent(
 					{name: 'timeWrapper', kind: Control, classes: 'moon-time-picker-wrap'},
 					{kind: Control, classes: 'moon-date-picker-wrap', components:[
 						{name: 'minute', kind: MinutePicker, formatter: this.minuteFormatter || this, value: valueMinutes, onChange: 'minutePickerChanged'},
-						{name: 'minuteLabel', kind: Control, content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true, showing: this.showPickerLabels}
+						{name: 'minuteLabel', kind: Control, content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true}
 					]},
 					this
 				);
-				
-				if(this.showPickerLabels === true){
-					this.$.minuteLabel.show();
-				}
 				break;
 			case 'a':
 				if (this.meridiemEnable === true) {
 					this.createComponent(
 						{kind: Control, classes: 'moon-date-picker-wrap', components:[
 							{name: 'meridiem', kind: MeridiemPicker, classes: 'moon-date-picker-field', value: valueHours > 12 ? 1 : 0, meridiems: this.meridiems || ['am','pm'], onChange: 'meridiemPickerChanged'},
-							{name: 'meridiemLabel', kind: Control, content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true, showing: this.showPickerLabels}
+							{name: 'meridiemLabel', kind: Control, content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true}
 						]}
 					);
-					
-					if(this.showPickerLabels === true){
-						this.$.meridiemLabel.show();
-					}
 				}
 				break;
 			default:
@@ -497,7 +485,7 @@ var TimePicker = module.exports = kind(
 			}
 
 		}
-
+		this.showPickerLabelsChanged();
 		DateTimePickerBase.prototype.setupPickers.apply(this, arguments);
 	},
 
@@ -672,7 +660,9 @@ var TimePicker = module.exports = kind(
 	showPickerLabelsChanged: function (inOldvalue, inNewValue) {
 		this.$.hourLabel.set('showing', this.showPickerLabels);
 		this.$.minuteLabel.set('showing', this.showPickerLabels);
-		this.$.meridiemLabel.set('showing', this.showPickerLabels);
+		if(this.meridiemEnable){
+			this.$.meridiemLabel.set('showing', this.showPickerLabels);
+		}
  	}
 });
 

--- a/lib/TimePicker/TimePicker.js
+++ b/lib/TimePicker/TimePicker.js
@@ -453,7 +453,7 @@ var TimePicker = module.exports = kind(
 			case 'k':
 				this.wrapComponent(
 					{name: 'timeWrapper', kind: Control, classes: 'moon-time-picker-wrap'},
-					{name: 'hourWrapper', kind: Control, classes: 'moon-date-picker-wrap', components:[
+					{kind: Control, classes: 'moon-date-picker-wrap', components:[
 						{name: 'hour', kind: HourPicker, formatter: this.hourFormatter || this, value: valueHours, onChange: 'hourPickerChanged'},
 						{name: 'hourLabel', kind: Control, content: this.hourText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true, showing: this.showPickerLabels}
 					]},
@@ -467,7 +467,7 @@ var TimePicker = module.exports = kind(
 			case 'm':
 				this.wrapComponent(
 					{name: 'timeWrapper', kind: Control, classes: 'moon-time-picker-wrap'},
-					{name: 'minuteWrapper', classes: 'moon-date-picker-wrap', components:[
+					{kind: Control, classes: 'moon-date-picker-wrap', components:[
 						{name: 'minute', kind: MinutePicker, formatter: this.minuteFormatter || this, value: valueMinutes, onChange: 'minutePickerChanged'},
 						{name: 'minuteLabel', kind: Control, content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true, showing: this.showPickerLabels}
 					]},
@@ -481,7 +481,7 @@ var TimePicker = module.exports = kind(
 			case 'a':
 				if (this.meridiemEnable === true) {
 					this.createComponent(
-						{name: 'meridiemWrapper', kind: Control, classes: 'moon-date-picker-wrap', components:[
+						{kind: Control, classes: 'moon-date-picker-wrap', components:[
 							{name: 'meridiem', kind: MeridiemPicker, classes: 'moon-date-picker-field', value: valueHours > 12 ? 1 : 0, meridiems: this.meridiems || ['am','pm'], onChange: 'meridiemPickerChanged'},
 							{name: 'meridiemLabel', kind: Control, content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text', renderOnShow: true, showing: this.showPickerLabels}
 						]}

--- a/lib/TimePicker/TimePicker.js
+++ b/lib/TimePicker/TimePicker.js
@@ -355,7 +355,16 @@ var TimePicker = module.exports = kind(
 		* @default false
 		* @public
 		*/
-		hoursZeroPadded: false
+		hoursZeroPadded: false,
+
+		/**
+		* When `true`, bottom text will be displayed
+		*
+		* @type {Boolean}
+		* @default true
+		* @public
+		*/
+		showBottomText: true
 	},
 
 	/**
@@ -444,31 +453,40 @@ var TimePicker = module.exports = kind(
 			case 'k':
 				this.wrapComponent(
 					{name: 'timeWrapper', kind: Control, classes: 'moon-time-picker-wrap'},
-					{kind: Control, classes: 'moon-date-picker-wrap', components:[
-						{name: 'hour', kind: HourPicker, formatter: this.hourFormatter || this, value: valueHours, onChange: 'hourPickerChanged'},
-						{name: 'hourLabel', kind: Control, content: this.hourText, classes: 'moon-date-picker-label moon-divider-text'}
+					{name: 'hourWrapper', kind: Control, classes: 'moon-date-picker-wrap', components:[
+						{name: 'hour', kind: HourPicker, formatter: this.hourFormatter || this, value: valueHours, onChange: 'hourPickerChanged'}
 					]},
 					this
 				);
+				
+				if(this.showBottomText){
+						this.$.hourWrapper.createComponent({name: 'hourLabel', kind: Control, content: this.hourText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+				}
 				break;
 			case 'm':
 				this.wrapComponent(
 					{name: 'timeWrapper', kind: Control, classes: 'moon-time-picker-wrap'},
-					{classes: 'moon-date-picker-wrap', components:[
-						{name: 'minute', kind: MinutePicker, formatter: this.minuteFormatter || this, value: valueMinutes, onChange: 'minutePickerChanged'},
-						{name: 'minuteLabel', content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}
+					{name: 'minuteWrapper', classes: 'moon-date-picker-wrap', components:[
+						{name: 'minute', kind: MinutePicker, formatter: this.minuteFormatter || this, value: valueMinutes, onChange: 'minutePickerChanged'}
 					]},
 					this
 				);
+				
+				if(this.showBottomText){
+						this.$.minuteWrapper.createComponent({name: 'minuteLabel', kind: Control, content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+				}
 				break;
 			case 'a':
 				if (this.meridiemEnable === true) {
 					this.createComponent(
-						{kind: Control, classes: 'moon-date-picker-wrap', components:[
-							{name: 'meridiem', kind: MeridiemPicker, classes: 'moon-date-picker-field', value: valueHours > 12 ? 1 : 0, meridiems: this.meridiems || ['am','pm'], onChange: 'meridiemPickerChanged'},
-							{name: 'meridiemLabel', kind: Control, content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'}
+						{name: 'meridiemWrapper', kind: Control, classes: 'moon-date-picker-wrap', components:[
+							{name: 'meridiem', kind: MeridiemPicker, classes: 'moon-date-picker-field', value: valueHours > 12 ? 1 : 0, meridiems: this.meridiems || ['am','pm'], onChange: 'meridiemPickerChanged'}
 						]}
 					);
+					
+					if(this.showBottomText){
+						this.$.meridiemWrapper.createComponent({name: 'meridiemLabel', kind: Control, content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+					}
 				}
 				break;
 			default:
@@ -643,7 +661,26 @@ var TimePicker = module.exports = kind(
 	*/
 	meridiemTextChanged: function (inOldvalue, inNewValue) {
 		this.$.meridiemLabel.setContent(inNewValue);
-	}
+	},
+
+	/**
+	* @private
+	*/
+	showBottomTextChanged: function (inOldvalue, inNewValue) {
+		if(inOldvalue===true && inNewValue===false){
+			this.$.hourLabel.destroy();
+			this.$.minuteLabel.destroy();
+			this.$.meridiemLabel.destroy();
+		}
+		else if(inOldvalue===false && inNewValue===true){
+			this.$.hourWrapper.createComponent({name: 'hourLabel', kind: Control, content: this.hourText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+			this.$.minuteWrapper.createComponent({name: 'minuteLabel', kind: Control, content: this.minuteText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+			this.$.meridiemWrapper.createComponent({name: 'meridiemLabel', kind: Control, content: this.meridiemText, classes: 'moon-date-picker-label moon-divider-text'}, {owner: this});
+			this.$.hourWrapper.render();
+			this.$.minuteWrapper.render();
+			this.$.meridiemWrapper.render();
+		}
+ 	}
 });
 
 TimePicker.HourPicker = HourPicker;


### PR DESCRIPTION
## Issue

There is a requirement to make bottom text of Time Picker be displayed optionally in Dreadlocks.

## Solution

For the requirement, I added published property "bottomTextEnable" whose default value is true.
Also, I made changes in setupPickers func.
 - "current" : creates both picker and bottomText -> "modified" : creates picker first and then only when bottomTextEnable is true, creates bottomText.

This is copy of #2082 for 2.6.0-dev

DCO-1.1-Signed-Off-By: Suhyung Lee suhyung2.lee@lge.com