### PR TITLE
ENYO-510 : Modified so to pass custom placeholder to GridListImageIte…

### DIFF
--- a/lib/GridListImageItem/GridListImageItem.js
+++ b/lib/GridListImageItem/GridListImageItem.js
@@ -6,7 +6,8 @@ require('moonstone');
 */
 
 var
-	kind = require('enyo/kind');
+	kind = require('enyo/kind'),
+	Image = require('enyo/Image');
 
 var
 	GridListImageItem = require('layout/GridListImageItem');
@@ -58,17 +59,9 @@ module.exports = kind(
 
 	/**
 	* @private
-	* @lends moon.GridListImageItem.prototype
 	*/
-	published: {
-		/**
-		* @type {String}
-		* @default enyo.Image.placeholder
-		* @public
-		*/
-		placeholder: Image.placeholder
-		
-	},
+	placeholder: Image.placeholder,
+
 	/**
 	* @private
 	*/

--- a/lib/GridListImageItem/GridListImageItem.js
+++ b/lib/GridListImageItem/GridListImageItem.js
@@ -58,6 +58,19 @@ module.exports = kind(
 
 	/**
 	* @private
+	* @lends moon.GridListImageItem.prototype
+	*/
+	published: {
+		/**
+		* @type {String}
+		* @default enyo.Image.placeholder
+		* @public
+		*/
+		placeholder: Image.placeholder
+		
+	},
+	/**
+	* @private
 	*/
 	spotlight: true,
 

--- a/lib/GridListImageItem/GridListImageItem.less
+++ b/lib/GridListImageItem/GridListImageItem.less
@@ -46,11 +46,11 @@
 		}
 
 		&.use-caption.use-subcaption {
-			padding-bottom: 84px;
+			padding-bottom: 96px;
 
 			> .caption {
 				position: absolute;
-				bottom: 36px;
+				bottom: 48px;
 			}
 		}
 	}
@@ -59,6 +59,10 @@
 	.moon-image {
 		display: block;
 		margin: 0;
+	}
+
+	&:not(.sized-image) {
+		padding-bottom: 96px;
 	}
 }
 

--- a/lib/Image/Image.js
+++ b/lib/Image/Image.js
@@ -117,7 +117,16 @@ module.exports = kind(
 		* @default ''
 		* @public
 		*/
-		position: ''
+		position: '',
+
+		/**
+		* See {@link enyo.Image#placeholder}
+		*
+		* @type {String}
+		* @default ''
+		* @public
+		*/
+		placeholder: ''
 	},
 
 	/**
@@ -134,7 +143,8 @@ module.exports = kind(
 		{from: 'src', to: '$.image.src'},
 		{from: 'alt', to: '$.image.alt'},
 		{from: 'sizing', to: '$.image.sizing'},
-		{from: 'position', to: '$.image.position'}
+		{from: 'position', to: '$.image.position'},
+		{from: 'placeholder', to: '$.image.placeholder'}
 	],
 
 	/**


### PR DESCRIPTION
…m kind

Issue:

There was no placeholder in image grid, and image gets displayed once loaded. In between grid remains empty.

Fix:

Using multiple background images through css, we can set the placeholder, a static image, which will be seen until the image gets loaded and will be replaced.

Enyo-DCO-1.1-Signed-off-by: Rakesh kumar rakesh25.kumar@lge.com