### PR TITLE
ENYO-1649: scrollToControl makes scroller shake on rtl case

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -961,6 +961,9 @@
 				x,
 				y
 			;
+			
+			controlBounds.right = document.body.offsetWidth - controlBounds.right;
+			absoluteBounds.right = document.body.offsetWidth - absoluteBounds.right;
 
 			// Make absolute controlBounds relative to scroll position
 			controlBounds.top += scrollBounds.top;
@@ -971,7 +974,7 @@
 			}
 
 			offsetTop      = controlBounds.top - absoluteBounds.top;
-			offsetLeft     = (this.rtl ? absoluteBounds.right : controlBounds.left) - (this.rtl ? controlBounds.right : absoluteBounds.left);
+			offsetLeft     = (this.rtl ? controlBounds.right : controlBounds.left) - (this.rtl ? absoluteBounds.right : absoluteBounds.left);
 			offsetHeight   = controlBounds.height;
 			offsetWidth    = controlBounds.width;
 

--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -971,7 +971,7 @@
 			}
 
 			offsetTop      = controlBounds.top - absoluteBounds.top;
-			offsetLeft     = (this.rtl ? controlBounds.right : controlBounds.left) - (this.rtl ? absoluteBounds.right : absoluteBounds.left);
+			offsetLeft     = (this.rtl ? absoluteBounds.right : controlBounds.left) - (this.rtl ? controlBounds.right : absoluteBounds.left);
 			offsetHeight   = controlBounds.height;
 			offsetWidth    = controlBounds.width;
 


### PR DESCRIPTION
Issue:
- getAbsoluteBounds right value was measured from the right edge before https://github.com/enyojs/enyo/commit/c1189eef1fb245badaa3ac9d22af930cda678183 commit.
- Now right value is measured from the left edge. So, controlBounds.right - absoluteBounds.right is negative value.

Fix:
- Reverse offsetLeft calculation to it can have positive value.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com