### PR TITLE
ENYO-1648: Increase moveTolerance value from 16 to 1500 on configureH…

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,7 @@ exports.version = '2.6.0-pre';
 // Override the default holdpulse config to account for greater delays between keydown and keyup
 // events in Moonstone with certain input devices.
 gesture.drag.configureHoldPulse({
-	frequency: 200,
 	events: [{name: 'hold', time: 400}],
-	resume: false,
-	moveTolerance: 16,
 	endHold: 'onLeave'
 });
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ gesture.drag.configureHoldPulse({
 	frequency: 200,
 	events: [{name: 'hold', time: 400}],
 	resume: false,
-	moveTolerance: 16,
+	moveTolerance: 1500,
 	endHold: 'onMove'
 });
 

--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ gesture.drag.configureHoldPulse({
 	frequency: 200,
 	events: [{name: 'hold', time: 400}],
 	resume: false,
-	moveTolerance: 1500,
-	endHold: 'onMove'
+	moveTolerance: 16,
+	endHold: 'onLeave'
 });
 
 /**

--- a/lib/IntegerPicker/IntegerPicker.js
+++ b/lib/IntegerPicker/IntegerPicker.js
@@ -454,7 +454,7 @@ module.exports = kind(
 	* @private
 	*/
 	downPrevious: function (inSender, inEvent) {
-		inEvent.configureHoldPulse({endHold: 'onLeave', delay: 300});
+		inEvent.configureHoldPulse({delay: 300});
 		this.previous(inSender, inEvent);
 	},
 
