### PR TITLE
ENYO-1224: ContextualPopup: Nothing is Spottable outside of Spotlight Modal Off

### DIFF
--- a/samples/ContextualPopupSample.js
+++ b/samples/ContextualPopupSample.js
@@ -147,14 +147,14 @@ enyo.kind({
 			{
 				kind: 'moon.ContextualPopup',
 				name: 'buttonPopup',
-				classes: 'moon-8h moon-8v',
+				classes: 'moon-9h moon-8v',
 				modal: true,
 				autoDismiss: false,
 				spotlightModal: true,
 				components: [
 					{kind: 'moon.Scroller', horizontal: 'auto', classes: 'enyo-fill', components: [
-						{kind: 'moon.Button', content: 'Button'},
-						{kind: 'moon.ToggleButton', content: 'SpotlightModal', value: true, ontap: 'buttonToggled'},
+						{kind: 'moon.ToggleButton', content: 'SpotlightModal',  value: true, ontap: 'buttonToggled'},
+						{kind: 'moon.ToggleButton', content: 'Modal', value: true, ontap: 'modelToggled'},
 						{tag: 'br'},
 						{tag: 'br'},
 						{kind: 'moon.InputDecorator', spotlight: true, components: [
@@ -219,6 +219,9 @@ enyo.kind({
 			return val;
 		}}
 	],
+	modelToggled: function(inSender, inEvent) {
+		this.$.buttonPopup.setModal(inSender.getActive());
+	},
 	buttonToggled: function(inSender, inEvent) {
 		this.$.buttonPopup.setSpotlightModal(inSender.getActive());
 		this.$.buttonPopup.setAutoDismiss(!inSender.getActive());

--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -105,6 +105,12 @@
 			*/
 			spotlightModal: false,
 
+			/* @type {Boolean}
+			* @default false
+			* @public
+			*/
+			modal: false,
+
 			/**
 			* If `false`, the close button is hidden; if `true`, it is shown. When this
 			* property is set to `'auto'` (the default), the close button is shown when
@@ -177,6 +183,10 @@
 		* @private
 		*/
 		activator: null,
+
+		bindings: [
+			{from: 'spotlightModal', to: 'modal', oneWay: false}
+		],
 
 		/**
 		* @private
@@ -448,6 +458,13 @@
 		},
 
 		/**
+		* @private
+		*/
+		modalChanged: function() {
+			this.showHideScrim(this.showing);
+		},
+
+		/**
 		* Called when [showCloseButton]{@link moon.ContextualPopup#showCloseButton} changes.
 		*
 		* @private
@@ -509,7 +526,7 @@
 		* @private
 		*/
 		showHideScrim: function (inShow) {
-			if (this.floating && (this.scrim || (this.modal && this.scrimWhenModal))) {
+			if (this.floating && (this.scrim || this.modal || this.scrimWhenModal)) {
 				var scrim = this.getScrim();
 				if (inShow && this.modal && this.scrimWhenModal) {
 					// move scrim to just under the popup to obscure rest of screen
@@ -538,7 +555,7 @@
 			// show a transparent scrim for modal popups if
 			// {@link moon.ContextualPopup#scrimWhenModal} is `true`, else show a
 			// regular scrim.
-			if (this.modal && this.scrimWhenModal) {
+			if (this.scrimWhenModal) {
 				return moon.scrimTransparent.make();
 			}
 			return moon.scrim.make();


### PR DESCRIPTION
### issue:
The components outside the contextual popup were not spottable even after the spotlightModal property set to false for the contextual popup. The spotlightModal property doesn't  use for show/hide the scrim which caused this issue. 

### Fix
It was the modal property used for show/hide the scrim, so that the modal and spotlightModal are binded together and the this.showHideScrim() function called on modelChanged will solve the issue.

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com