### PR TITLE
ENYO-1172 : Display text with a scrim over images in an image grid (new rank: 2)

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -157,6 +157,11 @@
 
 @accordion-sub-menu-line-height: 1.7em;
 
+// TextOverlay Support
+// ---------------------------------------
+@moon-upperTextOverlay-font-family: "MuseoSans 500";
+@moon-bottomTextOverlay-font-family: "Moonstone Miso Bold";
+
 // Drawer
 // ---------------------------------------
 @moon-drawers-activator-bar-height: 24px;
@@ -371,3 +376,17 @@
 // ----------------------------------------
 @moon-progress-button-bar-border-radius: @moon-button-border-radius;
 @moon-progress-button-border-width: @moon-button-border-width;
+
+// TextOverLay Support
+// ----------------------------------------
+@moon-text-overlay-support-scrim-background-color: rgba(0, 0, 0, 0.5);
+@moon-text-overlay-support-text-width: 72%;
+@moon-text-overlay-support-text-padding-leftRight: 14%;
+@moon-text-overlay-support-upperText-font-size: 24px;
+@moon-text-overlay-support-upperText-line-height: 27px;
+@moon-text-overlay-support-upperText-color: rgba(255, 255, 255, 0.7);
+@moon-text-overlay-support-upperText-margin-bottom: 2px;
+@moon-text-overlay-support-bottomText-font-size: 48px;
+@moon-text-overlay-support-bottomText-line-height: 48px;
+@moon-text-overlay-support-bottomText-color: rgba(255, 255, 255, 0.3);
+@moon-text-overlay-support-bottomText-margin-top: 1px;

--- a/lib/TextOverlaySupport/TextOverlaySupport.js
+++ b/lib/TextOverlaySupport/TextOverlaySupport.js
@@ -1,0 +1,68 @@
+require('moonstone');
+
+var
+	kind = require('enyo/kind'),
+	Control = require('enyo/Control');
+
+var
+	Marquee = require('moonstone/Marquee'),
+	MarqueeText = Marquee.Text;
+
+module.exports = {
+
+	name: 'moon.TextOverlay',
+
+	useoverlaytextmarquee: undefined,
+	overlaytextLineNum: undefined,
+	overLayText: '',
+	overLaySubText: '',
+	showScrim: undefined,
+	useSpotLightOverlayText: undefined,
+
+	create: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.useoverlaytextmarqueeChanged();	
+			this.overlaytextLineNumChanged();
+			this.overLayTextChanged();
+			this.overLaySubTextChanged();
+			this.showScrimChanged();
+			this.useSpotLightOverlayTextChanged();		
+		};
+	}),
+	
+	useoverlaytextmarqueeChanged: function(){
+		if(this.$.textScrim===undefined){
+		this.createComponent({name:'textScrim', classes: 'enyo-fit moon-text-overlay-support-scrim',  kind: Control, components: [
+				{name:'overLayTextContainer', classes: 'enyo-fit moon-text-overlay-support-scrim-center',  kind: Control, components: [
+					{name:'overLayText', kind: this.useoverlaytextmarquee ? MarqueeText : Control,  classes: this.useoverlaytextmarquee ?  undefined : 'moon-text-overlay-upperText'},
+					{name:'overLaySubText', classes:'moon-text-overlay-bottomText', kind: Control}]
+				}
+		]}, {owner: this});
+		}
+		else{
+			this.$.overLayText.destroy();
+			this.$.overLayTextContainer.createComponent({name:'overLayText', kind: this.useoverlaytextmarquee ? MarqueeText : Control,  classes: this.useoverlaytextmarquee ?  undefined : 'moon-text-overlay-upperText', addBefore: null}, {owner: this});
+			this.overLayTextChanged();
+			this.$.overLayText.render();
+			
+		}
+
+	},
+	overlaytextLineNumChanged: function(){
+		this.useoverlaytextmarquee !== true && this.$.overLayText.applyStyle('-webkit-line-clamp', this.overlaytextLineNum);
+	},
+	overLayTextChanged: function () {
+		this.$.overLayText.setContent( this.overLayText );
+	},
+
+	overLaySubTextChanged: function () {
+		this.$.overLaySubText.setContent( this.overLaySubText );
+	},
+	showScrimChanged: function () {
+		this.useSpotLightOverlayText!==true && this.$.textScrim.applyStyle('visibility', this.showScrim ? 'visible' : 'hidden');
+	},
+	useSpotLightOverlayTextChanged: function () {	
+		this.addRemoveClass('moon-text-overlay-support', this.useSpotLightOverlayText);
+	}
+};

