### PR TITLE
Fixes ENYO-1677

### DIFF
--- a/lib/History/History.js
+++ b/lib/History/History.js
@@ -4,6 +4,7 @@ var
 	kind = require('enyo/kind'),
 	ready = require('enyo/ready'),
 	dispatcher = require('enyo/dispatcher'),
+	Component = require('enyo/Component'),
 	Signals = require('enyo/Signals');
 
 /**
@@ -14,7 +15,7 @@ var
 * @module moonstone/History
 * @public
 */
-var History = module.exports = kind.singleton({
+var History = module.exports = new Component({
 	/** @lends module:moonstone/History */
 
 	/**


### PR DESCRIPTION
## Issue
In the new module system, there's no obvious need to have singletons as their purpose was to make a globally available instance. Instead, the kind can be instanced and exposed from the module. Now, the singletons are being exported into the global namespace unnecessarily potentially allowing usage without importing the required module (which is fragile).

# Fix
Remove singleton usage in moonstone/History

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)