### PR TITLE
Qtd 2176 ListAction: Stacked value set to false when drawer is opened one more time.

### DIFF
--- a/lib/Header/Header.js
+++ b/lib/Header/Header.js
@@ -805,6 +805,6 @@ module.exports = kind(
 		if (!inEvent.open) {
 			return;
 		}
-		inEvent.originator.beforeOpenDrawer(this.standardHeight, this.get('type'));
+		inEvent.originator.beforeOpenDrawer(this.standardHeight);
 	}
 });

--- a/lib/ListActions/ListActions.js
+++ b/lib/ListActions/ListActions.js
@@ -629,7 +629,7 @@ var ListActions = module.exports = kind(
 	*/
 	shouldStack: function() {
 		// Assumption: min-width of all listActionsComponents set to 300px in CSS
-		return this.$.listActions.getBounds().width < (300 * this.listActionComponents.length);
+		return this.$.listActions.getBounds().width < (ri.scale(300) * this.listActionComponents.length);
 	},
 
 	/**

--- a/lib/ListActions/ListActions.js
+++ b/lib/ListActions/ListActions.js
@@ -536,11 +536,8 @@ var ListActions = module.exports = kind(
 	/**
 	* @private
 	*/
-	beforeOpenDrawer: function(standardHeight, type) {
+	beforeOpenDrawer: function(standardHeight) {
 		this.standardHeight = standardHeight;
-		if (type !== 'large') {
-			this.set('stacked', false);
-		}
 	},
 
 	//TODO: Remove the onListActionOpenChanged event. It will be deprecated in favor of the onShow/onHide events


### PR DESCRIPTION
Issue
-------
`stacked` property on ListAction become false even though it was true when we open drawer again

Cause
--------
-moon.Header set it false when drawer open again.
-min-width of listAction group does not change when resolution is changed

Fix
----
-Prevent moon.Header to change `stacked` property. 
-Use ri.scale for min-width value

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com