### PR TITLE
Enyo-1722 Set default value false to do not affect on moon.Slider's s…

### DIFF
--- a/lib/Slider/Slider.js
+++ b/lib/Slider/Slider.js
@@ -137,10 +137,10 @@ module.exports = kind(
 		* When `true`, jumpIncrement button will be displayed in both side of slider.
 		*
 		* @type {Boolean}
-		* @default true
+		* @default false
 		* @public
 		*/
-		enableJumpIncrement: true,
+		enableJumpIncrement: false,
 
 		/**
 		* Sliders will increase or decrease as much as this percentage value in either direction

--- a/lib/VideoTransportSlider/VideoTransportSlider.js
+++ b/lib/VideoTransportSlider/VideoTransportSlider.js
@@ -118,11 +118,6 @@ module.exports = kind(
 
 	/**
 	* @private
-	*/
-	enableJumpIncrement: false,
-
-	/**
-	* @private
 	* @lends moon.VideoTransportSlider.prototype
 	*/
 	published: {


### PR DESCRIPTION
…ub-kind

Issue
-------
Current default value of {{enableJumpIncrement}} is true. So some controls which use moon.Slider will have jumpIncrement button even though they do not want it.

Cause
--------
Default value is true.

Fix
-----
Set its defalut value to false

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com