### PR TITLE
Fixes ENYO-1542

### DIFF
--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -118,7 +118,7 @@
 		components: [
 			{name: 'clientContainer', classes: 'moon-scroller-client-wrapper', components: [
 				{name: 'viewport', classes:'moon-scroller-viewport', components: [
-					{name: 'client', classes: 'enyo-touch-scroller matrix-scroll-client matrix3dsurface'}
+					{name: 'client', classes: 'enyo-touch-scroller enyo-touch-scroller-client matrix-scroll-client matrix3dsurface'}
 				]}
 			]},
 			{name: 'vColumn', classes: 'moon-scroller-v-column', components: [


### PR DESCRIPTION
## Issue
Scroller contents with leading or trailing margins may not be included in the size calculations throwing off scrolling at the edges.

## Fix
Add pseudo elements to scroller to force block formatting context

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)