### PR TITLE
ENYO-1543-Customization on moon.Dialog

### DIFF
--- a/lib/Dialog/Dialog.js
+++ b/lib/Dialog/Dialog.js
@@ -94,8 +94,8 @@ module.exports = kind(
 		uppercase: true,
 
 		/**
-		* When assigned with components, will replace the bodyText component with the controls
-		* given in the array. defaulted value should be revisited.
+		* When assigned with components before creation, will replace the {@link moon.Dialog#message}
+		* component with the controls given in the array.
 		*
 		* @type {Array}
 		* @default null

--- a/lib/Dialog/Dialog.js
+++ b/lib/Dialog/Dialog.js
@@ -94,6 +94,16 @@ module.exports = kind(
 		uppercase: true,
 
 		/**
+		* When assigned with components, will replace the bodyText component with the controls
+		* given in the array. defaulted value should be revisited.
+		*
+		* @type {Array}
+		* @default null
+		* @public
+		*/
+		bodyComponents: null,
+
+		/**
 		* @deprecated Replaced by [uppercase]{@link moon.Dialog#uppercase}.
 		*
 		* Formerly defaulted to `true`, now defaults to `null` and will only have
@@ -152,6 +162,12 @@ module.exports = kind(
 	* @private
 	*/
 	create: function () {
+		if(this.bodyComponents) {
+			this.tools = this.tools.slice(0,this.tools.length-2);
+			for(var comp in this.bodyComponents) {
+				this.tools.push(this.bodyComponents[comp]);
+			}
+		}
 		Popup.prototype.create.apply(this, arguments);
 
 		// FIXME: Backwards-compatibility for deprecated property - can be removed when
@@ -161,7 +177,7 @@ module.exports = kind(
 
 		this.titleChanged();
 		this.subTitleChanged();
-		this.messageChanged();
+		this.bodyComponents? '' : this.messageChanged();
 	},
 
 	/**

--- a/lib/Dialog/Dialog.js
+++ b/lib/Dialog/Dialog.js
@@ -154,7 +154,9 @@ module.exports = kind(
 			]}
 		]},
 		{kind: Divider, classes: 'moon-dialog-divider'},
-		{name: 'message', kind: BodyText, classes: 'moon-dialog-content'},
+		{name: 'bodyComps', components: [
+			{name: 'message', kind: BodyText, classes: 'moon-dialog-content'}
+		]},
 		{name: 'spotlightDummy', kind: Control, spotlight: false}
 	],
 
@@ -162,13 +164,13 @@ module.exports = kind(
 	* @private
 	*/
 	create: function () {
-		if(this.bodyComponents) {
-			this.tools = this.tools.slice(0,this.tools.length-2);
-			for(var comp in this.bodyComponents) {
-				this.tools.push(this.bodyComponents[comp]);
-			}
-		}
 		Popup.prototype.create.apply(this, arguments);
+		if(this.bodyComponents) {
+			this.$.message.destroy();
+			var owner = this.hasOwnProperty('bodyComponents') ? this.getInstanceOwner() : this;
+			this.$.bodyComps.createComponents(this.bodyComponents,{owner:owner});
+		}
+
 
 		// FIXME: Backwards-compatibility for deprecated property - can be removed when
 		// the titleUpperCase property is fully deprecated and removed. The legacy
@@ -177,7 +179,7 @@ module.exports = kind(
 
 		this.titleChanged();
 		this.subTitleChanged();
-		this.bodyComponents? '' : this.messageChanged();
+		this.messageChanged();
 	},
 
 	/**
@@ -217,6 +219,7 @@ module.exports = kind(
 	* @private
 	*/
 	messageChanged: function () {
-		this.$.message.setContent(this.message);
+		if(this.bodyComponents)
+			this.$.message.setContent(this.message);
 	}
 });

--- a/lib/Dialog/Dialog.js
+++ b/lib/Dialog/Dialog.js
@@ -219,7 +219,7 @@ module.exports = kind(
 	* @private
 	*/
 	messageChanged: function () {
-		if(this.bodyComponents)
+		if(!this.bodyComponents)
 			this.$.message.setContent(this.message);
 	}
 });

--- a/lib/Dialog/Dialog.js
+++ b/lib/Dialog/Dialog.js
@@ -154,23 +154,32 @@ module.exports = kind(
 			]}
 		]},
 		{kind: Divider, classes: 'moon-dialog-divider'},
-		{name: 'bodyComps', components: [
-			{name: 'message', kind: BodyText, classes: 'moon-dialog-content'}
-		]},
+		{name: 'bodyComps'},
 		{name: 'spotlightDummy', kind: Control, spotlight: false}
 	],
 
 	/**
 	* @private
 	*/
+	initComponents: function () {
+        this.inherited(arguments);
+        if (this.bodyComponents) {
+            var owner = this.hasOwnProperty('bodyComponents') ? this.getInstanceOwner() : this;
+            this.$.bodyComps.createComponents(this.bodyComponents, {owner:owner});
+        } else {
+            this.$.bodyComps.createComponent({
+                name: 'message',
+                kind: BodyText,
+                classes: 'moon-dialog-content'
+            }, {owner:this});
+        }
+    },
+	
+	/**
+	* @private
+	*/
 	create: function () {
 		Popup.prototype.create.apply(this, arguments);
-		if(this.bodyComponents) {
-			this.$.message.destroy();
-			var owner = this.hasOwnProperty('bodyComponents') ? this.getInstanceOwner() : this;
-			this.$.bodyComps.createComponents(this.bodyComponents,{owner:owner});
-		}
-
 
 		// FIXME: Backwards-compatibility for deprecated property - can be removed when
 		// the titleUpperCase property is fully deprecated and removed. The legacy
@@ -219,7 +228,6 @@ module.exports = kind(
 	* @private
 	*/
 	messageChanged: function () {
-		if(!this.bodyComponents)
-			this.$.message.setContent(this.message);
+		if (this.$.message) this.$.message.setContent(this.message);
 	}
 });


### PR DESCRIPTION
'bodyComponents' property is added, which allows the user can replace
the bodyText component in dialog with the components of one's choice.
Enyo-DCO-1.1-Signed-off-by: RajyavardhanP <rajyavardhan.p@lge.com>