### PR TITLE
Enyo 1740 Refactoring css class for CheckboxItem

### DIFF
--- a/lib/CheckboxItem/CheckboxItem.js
+++ b/lib/CheckboxItem/CheckboxItem.js
@@ -182,7 +182,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	classes: 'moon-item moon-checkbox-item',
+	classes: 'moon-checkbox-item',
 
 	/**
 	* @private

--- a/lib/CheckboxItem/CheckboxItem.less
+++ b/lib/CheckboxItem/CheckboxItem.less
@@ -2,6 +2,8 @@
 	position: relative;
 	overflow: hidden;
 	// Item
+	.moon-text-base (@moon-item-font-size);
+	line-height: @moon-item-line-height;
 	padding: @moon-spotlight-outset;
 
 	&.spotlight {

--- a/lib/CheckboxItem/CheckboxItem.less
+++ b/lib/CheckboxItem/CheckboxItem.less
@@ -1,7 +1,18 @@
 .moon-checkbox-item {
 	position: relative;
 	overflow: hidden;
+	// Item
 	padding: @moon-spotlight-outset;
+
+	&.spotlight {
+		background-color: @moon-accent;
+		color: @moon-white;
+	}
+
+	&.disabled {
+		cursor: default;
+		opacity: @moon-disabled-opacity;
+	}
 
 	// Checkbox
 	.moon-checkbox {
@@ -66,4 +77,9 @@
 			margin-left: 0px;
 		}
 	}
+}
+
+/* For non latin locale */
+.enyo-locale-non-latin .moon-checkbox-item {
+	.enyo-locale-non-latin .moon-sub-header-text;
 }

--- a/lib/CheckboxItem/CheckboxItem.less
+++ b/lib/CheckboxItem/CheckboxItem.less
@@ -1,6 +1,7 @@
 .moon-checkbox-item {
 	position: relative;
 	overflow: hidden;
+	padding: @moon-spotlight-outset;
 
 	// Checkbox
 	.moon-checkbox {


### PR DESCRIPTION
Issue
-------
check mark layout of CheckboxItem needs to fix

Cause
--------
CheckboxItem uses some css class of moon.Item. But we do not require it from .js file

Fix
----
Refactor CheckboxItem.less to meet some feature of moon.Item

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com 