--- a/lib/TextOverlaySupport/TextOverlaySupport.js
+++ b/lib/TextOverlaySupport/TextOverlaySupport.js
@@ -12,11 +12,64 @@ module.exports = {
 
 	name: 'moon.TextOverlay',
 
+	/**
+	* When `true`, the overlay scrim will be marquee
+	*
+	* @name moon.TextOverlaySupport#useoverlaytextmarquee
+	* @type {Boolean}
+	* @default undefinded
+	* @public
+	*/
 	useoverlaytextmarquee: undefined,
+
+	/**
+	* When 1, 2, or 3, the overlay text line number can be set
+	*
+	* @name moon.TextOverlaySupport#overlaytextLineNum
+	* @type {Number}
+	* @default undefinded
+	* @public
+	*/
 	overlaytextLineNum: undefined,
+
+	/**
+	* upper text in scrim
+	*
+	* @name moon.TextOverlaySupport#overlayText
+	* @type {String}
+	* @default ''
+	* @public
+	*/
 	overLayText: '',
+
+	/**
+	* bottom text in scrim
+	*
+	* @name moon.TextOverlaySupport#overlaySubText
+	* @type {String}
+	* @default ''
+	* @public
+	*/
 	overLaySubText: '',
+
+	/**
+	* When `true`, the overlay scrim will be shown
+	*
+	* @name moon.TextOverlaySupport#showScrim
+	* @type {Boolean}
+	* @default undefinded
+	* @public
+	*/
 	showScrim: undefined,
+
+	/**
+	* When `true`, the overlay scrim will be shown only when hover 
+	*
+	* @name moon.TextOverlaySupport#useSpotLightOverlayText
+	* @type {Boolean}
+	* @default undefinded
+	* @public
+	*/
 	useSpotLightOverlayText: undefined,
 
 	create: kind.inherit(function (sup) {
@@ -32,6 +85,7 @@ module.exports = {
 	}),
 	
 	useoverlaytextmarqueeChanged: function(){
+		//initial creation
 		if(this.$.textScrim===undefined){
 		this.createComponent({name:'textScrim', classes: 'enyo-fit moon-text-overlay-support-scrim',  kind: Control, components: [
 				{name:'overLayTextContainer', classes: 'enyo-fit moon-text-overlay-support-scrim-center',  kind: Control, components: [
@@ -40,6 +94,7 @@ module.exports = {
 				}
 		]}, {owner: this});
 		}
+		//to deal with runtime change
 		else{
 			this.$.overLayText.destroy();
 			this.$.overLayTextContainer.createComponent({name:'overLayText', kind: this.useoverlaytextmarquee ? MarqueeText : Control,  classes: this.useoverlaytextmarquee ?  undefined : 'moon-text-overlay-upperText', addBefore: null}, {owner: this});
@@ -60,7 +115,7 @@ module.exports = {
 		this.$.overLaySubText.setContent( this.overLaySubText );
 	},
 	showScrimChanged: function () {
-		this.useSpotLightOverlayText!==true && this.$.textScrim.applyStyle('visibility', this.showScrim ? 'visible' : 'hidden');
+		this.useSpotLightOverlayText !== true && this.$.textScrim.applyStyle('visibility', this.showScrim ? 'visible' : 'hidden');
 	},
 	useSpotLightOverlayTextChanged: function () {	
 		this.addRemoveClass('moon-text-overlay-support', this.useSpotLightOverlayText);

--- a/lib/TextOverlaySupport/TextOverlaySupport.less
+++ b/lib/TextOverlaySupport/TextOverlaySupport.less
@@ -1,0 +1,49 @@
+.moon-text-overlay-support .moon-text-overlay-support-scrim{
+  display: none;
+}
+
+.moon-text-overlay-support.spotlight .moon-text-overlay-support-scrim{
+  display: block;
+}
+
+.moon-text-overlay-support-scrim {
+  background: @moon-text-overlay-support-scrim-background-color;
+}
+
+.moon-text-overlay-support-scrim-center {
+  margin: auto;
+  width: 100%;
+  display: table;
+  table-layout: fixed;
+}
+
+.moon-text-overlay-support-scrim-center > * {
+  position: relative;
+  display: block; 
+  text-align: center;
+  width: @moon-text-overlay-support-text-width;
+  padding-left: @moon-text-overlay-support-text-padding-leftRight;
+  padding-right: @moon-text-overlay-support-text-padding-leftRight;
+  font-family: @moon-upperTextOverlay-font-family;
+  font-size: @moon-text-overlay-support-upperText-font-size;
+  line-height: @moon-text-overlay-support-upperText-line-height;
+
+}
+
+.moon-text-overlay-upperText {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.moon-text-overlay-bottomText {
+  font-family: @moon-bottomTextOverlay-font-family;
+  font-size: @moon-text-overlay-support-bottomText-font-size;
+  line-height: @moon-text-overlay-support-bottomText-line-height;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  color: @moon-text-overlay-support-bottomText-color;
+  margin-top: @moon-text-overlay-support-bottomText-margin-top;
+}

--- a/lib/TextOverlaySupport/package.json
+++ b/lib/TextOverlaySupport/package.json
@@ -1,0 +1,6 @@
+{
+	"main": "TextOverlaySupport.js",
+	"styles": [
+		"TextOverlaySupport.less"
+	]
+}


### PR DESCRIPTION
## Issue

There is a requirement to display text with a scrim in Dreadlocks.
Display text with a scrim over images in an image grid. This could display by default or hide/show on hover.

## Solution

##### 1. For the requirement, I added TextOverlaySupport.less file.

##### 2. Also, I made TextOverlaySupport.js.

 - I made properties for "overLayText" / "overLaySubText" / "showScrim" which user can set anytime.
 - and properties user can set "useoverlaytextmarquee" property to choose usage of marquee or not.
 - If marquee is not used, then '-webkit-line-clamp' style will be applied with "overlaytextLineNum" property set by user.
 - Also, to handle show/hide, I added showScrimChanged.
 - Also, to handle showing scrim only when hover status, "moon-text-overlay-support" class will be applied or not according to "useSpotLightOverlayText" property.

##### 3. for testing, please see https://jira2.lgsvl.com/browse/ENYO-1172 and use "sample.zip" file

This is copy of #2090 for 2.6.0-dev

DCO-1.1-Signed-Off-By: Suhyung Lee suhyung2.lee@lge.com