### PR TITLE
ENYO-1054: Accessibility: add text to speech accessibility support to…

### DIFF
--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	Component = require('enyo/Component'),
 	Control = require('enyo/Control'),
 	Group = require('enyo/Group');
@@ -21,7 +22,8 @@ var
 	ExpandableListItem = require('../ExpandableListItem'),
 	Item = require('../Item'),
 	Marquee = require('../Marquee'),
-	MarqueeText = Marquee.Text;
+	MarqueeText = Marquee.Text,
+	ExpandablePickerAccessibilitySupport = require('./ExpandablePickerAccessibilitySupport');
 
 /**
 * Fires when the currently selected item changes.
@@ -102,6 +104,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: ExpandableListItem,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [ExpandablePickerAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/ExpandablePicker/ExpandablePickerAccessibilitySupport.js
+++ b/lib/ExpandablePicker/ExpandablePickerAccessibilitySupport.js
@@ -13,15 +13,15 @@ module.exports = {
 	initAccessibility: kind.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
-			this.$.currentValue.observe('content', this.valueChanged, this);
-			this.valueChanged();
+			this.$.currentValue.observe('content', this.changeLabel, this);
+			this.changeLabel();
 		};
 	}),
 
 	/**
 	* @private
 	*/
-	valueChanged: function() {
+	changeLabel: function() {
 		this.set('accessibilityHint', this.$.currentValue.getContent());
 	}
 };

--- a/lib/ExpandablePicker/ExpandablePickerAccessibilitySupport.js
+++ b/lib/ExpandablePicker/ExpandablePickerAccessibilitySupport.js
@@ -1,0 +1,27 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name ExpandablePickerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.$.currentValue.observe('content', this.valueChanged, this);
+			this.valueChanged();
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	valueChanged: function() {
+		this.set('accessibilityHint', this.$.currentValue.getContent());
+	}
+};

--- a/lib/VideoPlayer/VideoPlayer.js
+++ b/lib/VideoPlayer/VideoPlayer.js
@@ -9,6 +9,7 @@ var
 	dispatcher = require('enyo/dispatcher'),
 	dom = require('enyo/dom'),
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	util = require('enyo/utils'),
 	Animator = require('enyo/Animator'),
 	Control = require('enyo/Control'),
@@ -33,7 +34,8 @@ var
 	HistorySupport = MoonHistory.HistorySupport,
 	Spinner = require('../Spinner'),
 	VideoFullscreenToggleButton = require('../VideoFullscreenToggleButton'),
-	VideoTransportSlider = require('../VideoTransportSlider');
+	VideoTransportSlider = require('../VideoTransportSlider'),
+	VideoPlayerAccessibilitySupport = require('./VideoPlayerAccessibilitySupport');
 
 /**
 * Fires when [disablePlaybackControls]{@link moon.VideoPlayer#disablePlaybackControls}
@@ -122,7 +124,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins: [HistorySupport],
+	mixins: options.accessibility ? [HistorySupport, VideoPlayerAccessibilitySupport] : [HistorySupport],
 
 	/**
 	* @private

--- a/lib/VideoPlayer/VideoPlayerAccessibilitySupport.js
+++ b/lib/VideoPlayer/VideoPlayerAccessibilitySupport.js
@@ -16,11 +16,11 @@ module.exports = {
 	initAccessibility: kind.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
-			this.$.jumpBack.set('accessibilityLabel', $L('jumpBack'));
-			this.$.rewind.set('accessibilityLabel', $L('rewind'));
-			this.$.fastForward.set('accessibilityLabel', $L('fastForward'));
-			this.$.jumpForward.set('accessibilityLabel', $L('jumpForward'));
-			this.$.moreButton.set('accessibilityLabel', $L('more'));
+			this.$.jumpBack.set('accessibilityLabel', $L('Jump Back'));
+			this.$.rewind.set('accessibilityLabel', $L('Rewind'));
+			this.$.fastForward.set('accessibilityLabel', $L('Fast Forward'));
+			this.$.jumpForward.set('accessibilityLabel', $L('Jump Forward'));
+			this.$.moreButton.set('accessibilityLabel', $L('More'));
 		};
 	}),
 
@@ -30,13 +30,9 @@ module.exports = {
 	updatePlayPauseButtons: kind.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
-			if (this._isPlaying) {
-				this.$.fsPlayPause.set('accessibilityLabel', $L('pause'));
-				this.$.ilPlayPause.set('accessibilityLabel', $L('pause'));
-			} else {
-				this.$.fsPlayPause.set('accessibilityLabel', $L('play'));
-				this.$.ilPlayPause.set('accessibilityLabel', $L('play'));
-			}
+			var label = this._isPlaying ? $L('Pause') : $L('Play');
+			this.$.fsPlayPause.set('accessibilityLabel', label);
+			this.$.ilPlayPause.set('accessibilityLabel', label);
 		};
 	}),
 
@@ -47,11 +43,8 @@ module.exports = {
 		return function (props) {
 			sup.apply(this, arguments);
 			var index = this.$.controlsContainer.getIndex();
-			if (index === 0) {
-				this.$.moreButton.set('accessibilityLabel', $L('more'));
-			} else {
-				this.$.moreButton.set('accessibilityLabel', $L('less'));
-			}
+			var label = index === 0 ? $L('More') : $L('Less');
+			this.$.moreButton.set('accessibilityLabel', label);
 		};
 	})
 

--- a/lib/VideoPlayer/VideoPlayerAccessibilitySupport.js
+++ b/lib/VideoPlayer/VideoPlayerAccessibilitySupport.js
@@ -1,0 +1,58 @@
+var
+	kind = require('enyo/kind');
+
+var
+	$L = require('../i18n');
+
+/**
+* @name VideoPlayerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.$.jumpBack.set('accessibilityLabel', $L('jumpBack'));
+			this.$.rewind.set('accessibilityLabel', $L('rewind'));
+			this.$.fastForward.set('accessibilityLabel', $L('fastForward'));
+			this.$.jumpForward.set('accessibilityLabel', $L('jumpForward'));
+			this.$.moreButton.set('accessibilityLabel', $L('more'));
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	updatePlayPauseButtons: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			if (this._isPlaying) {
+				this.$.fsPlayPause.set('accessibilityLabel', $L('pause'));
+				this.$.ilPlayPause.set('accessibilityLabel', $L('pause'));
+			} else {
+				this.$.fsPlayPause.set('accessibilityLabel', $L('play'));
+				this.$.ilPlayPause.set('accessibilityLabel', $L('play'));
+			}
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	moreButtonTapped: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			var index = this.$.controlsContainer.getIndex();
+			if (index === 0) {
+				this.$.moreButton.set('accessibilityLabel', $L('more'));
+			} else {
+				this.$.moreButton.set('accessibilityLabel', $L('less'));
+			}
+		};
+	})
+
+};


### PR DESCRIPTION
… moonstone widgets, part 1

Apply accessibilty on moonstone ExpandablePicker and VideoPlayer.

ExpandablePicker:  When spotlight focused on Expandablepicker, the dom
which is focused has aria-label including only the content of
ExpandablePicker. In this case, the currentValue should be added in
aria-label as well, so observing the content of currentValue and add it
using accessibilityHint.

VideoPlayer: set accessibilityLabel to each icon button according to UX
document.

https://jira2.lgsvl.com/browse/ENYO-1054
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>