### PR TITLE
ENYO-1579 : Marquee distance is not properly updated at first time, so marquee does not flow entirely

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -830,6 +830,7 @@
 			// Lazy creation of _this.$.marqueeText_
 			if (!this.$.marqueeText) {
 				this._marquee_createMarquee();
+				distance = this._marquee_calcDistance();
 			}
 
 			this._marquee_addAnimationStyles(distance);


### PR DESCRIPTION
## Issue

This issue is found by settings app developer.
In settings app, marquee does not flow entirely with certain language at first time.
From second time, marquee flows entirely.

Step to reproduce:
1. change language by below luna command
luna-send -n 1 luna://com.webos.settingsservice/setSystemSettings '{"settings": {"localeInfo": {"locales":
{ "UI": "ar-SA" }
} } }'
2. go Settings -> Picture -> Aspect Ratio -> cinema zoom
3. focus on last item ( I attached the image)

Problem :
marqueeText does not flowed entirely

Expected :
marqueeText should flow entirely (till end of context)

## FIx
I added line to update distance in '_marquee_startAnimation' function.
The reason why marqueeText does not flow entirely at first time is the distance which will be used in "this._marquee_addAnimationStyles(distance);" is not properly updated after this._marquee_createMarquee() call.
I added lineto update distance after "this._marquee_createMarquee();"

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung2.lee@lge.com