### PR TITLE
ENYO-1653: Hide the jump increment slider buttons.

### DIFF
--- a/lib/VideoTransportSlider/VideoTransportSlider.js
+++ b/lib/VideoTransportSlider/VideoTransportSlider.js
@@ -111,6 +111,11 @@ module.exports = kind(
 
 	/**
 	* @private
+	*/
+	enableJumpIncrement: false,
+
+	/**
+	* @private
 	* @lends moon.VideoTransportSlider.prototype
 	*/
 	published: {


### PR DESCRIPTION
### Issue
With the update in https://github.com/enyojs/moonstone/pull/2131, we added "jump increment" buttons to `moon.Slider`, which are enabled by default. We missed the fact that there is another control, `moon.VideoTransportSlider`, that subkinds `moon.Slider` and is not interested in these buttons. 

### Fix
We now set `enableJumpIncrement` to `false` for `moon.VideoTransportSlider`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>