### PR TITLE
Enyo-1313-InputHeader: Placeholder Does Not Display Focus State

### DIFF
--- a/lib/InputHeader/InputHeader.less
+++ b/lib/InputHeader/InputHeader.less
@@ -49,3 +49,9 @@
 .moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-moz-input-placeholder {
 	color: @moon-input-header-placeholder-color;
 }
+.moon-input-header-input-decorator.spotlight > .moon-input::-webkit-input-placeholder {
+	color: @moon-spotlight-text-color;
+}
+.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder {
+	color: @moon-input-header-placeholder-color;
+}


### PR DESCRIPTION
Issue: when we hover on the input field of Header, placeholder and input
text is not getting the focus.

Cause: lack of css classes.

Fix: added required CSS classes to achieve the same.

DCO-1.1-Signed-Off-By: Srinivas V srinivas.v@lge.com