@@ -462,7 +462,7 @@ module.exports = kind(
 	* @private
 	*/
 	downNext: function (inSender, inEvent) {
-		inEvent.configureHoldPulse({endHold: 'onLeave', delay: 300});
+		inEvent.configureHoldPulse({delay: 300});
 		this.next(inSender, inEvent);
 	},
 

--- a/lib/IntegerPicker/IntegerPicker.js
+++ b/lib/IntegerPicker/IntegerPicker.js
@@ -454,7 +454,6 @@ module.exports = kind(
 	* @private
 	*/
 	downPrevious: function (inSender, inEvent) {
-		inEvent.configureHoldPulse({delay: 300});
 		this.previous(inSender, inEvent);
 	},
 
@@ -462,7 +461,6 @@ module.exports = kind(
 	* @private
 	*/
 	downNext: function (inSender, inEvent) {
-		inEvent.configureHoldPulse({delay: 300});
 		this.next(inSender, inEvent);
 	},
 

--- a/lib/SimplePicker/SimplePicker.js
+++ b/lib/SimplePicker/SimplePicker.js
@@ -13,7 +13,7 @@ var
 
 /**
 * Fires when the currently selected item changes.
-* 
+*
 * @event moon.SimplePicker#onChange
 * @type {Object}
 * @property {enyo.Control} selected - A reference to the currently selected item.
@@ -35,10 +35,10 @@ var
 *	{content: 'Tokyo'}
 * ]}
 * ```
-* 
+*
 * The picker may be changed programmatically by calling
-* [previous()]{@link moon.SimplePicker#previous} or [next()]{@link moon.SimplePicker#next}, 
-* or by modifying the [selectedIndex]{@link moon.SimplePicker#selectedIndex} published 
+* [previous()]{@link moon.SimplePicker#previous} or [next()]{@link moon.SimplePicker#next},
+* or by modifying the [selectedIndex]{@link moon.SimplePicker#selectedIndex} published
 * property by calling `set('selectedIndex', <value>)`.
 *
 * The picker options may be modified programmatically in the standard manner, by calling
@@ -423,7 +423,7 @@ module.exports = kind(
 	* @private
 	*/
 	downLeft: function(sender, e) {
-		e.configureHoldPulse({endHold: 'onLeave', delay: 300});
+		e.configureHoldPulse({delay: 300});
 		this.left(sender, e);
 	},
 
@@ -431,7 +431,7 @@ module.exports = kind(
 	* @private
 	*/
 	downRight: function(sender, e) {
-		e.configureHoldPulse({endHold: 'onLeave', delay: 300});
+		e.configureHoldPulse({delay: 300});
 		this.right(sender, e);
 	},
 
@@ -440,11 +440,11 @@ module.exports = kind(
 	*/
 	configureSpotlightHoldPulse: function(sender, e) {
 		if (e.keyCode === 13) {
-			e.configureHoldPulse({endHold: 'onLeave', delay: 300});
+			e.configureHoldPulse({delay: 300});
 		}
 	},
 
-	/** 
+	/**
 	* Cycles the selected item to the one before the currently selected item. If chained from
 	* an event, {@link Spotlight} hold pulse events will be canceled once the first item is
 	* reached, unless [wrap]{@link moon.SimplePicker#wrap} is `true`. When calling this method
@@ -467,7 +467,7 @@ module.exports = kind(
 		}
 	},
 
-	/** 
+	/**
 	* Cycles the selected item to the one after the currently selected item. If chained from
 	* an event, {@link Spotlight} hold pulse events will be canceled once the last item is
 	* reached, unless [wrap]{@link moon.SimplePicker#wrap} is `true`. When calling this method

--- a/lib/SimplePicker/SimplePicker.js
+++ b/lib/SimplePicker/SimplePicker.js
@@ -167,11 +167,11 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{name: 'buttonLeft',  kind: IconButton, noBackground:true, classes: 'moon-simple-picker-button left', icon:'arrowlargeleft', onSpotlightKeyDown:'configureSpotlightHoldPulse', onSpotlightSelect: 'left', ondown: 'downLeft', onholdpulse:'left', defaultSpotlightDisappear: 'buttonRight'},
+		{name: 'buttonLeft',  kind: IconButton, noBackground:true, classes: 'moon-simple-picker-button left', icon:'arrowlargeleft', onSpotlightSelect: 'left', ondown: 'downLeft', onholdpulse:'left', defaultSpotlightDisappear: 'buttonRight'},
 		{name: 'clientWrapper', kind: Control, classes:'moon-simple-picker-client-wrapper', components: [
 			{name: 'client', kind: Control, classes: 'moon-simple-picker-client'}
 		]},
-		{name: 'buttonRight', kind: IconButton, noBackground:true, classes: 'moon-simple-picker-button right', icon:'arrowlargeright', onSpotlightKeyDown:'configureSpotlightHoldPulse', onSpotlightSelect: 'right', ondown: 'downRight', onholdpulse:'right', defaultSpotlightDisappear: 'buttonLeft'}
+		{name: 'buttonRight', kind: IconButton, noBackground:true, classes: 'moon-simple-picker-button right', icon:'arrowlargeright', onSpotlightSelect: 'right', ondown: 'downRight', onholdpulse:'right', defaultSpotlightDisappear: 'buttonLeft'}
 	],
 
 	/**
@@ -423,7 +423,6 @@ module.exports = kind(
 	* @private
 	*/
 	downLeft: function(sender, e) {
-		e.configureHoldPulse({delay: 300});
 		this.left(sender, e);
 	},
 
@@ -431,17 +430,7 @@ module.exports = kind(
 	* @private
 	*/
 	downRight: function(sender, e) {
-		e.configureHoldPulse({delay: 300});
 		this.right(sender, e);
-	},
-
-	/**
-	* @private
-	*/
-	configureSpotlightHoldPulse: function(sender, e) {
-		if (e.keyCode === 13) {
-			e.configureHoldPulse({delay: 300});
-		}
 	},
 
 	/**


### PR DESCRIPTION
…oldPulse

Issue:
- The onHoldPulse event is canceled too early when user move mouse abound.

Fix:
- We need higher moveTolerance value to make it stay pulse more on TV.
- Increase moveTolerance value from 16 to 1500 on configureHoldPulse by testing.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com