### PR TITLE
ENYO-1563 : add moon.DayPicker component as a Dreadlocks UX requirements

### DIFF
--- a/lib/DayPicker/DayPicker.js
+++ b/lib/DayPicker/DayPicker.js
@@ -1,0 +1,258 @@
+require('moonstone');
+
+var
+	kind = require('enyo/kind');
+
+var
+	ilib = require('enyo-ilib');
+
+var
+	ExpandablePicker = require('../ExpandablePicker'),
+	$L = require('../i18n');
+
+/**
+* {@link moon.DayPicker}, which extends {@link moon.ExpandablePicker}, is
+* a drop-down picker menu that solicits day of the week from the user.
+*
+* ```
+* {kind: 'moon.DayPicker'}
+* ```
+*
+* When the picker is minimized, the currently selected day are
+* displayed as subtext below the picker label. And if the picker select every weekday,
+* subtext will be changed 'Every Weekday' automatically.
+*
+* The content of representative value can be changed.
+* ```
+* {kind: 'moon.DayPicker', everyWeekdayText:'Weekdays', everyWeekendText:'Weekends', everyDayText:'Daily'}
+* ```
+*
+* @class moon.DayPicker
+* @extends moon.ExpandablePicker
+* @ui
+* @public
+*/
+module.exports = kind(
+	/** @lends moon.DayPicker.prototype */ {
+
+	/**
+	* @private
+	*/
+	name: 'moon.DayPicker',
+
+	/**
+	* @private
+	*/
+	kind: ExpandablePicker,
+
+	/**
+	* @private
+	*/
+	autoCollapseOnSelect: false,
+
+	/**
+	* @private
+	*/
+	multipleSelection: true,
+
+	/**
+	* @private
+	*/
+	content: $L('Select days'),
+
+	/**
+	* @private
+	* @lends moon.DayPicker.prototype
+	*/
+	published: {
+
+		/**
+		* Text to be displayed when all of the day are selected.
+		*
+		* @type {String}
+		* @default 'Every Day'
+		* @public
+		*/
+		everyDayText: $L('Every Day'),
+
+		/**
+		* Text to be displayed when all of the weekday are selected.
+		*
+		* @type {String}
+		* @default 'Every Weekday'
+		* @public
+		*/
+		everyWeekdayText: $L('Every Weekday'),
+
+		/**
+		* Text to be displayed when all of the weekend are selected.
+		*
+		* @type {String}
+		* @default 'Every Weekend'
+		* @public
+		*/
+		everyWeekendText: $L('Every Weekend'),
+
+		/**
+		* Text to be displayed as the current value if no item is currently selected.
+		*
+		* @type {String}
+		* @default 'Nothing selected'
+		* @public
+		*/
+		noneText: $L('Nothing selected')
+	},
+
+	/**
+	* @private
+	*/
+	firstDayOfWeek: 0,
+
+	/**
+	* @private
+	*/
+	weekEndStart: 6,
+
+	/**
+	* @private
+	*/
+	weekEndEnd: 0,
+
+	/**
+	* @private
+	*/
+	tools: [
+		{kind: 'enyo.Signals', onlocalechange: 'handleLocaleChangeEvent'}
+	],
+
+	/**
+	* @private
+	*/
+	daysComponents: [
+		{content: 'Sunday'},
+		{content: 'Monday'},
+		{content: 'Tuesday'},
+		{content: 'Wednesday'},
+		{content: 'Thursday'},
+		{content: 'Friday'},
+		{content: 'Saturday'}
+	],
+
+	/**
+	* @private
+	*/
+	days: ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'],
+
+	/**
+	* @private
+	*/
+	create: kind.inherit(function (sup) {
+		return function() {
+			// super initialization
+			sup.apply(this, arguments);
+			this.createChrome(this.tools);
+			this.initILib();
+			this.createComponents(this.daysComponents);
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	initILib: function () {
+		if (typeof ilib !== 'undefined') {
+			var df = new ilib.DateFmt({length: "full"});
+			var sdf = new ilib.DateFmt({length: "long"});
+			var li = new ilib.LocaleInfo(ilib.getLocale());
+			var daysFullName = df.getDaysOfWeek();
+			this.days = sdf.getDaysOfWeek();
+			this.firstDayOfWeek = li.getFirstDayOfWeek();
+			this.weekEndStart = li.getWeekEndStart ? li.getWeekEndStart() : this.weekEndStart;
+			this.weekEndEnd = li.getWeekEndEnd ? li.getWeekEndEnd() : this.getWeekEndEnd;
+
+			var index;
+			switch (this.firstDayOfWeek) {
+			case 0 :
+				for (index = 0; index < this.daysComponents.length; index++) {
+					this.daysComponents[index].content = daysFullName[index];
+				}
+				break;
+			case 1 :
+				for (index = 1; index < this.daysComponents.length; index++) {
+					this.daysComponents[index-1].content = daysFullName[index];
+				}
+				this.daysComponents[6].content = daysFullName[0];
+				this.days.push(this.days.shift());
+				this.weekEndStart = this.weekEndStart ? this.weekEndStart-1 : 6;
+				this.weekEndEnd = this.weekEndEnd ? this.weekEndEnd-1 : 6;
+				break;
+			}
+		}
+	},
+
+	/**
+	* @private
+	*/
+	handleLocaleChangeEvent: function () {
+		this.destroyClientControls();
+		this.initILib();
+		this.createComponents(this.daysComponents);
+		this.render();
+	},
+
+	/**
+	* @private
+	*/
+	multiSelectCurrentValue: function () {
+		var str = this.checkDays();
+		if (str){
+			return str;
+		}
+
+		for (var i=0; i < this.selectedIndex.length; i++) {
+			if (!str) {
+				str = this.days[this.selectedIndex[i]];
+			} else {
+				str = str + ', ' + this.days[this.selectedIndex[i]];
+			}
+		}
+		return str || this.getNoneText();
+	},
+
+	/**
+	* @private
+	*/
+	checkDays: function () {
+		var indexLength = this.selectedIndex.length;
+		var hasWeekEnd = this.checkWeekEnd();
+
+		switch (indexLength) {
+		case 7 :
+			return this.everyDayText;
+		case 5 :
+			if (hasWeekEnd === false) {
+				return this.everyWeekdayText;
+			}
+			break;
+		case 2 :
+			if (hasWeekEnd === true) {
+				return this.everyWeekendText;
+			}
+			break;
+		}
+	},
+
+	/**
+	* @private
+	*/
+	checkWeekEnd: function () {
+		var bWeekEndStart = this.selectedIndex.indexOf(this.weekEndStart);
+		var bWeekEndEnd = this.selectedIndex.indexOf(this.weekEndEnd);
+
+		if (bWeekEndStart >= 0 && bWeekEndEnd >= 0) {
+			return true;
+		} else if (bWeekEndStart == -1 && bWeekEndEnd == -1) {
+			return false;
+		}
+	}
+});

--- a/lib/DayPicker/package.json
+++ b/lib/DayPicker/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "DayPicker.js"
+}

--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -258,7 +258,9 @@ module.exports = kind(
 	},
 
 	/**
-	* @private
+	*  'multiSelectCurrentValue()' can be overridden by subkinds, such as moon.DayPicker
+	*
+	* @protected
 	*/
 	multiSelectCurrentValue: function () {
 		if (!this.multipleSelection) {


### PR DESCRIPTION
### Issue
There is a requirement for supporting string overlay on Expandable picker in Dreadlocks.
(Especially, it target expandable picker which can select day of the week and shows representative value )

### Solution
For resolving the requirement, make a new kind which inherited from Expandable Picker and add features which are described in ENYO-1563

(* This pr is converted from https://github.com/enyojs/moonstone/pull/1961)

DCO-1.1-Signed-Off-By: Sungbae Cho sb.cho@lge.com