### PR TITLE
Enyo-1740 Use some css classes from moon.ExpandablePicker

### DIFF
--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -89,7 +89,7 @@ module.exports = kind(
 		{name: 'headerWrapper', kind: Item, classes: 'moon-accordion-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths
 			// (webkit bug)
-			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-accordion-header', components: [
+			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-accordion-header', components: [
 				{name: 'header', kind: MarqueeText}
 			]}
 		]},

--- a/lib/Accordion/Accordion.less
+++ b/lib/Accordion/Accordion.less
@@ -1,11 +1,36 @@
 /* Header Accordion*/
 .moon-accordion .moon-expandable-list-item-header {
 	display: inline-block;
-	padding-right: @moon-spotlight-outset + 30;
+	padding-right: @moon-spotlight-outset + 30px;	
 }
+/* Header Open */
+.moon-accordion.open {
+	.moon-accordion-header:after {
+		content: @moon-icon-arrowlargeup;
+	}
+}
+
+.moon-accordion-header {
+	margin: 0px;
+	position: relative;
+
+	&:after {
+		position: absolute;
+		top: @moon-spotlight-outset - 12px;
+		right: @moon-spotlight-outset + 1px;
+		font-family: @moon-icon-font-family;
+		content: @moon-icon-arrowlargedown;
+		font-size: @moon-expandable-caret-icon-font-size;
+		line-height: @moon-icon-small-size;
+	}
+	&.spotlight {
+		color: @moon-white;
+	}
+}
+
 .enyo-locale-right-to-left .moon-accordion .moon-expandable-list-item-header {
 	padding-right: 0;
-	padding-left: @moon-spotlight-outset + 30;
+	padding-left: @moon-spotlight-outset + 30px;
 }
 .moon-accordion .moon-accordion-header-wrapper {
 	height: 1.2em;


### PR DESCRIPTION
to show icon properly.

Issue
------
Accordion does not show arrowDown and Up icon

Cause
--------
It used some css class of moon.ExpandablePicker but we do not require it

Fix
----
Borrow some css class from expandablePicker.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com