### PR TITLE
Enyo 1285 - master derekanderson

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -731,14 +731,15 @@
 		*/
 		_marquee_detectAlignment: function (forceAnimate, forceRtl) {
 			var alignment = null,
-				rtl = forceRtl || this.rtl;
+				rtl = forceRtl || this.rtl,
+				animate = this._marquee_shouldAnimate();
 
 			// We only attempt to set the alignment of this control if the locale's directionality
 			// differs from the directionality of our current marqueeable control (as determined by
 			// the control's content or is explicitly specified).
 			if (enyo.Control.prototype.rtl != rtl || this.centered) {
 				// If we will be marqueeing, we know the alignment needs to be set based on directionality.
-				if (forceAnimate || this._marquee_shouldAnimate()) {
+				if (forceAnimate || animate) {
 					if (rtl) {
 						alignment = 'right';
 					} else {
@@ -900,6 +901,15 @@
 				node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode();
 				rect = node.getBoundingClientRect();
 				this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
+				
+				 //if the distance is exactly 0, then the ellipsis 
+				//most likely are hiding the content, and marquee does not
+				//need to animate
+				if(this._marquee_distance === 0) {
+					this.applyStyle('text-overflow', 'clip');    
+				} else {
+					this.applyStyle('text-overflow', 'ellipsis');   
+				}
 			}
 
 			return this._marquee_distance;

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -691,8 +691,8 @@
 				// result in the appropriate text-align rule not being applied. For example, this
 				// can occur with a moon.Header that is located inside a moon.Scroller which has
 				// vertical scrollbars visible.
-				this._marquee_calcDistance();
 				this._marquee_detectAlignment();
+				setTimeout(enyo.bindSafely(this, this._marquee_calcDistance), enyo.platform.firefox ? 100 : 16);
 			};
 		}),
 
@@ -788,6 +788,7 @@
 			if (this.generated) {
 				this._marquee_invalidateMetrics();
 				this._marquee_detectAlignment();
+				this._marquee_calcDistance();
 			}
 			this._marquee_reset();
 		},

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -691,6 +691,7 @@
 				// result in the appropriate text-align rule not being applied. For example, this
 				// can occur with a moon.Header that is located inside a moon.Scroller which has
 				// vertical scrollbars visible.
+				this._marquee_calcDistance();
 				this._marquee_detectAlignment();
 			};
 		}),
@@ -731,15 +732,14 @@
 		*/
 		_marquee_detectAlignment: function (forceAnimate, forceRtl) {
 			var alignment = null,
-				rtl = forceRtl || this.rtl,
-				animate = this._marquee_shouldAnimate();
+				rtl = forceRtl || this.rtl;
 
 			// We only attempt to set the alignment of this control if the locale's directionality
 			// differs from the directionality of our current marqueeable control (as determined by
 			// the control's content or is explicitly specified).
 			if (enyo.Control.prototype.rtl != rtl || this.centered) {
 				// If we will be marqueeing, we know the alignment needs to be set based on directionality.
-				if (forceAnimate || animate) {
+				if (forceAnimate || this._marquee_shouldAnimate()) {
 					if (rtl) {
 						alignment = 'right';
 					} else {


### PR DESCRIPTION
issue. Marquee Text is ellipsis but doesn't roll when content has same length with div width

fix. when rendered, request the marquee to calculate it's distance. Remove the ellipse formatting if the distance to move is 0.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com