### PR TITLE
Enyo-1709 Make headerContainer as instance of defaultKind which is mo…

### DIFF
--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -173,7 +173,7 @@ module.exports = kind(
 	components: [
 		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 		// widths (webkit bug)
-		{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+		{name: 'headerContainer', classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			{name: 'header', kind: MarqueeText}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [

--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -157,11 +157,6 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	defaultKind: Item,
-
-	/**
-	* @private
-	*/
 	handlers: {
 		onSpotlightDown: 'spotlightDown',
 		onDrawerAnimationEnd: 'drawerAnimationEnd'
@@ -173,7 +168,7 @@ module.exports = kind(
 	components: [
 		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 		// widths (webkit bug)
-		{name: 'headerContainer', classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+		{name: 'headerContainer', kind: Item, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			{name: 'header', kind: MarqueeText}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [

--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -157,6 +157,11 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	defaultKind: Item,
+
+	/**
+	* @private
+	*/
 	handlers: {
 		onSpotlightDown: 'spotlightDown',
 		onDrawerAnimationEnd: 'drawerAnimationEnd'


### PR DESCRIPTION
…on.Item.

Issue
------
From 2.6.0-pre.5, headerContainer of ExpandableListItem is unspottable.

Cause
--------
Its kind is defaultKind. but when we convert it to modular structure, we denoted it as moon.Control

Fix
----
Remove kind assignment for headerContainer

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com