### PR TITLE
ENYO-1288 : Transparent button in image header and full image pattern. (rank: 27)

### DIFF
--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -21,6 +21,8 @@
 @moon-spotlight-border-color:         @moon-accent;
 @moon-spotlight-color:                @moon-accent;
 @moon-button-background-color:        #4d4d4d;
+@moon-button-translucent-font-color:  #d5d5d5;
+@moon-button-translucent-background-color:        rgb(255, 255, 255);
 @moon-divider-border-color:           #595959;
 @moon-active-border-color:            #a6a6a6;
 @moon-button-disabled-bg-color:       #262626;

--- a/lib/Button/Button.less
+++ b/lib/Button/Button.less
@@ -36,20 +36,20 @@
 	&.spotlight.pressed,
 	&.spotlight:active {
 		border: @moon-button-border-width solid @moon-spotlight-border-color;
-		background-color: @moon-button-background-color;
-		color: @moon-button-text-color;
+		background-color: @moon-button-background-color !important;
+		color: @moon-button-text-color !important;
 	}
 
 	&.spotlight {
-		background-color: @moon-spotlight-border-color;
-		color: @moon-spotlight-text-color;
+		background-color: @moon-spotlight-border-color !important;
+		color: @moon-spotlight-text-color !important;
 	}
 
 	// 'Selected+Focus' state
 	&.active.spotlight:not(.contextual-popup-button) {
 		border-color: @moon-active-spotlight-border-color;
-		background-color: @moon-spotlight-border-color;
-		color: @moon-spotlight-text-color;
+		background-color: @moon-spotlight-border-color !important;
+		color: @moon-spotlight-text-color !important;
 
 		&:active,
 		&.pressed {
@@ -103,10 +103,10 @@
 	}
 
 	&.spotlight {
-		background-color: @moon-spotlight-color;
+		background-color: @moon-spotlight-color !important;
 
 		* {
-			color: @moon-spotlight-text-color;
+			color: @moon-spotlight-text-color !important;
 		}
 	}
 
@@ -115,10 +115,10 @@
 	&.spotlight.pressed,
 	&.spotlight:active {
 		border: @moon-button-border-width solid @moon-spotlight-border-color;
-		background-color: @moon-neutral-button-bg-color;
+		background-color: @moon-neutral-button-bg-color !important;
 
 		* {
-			color: @moon-neutral-button-text-color;
+			color: @moon-neutral-button-text-color !important;
 		}
 	}
 

--- a/lib/Header/Header.js
+++ b/lib/Header/Header.js
@@ -230,7 +230,26 @@ module.exports = kind(
 		* @default null
 		* @public
 		*/
-		titleUpperCase: null
+		titleUpperCase: null,
+
+		/**
+		* When `true`, the buttons in header will be transparent.
+		*
+		* @type {Boolean}
+		* @default false
+		* @public
+		*/
+		translucentButtons: false,
+
+		/**
+		* translucentAmount will be applied to the buttons in header.
+		*
+		* @type {Number}
+		* @default 30
+		* @public
+		*/
+		translucentAmount: 30
+
 	},
 
 	/**
@@ -342,6 +361,9 @@ module.exports = kind(
 		this.inputModeChanged();
 		this.placeholderChanged();
 		this.fullBleedBackgroundChanged();
+		if(this.translucentButtons){
+			this.translucentAmountChanged();
+		}
 	},
 
 	rendered: function() {
@@ -806,5 +828,22 @@ module.exports = kind(
 			return;
 		}
 		inEvent.originator.beforeOpenDrawer(this.standardHeight, this.get('type'));
+	},
+
+	translucentButtonsChanged: function(){
+		if(this.translucentButtons){
+			this.translucentAmountChanged();
+		}
+		else{
+			this.removeClass('translucentBy' + this.translucentAmount + '-buttons');
+		}
+	},
+
+	translucentAmountChanged: function(inOldvalue){
+		if(this.translucentButtons){
+			this.removeClass('translucentBy' + inOldvalue + '-buttons');
+			this.addClass('translucentBy' + this.translucentAmount + '-buttons');
+		}
 	}
+
 });

--- a/lib/Header/Header.less
+++ b/lib/Header/Header.less
@@ -112,6 +112,50 @@
 	.moon-header-client-text {
 		line-height: @moon-button-small-height;
 	}
+
+	//to handle transparent
+	.translucent-buttons(@translucent) {
+		color: @moon-button-translucent-font-color;
+		.moon-icon-button, .moon-button {
+			background-color: fade(@moon-button-translucent-background-color, @translucent);
+		}
+	}
+
+	&.translucentBy10-buttons {
+		.translucent-buttons(10%);
+	}
+
+	&.translucentBy20-buttons {
+		.translucent-buttons(20%);
+	}
+
+	&.translucentBy30-buttons {
+		.translucent-buttons(30%);
+	}
+
+	&.translucentBy40-buttons {
+		.translucent-buttons(40%);
+	}
+
+	&.translucentBy50-buttons {
+		.translucent-buttons(50%);
+	}
+
+	&.translucentBy60-buttons {
+		.translucent-buttons(60%);
+	}
+
+	&.translucentBy70-buttons {
+		.translucent-buttons(70%);
+	}
+
+	&.translucentBy80-buttons {
+		.translucent-buttons(80%);
+	}
+
+	&.translucentBy90-buttons {
+		.translucent-buttons(90%);
+	}
 }
 
 // neutral

--- a/lib/IconButton/IconButton.less
+++ b/lib/IconButton/IconButton.less
@@ -26,8 +26,8 @@
 
 	&.hover:hover:not(.disabled),
 	&.spotlight {
-		color: @moon-spotlight-text-color;
-		background-color: @moon-icon-button-spotlight-bg-color;
+		color: @moon-spotlight-text-color !important;
+		background-color: @moon-icon-button-spotlight-bg-color !important;
 		background-position: center -@moon-icon-sprite-size;
 
 		&.small {
@@ -39,8 +39,8 @@
 	&:active,
 	&.pressed,
 	&.hover:hover:not(.disabled):active {
-		color: @moon-icon-button-font-color;
-		background-color: @moon-icon-button-active-bg-color;
+		color: @moon-icon-button-font-color !important;
+		background-color: @moon-icon-button-active-bg-color !important;
 		background-position: center 0;
 		border-color: @moon-icon-button-active-border-color;
 
@@ -66,8 +66,8 @@
 	// 'Selected+Focus' state
 	&.active.spotlight:not(.contextual-popup-button) {
 		border-color: @moon-active-spotlight-border-color;
-		background-color: @moon-icon-button-spotlight-bg-color;
-		color: @moon-spotlight-text-color;
+		background-color: @moon-icon-button-spotlight-bg-color !important;
+		color: @moon-spotlight-text-color !important;
 
 		&:active,
 		&.pressed {


### PR DESCRIPTION
## Issue
There is a requirement to display transparent buttons in panel's header in Dreadlock

## Solution

 - in Header.less, I added 9 classes from 10-transparency to 90-transparency
 - Framework provides only [10, 20, 30, 40, 50, 60, 70, 80, 90] transparency which can be set.
 - in Header.js, I added two properties ( translucentButtons which can make buttons be transparent and translucentAmount which can set how much transparent).
 - Because class that will be applied from Header.less override spotlight related css, I added '!important' in Button.less and IconButton.less

Enyo-DCO-1.1-signed-off-by: Suhyung Lee suhyung2.lee@lge.com