### PR TITLE
ENYO-1285: text ellipse on marquee

### DIFF
--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -711,6 +711,7 @@ var MarqueeItem = exports.Item = {
 			// result in the appropriate text-align rule not being applied. For example, this
 			// can occur with a moon.Header that is located inside a moon.Scroller which has
 			// vertical scrollbars visible.
+			this._marquee_calcDistance();
 			this._marquee_detectAlignment();
 		};
 	}),
@@ -920,6 +921,15 @@ var MarqueeItem = exports.Item = {
 			node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode();
 			rect = node.getBoundingClientRect();
 			this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
+			
+			//if the distance is exactly 0, then the ellipsis 
+			//most likely are hiding the content, and marquee does not
+			//need to animate
+			if(this._marquee_distance === 0) {
+				this.applyStyle('text-overflow', 'clip');    
+			} else {
+				this.applyStyle('text-overflow', 'ellipsis');   
+			}
 		}
 
 		return this._marquee_distance;

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -711,8 +711,8 @@ var MarqueeItem = exports.Item = {
 			// result in the appropriate text-align rule not being applied. For example, this
 			// can occur with a moon.Header that is located inside a moon.Scroller which has
 			// vertical scrollbars visible.
-			this._marquee_calcDistance();
 			this._marquee_detectAlignment();
+			setTimeout(enyo.bindSafely(this, this._marquee_calcDistance), enyo.platform.firefox ? 100 : 16);
 		};
 	}),
 
@@ -808,6 +808,7 @@ var MarqueeItem = exports.Item = {
 		if (this.generated) {
 			this._marquee_invalidateMetrics();
 			this._marquee_detectAlignment();
+			this._marquee_calcDistance();
 		}
 		this._marquee_reset();
 	},


### PR DESCRIPTION
issue. Marquee Text is ellipsis but doesn't roll when content has same length with div width

fix. when rendered, request the marquee to calculate it's distance. Remove the ellipse formatting if the distance to move is 0.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com