### PR TITLE
ENYO-1224: ContextualPopup: Nothing is Spottable outside of Spotlight Modal Off

### DIFF
--- a/lib/ContextualPopup/ContextualPopup.js
+++ b/lib/ContextualPopup/ContextualPopup.js
@@ -127,6 +127,12 @@ module.exports = kind(
 		*/
 		spotlightModal: false,
 
+		/* @type {Boolean}
+		* @default false
+		* @public
+		*/
+		modal: false,
+
 		/**
 		* If `false`, the close button is hidden; if `true`, it is shown. When this
 		* property is set to `'auto'` (the default), the close button is shown when
@@ -200,6 +206,9 @@ module.exports = kind(
 	*/
 	activator: null,
 
+	bindings: [
+		{from: 'spotlightModal', to: 'modal', oneWay: false}
+	],
 	/**
 	* @private
 	*/
@@ -471,6 +480,13 @@ module.exports = kind(
 	},
 
 	/**
+	* @private
+	*/
+	modalChanged: function() {
+		this.showHideScrim(this.showing);
+	},
+
+	/**
 	* Called when [showCloseButton]{@link moon.ContextualPopup#showCloseButton} changes.
 	*
 	* @private
@@ -533,7 +549,7 @@ module.exports = kind(
 	* @private
 	*/
 	showHideScrim: function (inShow) {
-		if (this.floating && (this.scrim || (this.modal && this.scrimWhenModal))) {
+		if (this.floating && (this.scrim || this.modal || this.scrimWhenModal)) {
 			var scrim = this.getScrim();
 			if (inShow && this.modal && this.scrimWhenModal) {
 				// move scrim to just under the popup to obscure rest of screen
@@ -562,7 +578,7 @@ module.exports = kind(
 		// show a transparent scrim for modal popups if
 		// {@link moon.ContextualPopup#scrimWhenModal} is `true`, else show a
 		// regular scrim.
-		if (this.modal && this.scrimWhenModal) {
+		if (this.scrimWhenModal) {
 			return Scrim.scrimTransparent.make();
 		}
 		return Scrim.make();

--- a/lib/ContextualPopup/ContextualPopup.js
+++ b/lib/ContextualPopup/ContextualPopup.js
@@ -206,9 +206,13 @@ module.exports = kind(
 	*/
 	activator: null,
 
-	bindings: [
-		{from: 'spotlightModal', to: 'modal', oneWay: false}
+	/**
+	* @private
+	*/
+	observers: [
+		{method: 'updateScrim', path: [ 'modal', 'spotlightModal', 'floating', 'scrim', 'scrimWhenModal' ]}
 	],
+
 	/**
 	* @private
 	*/
@@ -480,13 +484,6 @@ module.exports = kind(
 	},
 
 	/**
-	* @private
-	*/
-	modalChanged: function() {
-		this.showHideScrim(this.showing);
-	},
-
-	/**
 	* Called when [showCloseButton]{@link moon.ContextualPopup#showCloseButton} changes.
 	*
 	* @private
@@ -548,18 +545,32 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	updateScrim: function (old, value, source) {
+		// We sync modal and spotlightModal here because binding doesn't guarantee sequence
+		// when it is used with observers.
+		if (source == 'modal') this.set('spotlightModal', this.modal);
+		if (source == 'spotlightModal') this.set('modal', this.spotlightModal);
+		this.showHideScrim(this.showing);
+	},
+
+	/**
+	* @private
+	*/
 	showHideScrim: function (inShow) {
-		if (this.floating && (this.scrim || this.modal || this.scrimWhenModal)) {
-			var scrim = this.getScrim();
-			if (inShow && this.modal && this.scrimWhenModal) {
+		if (this.floating && (this.scrim || (this.modal && this.scrimWhenModal))) {
+			this._scrim = this.getScrim();
+			if (inShow) {
 				// move scrim to just under the popup to obscure rest of screen
 				var i = this.getScrimZIndex();
 				this._scrimZ = i;
-				scrim.showAtZIndex(i);
+				this._scrim.showAtZIndex(i);
 			} else {
-				scrim.hideAtZIndex(this._scrimZ);
+				this._scrim.hideAtZIndex(this._scrimZ);
 			}
-			util.call(scrim, 'addRemoveClass', [this.scrimClassName, scrim.showing]);
+			util.call(this._scrim, 'addRemoveClass', [this.scrimClassName, this._scrim.showing]);
+		} else {
+			// clean up scrim here when showHideScrim is not called from showingChanged
+			this._scrim && this._scrim.hideAtZIndex(this._scrimZ);
 		}
 	},
 
@@ -578,7 +589,7 @@ module.exports = kind(
 		// show a transparent scrim for modal popups if
 		// {@link moon.ContextualPopup#scrimWhenModal} is `true`, else show a
 		// regular scrim.
-		if (this.scrimWhenModal) {
+		if (this.modal && this.scrimWhenModal && !this.scrim) {
 			return Scrim.scrimTransparent.make();
 		}
 		return Scrim.make();


### PR DESCRIPTION
### Issue:

The components outside the contextual popup were not spottable even after the spotlightModal property set to false for the contextual popup. The spotlightModal property doesn't use for show/hide the scrim which caused this issue.

### Fix

It was the modal property used for show/hide the scrim, so that the modal and spotlightModal are binded together and the this.showHideScrim() function called on modelChanged will solve the issue.

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com