### PR TITLE
ENYO-1331: update PageUp/Down to support horizontal scrolling

### DIFF
--- a/lib/Scroller/Scroller.js
+++ b/lib/Scroller/Scroller.js
@@ -390,14 +390,14 @@ if (platform.touch) {
 			switch (inEvent.keyCode) {
 				case KEY_POINTER_PAGE_UP:
 					if (pageUpKeyCtr.getDisabled()) {
-						strategy.requestSetupBounds();
+						strategy.alertThumbs();
 						break
 					}
 					pageUpKeyCtr.sendPaginateEvent();
 					break
 				case KEY_POINTER_PAGE_DOWN:
 					if (pageDownKeyCtr.getDisabled()) {
-						strategy.requestSetupBounds();
+						strategy.alertThumbs();
 						break
 					}
 					pageDownKeyCtr.sendPaginateEvent();

--- a/lib/Scroller/Scroller.js
+++ b/lib/Scroller/Scroller.js
@@ -182,10 +182,10 @@ if (platform.touch) {
 		handlers: {
 			onSpotlightScrollUp:'spotlightWheel',
 			onSpotlightScrollDown:'spotlightWheel',
-			onSpotlightContainerEnter:'spotlightContainerEnter',
-			onSpotlightContainerLeave:'spotlightContainerLeave',
-			onenter:'enter',
-			onleave:'leave',
+			onSpotlightContainerEnter:'enablePageUpDownKey',
+			onSpotlightContainerLeave:'disablePageUpDownKey',
+			onenter:'enablePageUpDownKey',
+			onleave:'disablePageUpDownKey',
 			onmove:'move'
 		},
 
@@ -340,36 +340,15 @@ if (platform.touch) {
 		/**
 		* @private
 		*/
-		setHandlePageUpDownKey: function (param) {
-			this.handlePageUpDownKey = param;
+		enablePageUpDownKey: function () {
+			this.handlePageUpDownKey = true;
 		},
 
 		/**
 		* @private
 		*/
-		spotlightContainerEnter: function (inSender, inEvent) {
-			this.setHandlePageUpDownKey(true);
-		},
-
-		/**
-		* @private
-		*/
-		spotlightContainerLeave: function (inSender, inEvent) {
-			this.setHandlePageUpDownKey(false);
-		},
-
-		/**
-		* @private
-		*/
-		enter: function (inSender, inEvent) {
-			this.setHandlePageUpDownKey(true);
-		},
-
-		/**
-		* @private
-		*/
-		leave: function (inSender, inEvent) {
-			this.setHandlePageUpDownKey(false);
+		disablePageUpDownKey: function () {
+			this.handlePageUpDownKey = false;
 		},
 
 		/**
@@ -377,7 +356,7 @@ if (platform.touch) {
 		*/
 		move: function (inSender, inEvent) {
 			if (!this.getHandlePageUpDownKey()) {
-				this.setHandlePageUpDownKey(true);
+				this.enablePageUpDownKey();
 			}
 		},
 
@@ -385,18 +364,44 @@ if (platform.touch) {
 		* @private
 		*/
 		keyup: function (inSender, inEvent) {
-			var KEY_POINTER_PAGE_UP = 33;
-			var KEY_POINTER_PAGE_DOWN = 34;
 
-			if (!this.getHandlePageUpDownKey()) {
+			var KEY_POINTER_PAGE_UP = 33;
+				KEY_POINTER_PAGE_DOWN = 34;
+
+			var strategy = this.getStrategy(),
+				showVertical = strategy.showVertical(),
+				showHorizontal = strategy.showHorizontal(),
+				pageUpKeyCtr,
+				pageDownKeyCtr;
+
+			if (!this.getHandlePageUpDownKey() || (showVertical && showHorizontal)) {
 				return;
 			}
 
-			var strategy = this.getStrategy();
-			if (inEvent.keyCode === KEY_POINTER_PAGE_UP) {
-				strategy.$.pageUpControl.sendPaginateEvent();
-			} else if (inEvent.keyCode === KEY_POINTER_PAGE_DOWN) {
-				strategy.$.pageDownControl.sendPaginateEvent();
+			if (showVertical) {
+				pageUpKeyCtr = strategy.$.pageUpControl;
+				pageDownKeyCtr = strategy.$.pageDownControl;
+			}
+			else {
+				pageUpKeyCtr = strategy.$.pageLeftControl;
+				pageDownKeyCtr = strategy.$.pageRightControl;
+			}
+
+			switch (inEvent.keyCode) {
+				case KEY_POINTER_PAGE_UP:
+					if (pageUpKeyCtr.getDisabled()) {
+						strategy.requestSetupBounds();
+						break
+					}
+					pageUpKeyCtr.sendPaginateEvent();
+					break
+				case KEY_POINTER_PAGE_DOWN:
+					if (pageDownKeyCtr.getDisabled()) {
+						strategy.requestSetupBounds();
+						break
+					}
+					pageDownKeyCtr.sendPaginateEvent();
+					break
 			}
 		},
 


### PR DESCRIPTION
### Issue
PageUp/Down Does Not Function in Horizontal Scrolling

### Fix
Update PageUp/Down key to support horizontal scrolling. It scrolls horizontally if app has only horizontal scroll contents, and it go vertically if there is horizontal and vertical scroll contents both.

DCO-1.1-Signed-Off-By: Sungbae Cho sb.cho@lge.com