### PR TITLE
ENYO-1443: ExpandablePicker: Pre-Expanded Picker Does Not Collapse Initially after Selection

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -238,8 +238,8 @@
 		* @private
 		*/
 		rendered: function () {
-			this.inherited(arguments);
-			if (!this.$.drawer.renderOnShow) this.isDrawerRendered = true;
+			this.inherited(arguments);			
+			if (this.getOpen()) this.isDrawerRendered = true;
 		},
 
 		/**

--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -239,7 +239,7 @@
 		*/
 		rendered: function () {
 			this.inherited(arguments);			
-			if (this.getOpen()) this.isDrawerRendered = true;
+			if (!this.$.drawer.renderOnShow || this.getOpen()) this.isDrawerRendered = true;
 		},
 
 		/**


### PR DESCRIPTION
### Issue:
The selectAndClose() get called if the isDrawerRendered property true. But in initially isDrawerRendered property was became false in the render function as the drawer.renderOnShow is always true. This cause the issue that in activated function this.startJob won't fire as the this.isDrawerRendered is false.

### Fix:
Instead of using  drawer.renderOnShow, use this.getOpen() to identify whether the drawer is  already opened and set isDrawerRendered property true in such cases will solve the issue.

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com  