### PR TITLE
ENYO-1589: Fix and enhance post transition behavior

### DIFF
--- a/lib/LightPanel/LightPanel.js
+++ b/lib/LightPanel/LightPanel.js
@@ -146,7 +146,7 @@ module.exports = kind(
 	deactivated: function () {},
 
 	/**
-	* This overridable method is called after a transition.
+	* This overridable (or extendable) method is called after a transition.
 	*
 	* @public
 	*/
@@ -155,12 +155,23 @@ module.exports = kind(
 			var owner = this.hasOwnProperty('clientComponents') ? this.getInstanceOwner() : this;
 			this.createComponents(this.clientComponents, {owner: owner});
 			this.$.client.render();
-			this.$.client.addClass('populated');
+			this.didClientRender();
 		}
 
 		if (!Spotlight.getCurrent()) {
 			Spotlight.spot(this);
 		}
+	},
+
+	/**
+	* This overridable (extendable) method is called when the client area has been rendered. This
+	* can be used to perform any actions that should occur once the client components, for example,
+	* of the {@link moon.LightPanel} have been created and rendered, such as custom focusing logic.
+	*
+	* @public
+	*/
+	didClientRender: function () {
+		this.$.client.addClass('populated');
 	}
 
 });


### PR DESCRIPTION
### Issue
We are currently attempting to spot the current panel if there is no spotlight focus, without taking into account pointer mode and/or whether or not the current item is spottable. Additionally, we want to allow for custom logic to be executed once the deferred client components have actually been created and rendered.

### Fix
I've cherry-picked the following commit from @KunmyonChoi to resolve the first issue: https://github.com/enyojs/moonstone/commit/568ef3784e50d4eeaa6284edd8702124e4edb5. And for the second issue, we've followed the pattern of `enyo.DataList` and execute the `didClientRender` method if applicable.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>