### PR TITLE
ENYO-1543: Scroller doesn't display last line when using p tag on con…

### DIFF
--- a/css/Scroller.less
+++ b/css/Scroller.less
@@ -10,7 +10,12 @@
 	width: auto;
 	height: auto;
 	position: relative;
-	overflow: visible;
+	overflow: auto;
+	overflow: -moz-scrollbars-none;
+	-ms-overflow-style: none;
+	&::-webkit-scrollbar  {
+		width: 0 !important;
+	}
 }
 
 .matrix3dsurface {

--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -4414,7 +4414,12 @@ html {
   width: auto;
   height: auto;
   position: relative;
-  overflow: visible;
+  overflow: auto;
+  overflow: -moz-scrollbars-none;
+  -ms-overflow-style: none;
+}
+.matrix-scroll-client::-webkit-scrollbar {
+  width: 0 !important;
 }
 .matrix3dsurface {
   -webkit-transform-origin: center center;

--- a/css/moonstone-light.css
+++ b/css/moonstone-light.css
@@ -4414,7 +4414,12 @@ html {
   width: auto;
   height: auto;
   position: relative;
-  overflow: visible;
+  overflow: auto;
+  overflow: -moz-scrollbars-none;
+  -ms-overflow-style: none;
+}
+.matrix-scroll-client::-webkit-scrollbar {
+  width: 0 !important;
 }
 .matrix3dsurface {
   -webkit-transform-origin: center center;


### PR DESCRIPTION
…tent (Updated)

Issue:
- When I set <p> tag inside of scroller, Inner div (Scroll content) margin-Top push outer div (scroller client) down.
- This issue can be happens when user set margin top inside of moon.Scroller.
- When I set explicit width or height on inner control to explode, then native scroll bar is visible.

Fix:
- Set overflow: auto on container div
- Hide native scroller

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com