### PR TITLE
ENYO-1443: ExpandablePicker: Pre-Expanded Picker Does Not Collapse Initially after Selection

### DIFF
--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -254,7 +254,7 @@ module.exports = kind(
 	*/
 	rendered: function () {
 		ExpandableListItem.prototype.rendered.apply(this, arguments);
-		if (!this.$.drawer.renderOnShow) this.isDrawerRendered = true;
+		if (this.getOpen()) this.isDrawerRendered = true;
 	},
 
 	/**

--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -254,7 +254,7 @@ module.exports = kind(
 	*/
 	rendered: function () {
 		ExpandableListItem.prototype.rendered.apply(this, arguments);
-		if (this.getOpen()) this.isDrawerRendered = true;
+		if (!this.$.drawer.renderOnShow || this.getOpen()) this.isDrawerRendered = true;
 	},
 
 	/**


### PR DESCRIPTION
### Issue:

The selectAndClose() get called if the isDrawerRendered property true. But in initially isDrawerRendered property was became false in the render function as the drawer.renderOnShow is always true. This cause the issue that in activated function this.startJob won't fire as the this.isDrawerRendered is false.

### Fix:

Instead of using drawer.renderOnShow, use this.getOpen() to identify whether the drawer is already opened and set isDrawerRendered property true in such cases will solve the issue.

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com