### PR TITLE
ENYO-1313: Separate out vendor-specific pseudo-selector rules.

### DIFF
--- a/css/moonstone-mixins.less
+++ b/css/moonstone-mixins.less
@@ -42,3 +42,12 @@
 	width: 100% !important;
 	height: 100% !important;
 }
+
+.input-placeholder(@rule) {
+	&::-webkit-input-placeholder {
+		@rule();
+	}
+	&::-moz-placeholder {
+		@rule();
+	}
+}

--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -27,7 +27,6 @@
 @moon-button-disabled-text-color:     #4d4d4d;
 @moon-button-translucent-opacity:     30%;
 @moon-icon-color:                     @moon-white;
-@moon-input-header-text-color:        @moon-white;
 @moon-active-spotlight-border-color:  @moon-white;
 
 @moon-font-color-light:            #a6a6a6;
@@ -92,7 +91,7 @@
 @moon-label-text-color: @moon-font-color-light;
 @moon-label-border-color: @moon-active-border-color;
 @moon-integer-picker-item-bg-color: @moon-background-color;
-@moon-input-header-text-color: @moon-header-text-color;
+@moon-input-header-text-color: @moon-white;
 @moon-input-header-placeholder-color: darken(@moon-header-text-color, 45%);
 @moon-input-decorator-bg-color: @moon-white;
 

--- a/css/moonstone-variables-light.less
+++ b/css/moonstone-variables-light.less
@@ -27,7 +27,6 @@
 @moon-button-disabled-text-color: #b3b3b3;
 @moon-button-translucent-opacity: 30%;
 @moon-icon-color: @moon-white;
-@moon-input-header-text-color: @moon-dark-gray;
 @moon-active-spotlight-border-color: @moon-white;
 
 @moon-font-color-light: #4B4B4B;

--- a/lib/Header/Header.less
+++ b/lib/Header/Header.less
@@ -125,9 +125,12 @@
 			border: 0px;
 			width: 100%;
 			box-sizing: border-box;
-			background-color: transparent;
 
-			> .moon-input {
+			&.moon-focused {
+				color: @moon-input-header-text-color;
+			}
+
+			.moon-input {
 				.moon-header-text;
 				margin: 0px;
 				padding-left: 1px;
@@ -135,42 +138,35 @@
 				display: inline-block;
 				box-sizing: border-box;
 				line-height: 1em;
-				color: @moon-input-header-text-color;
+				color: inherit;
 				width: 100%;
 				text-overflow: ellipsis;
+
+				.input-placeholder({
+					color: @moon-input-header-placeholder-color;
+					margin-top: 12px;
+					line-height: 1.25em;
+				});
 			}
 
 			&.spotlight {
-				.moon-input {
+				&:not(.moon-focused) .moon-input {
 					color: inherit;
+					background-color: @moon-spotlight-background-color;
 
 					.input-placeholder({
 						color: inherit;
 					});
 				}
 
-				> .moon-input {
-					background-color: @moon-spotlight-background-color;
-				}
-
-				&.moon-focused > .moon-input {
+				&.moon-focused .moon-input {
 					background: none;
-
-					.input-placeholder({
-						color: @moon-input-header-placeholder-color;
-					});
 				}
 			}
 		}
 
-		.moon-input.moon-header-title {
-			position: static;
-
-			.input-placeholder({
-				color: @moon-input-header-placeholder-color;
-				margin-top:12px;
-				line-height: 1.25em;
-			});
+		.moon-header-title-below {
+			margin-top: 0;
 		}
 	}
 }

--- a/lib/Header/Header.less
+++ b/lib/Header/Header.less
@@ -116,6 +116,63 @@
 	.moon-header-client-text {
 		line-height: @moon-button-small-height;
 	}
+
+	//InputHeader classes
+	&.moon-input-header {
+		.moon-input-header-input-decorator {
+			margin: -1px 0px 0px;
+			padding: 0px;
+			border: 0px;
+			width: 100%;
+			box-sizing: border-box;
+			background-color: transparent;
+
+			> .moon-input {
+				.moon-header-text;
+				margin: 0px;
+				padding-left: 1px;
+				padding-right: 1px;
+				display: inline-block;
+				box-sizing: border-box;
+				line-height: 1em;
+				color: @moon-input-header-text-color;
+				width: 100%;
+				text-overflow: ellipsis;
+			}
+
+			&.spotlight {
+				.moon-input {
+					color: inherit;
+
+					.input-placeholder({
+						color: inherit;
+					});
+				}
+
+				> .moon-input {
+					background-color: @moon-spotlight-background-color;
+				}
+
+				&.moon-focused > .moon-input {
+					background: none;
+
+					.input-placeholder({
+						color: @moon-input-header-placeholder-color;
+					});
+				}
+			}
+		}
+
+		.moon-input.moon-header-title {
+			position: static;
+
+			.input-placeholder({
+				color: @moon-input-header-placeholder-color;
+				margin-top:12px;
+				line-height: 1.25em;
+			});
+		}
+	}
 }
 
 // neutral
@@ -125,43 +182,6 @@
 }
 
 // enyo-locale-non-latin
-.enyo-locale-non-latin .moon-header {
-	.moon-header-title, {
-		line-height: @moon-non-latin-header-text-line-height;
-	}
-	&.moon-medium-header .moon-header-title, {
-		line-height: @moon-non-latin-medium-header-line-height;
-	}
-	&.moon-small-header .moon-header-title, {
-		line-height: @moon-non-latin-small-header-line-height;
-	}
-}
-
-/* Special override for Japanese font (LG Display_JP) which, as of 07-Feb-2014
-   has a taller baseline. This corrects both Header and InputHeader. 2014-02-24
-   Please remove the line-height rule below if this font file is changed. */
-.enyo-locale-non-latin.enyo-locale-ja .moon-header-title,
-.enyo-locale-non-latin.enyo-locale-ja .moon-input-header .moon-input-header-input-decorator > .moon-input {
-	line-height: 1.25em;
-}
-
-// enyo-locale-right-to-left
-.enyo-locale-right-to-left {
-	.moon-small-header .moon-header-client,
-	.moon-medium-header .moon-header-client {
-		right: auto;
-		left: 0;
-	}
-}
-
-// moon-header-left is used in HeaderSample
-.moon-header:not(.moon-small-header):not(.moon-medium-header) .moon-header-left {
-	float: left;
-}
-.enyo-locale-right-to-left .moon-header:not(.moon-small-header):not(.moon-medium-header) .moon-header-left {
-	float: right;
-}
-
 .enyo-locale-non-latin {
 	// Languages with combining accent characters
 	&.enyo-locale-th, // Thai - Test Chars: ฟิ้ไััุุ
@@ -182,57 +202,43 @@
 			height: 159px;
 		}
 	}
+
+	.moon-header {
+		.moon-header-title, {
+			line-height: @moon-non-latin-header-text-line-height;
+		}
+		&.moon-medium-header .moon-header-title, {
+			line-height: @moon-non-latin-medium-header-line-height;
+		}
+		&.moon-small-header .moon-header-title, {
+			line-height: @moon-non-latin-small-header-line-height;
+		}
+	}
+
+	.moon-input-header .moon-input-header-input-decorator > .moon-input {
+		.enyo-locale-non-latin .moon-header-text;
+	}
+
+	.moon-input-header .moon-input.moon-header-title {
+		.input-placeholder({
+			line-height: 1.5em;
+		});
+	}
 }
 
-//InputHeader classes
-.moon-input-header-input-decorator {
-	margin: -1px 0px 0px;
-	padding: 0px;
-	border: 0px;
-	width: 100%;
-	box-sizing: border-box;
-	background-color: transparent;
+// enyo-locale-right-to-left
+.enyo-locale-right-to-left {
+	.moon-small-header .moon-header-client,
+	.moon-medium-header .moon-header-client {
+		right: auto;
+		left: 0;
+	}
 }
-.moon-input-header .moon-input-header-input-decorator > .moon-input {
-	.moon-header-text;
-	margin: 0px;
-	padding-left: 1px;
-	padding-right: 1px;
-	display: inline-block;
-	box-sizing: border-box;
-	line-height: 1em;
-	color: @moon-input-header-text-color;
-	width: 100%;
-	text-overflow: ellipsis;
+
+// moon-header-left is used in HeaderSample
+.moon-header:not(.moon-small-header):not(.moon-medium-header) .moon-header-left {
+	float: left;
 }
-.enyo-locale-non-latin .moon-input-header .moon-input-header-input-decorator > .moon-input {
-	.enyo-locale-non-latin .moon-header-text;
-}
-.moon-input-header .moon-input.moon-header-title {
-	position: static;
-}
-.moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder,
-.moon-input-header .moon-input.moon-header-title::-moz-placeholder {
-	color: @moon-input-header-placeholder-color;
-	margin-top:12px;
-	line-height: 1.25em;
-}
-.enyo-locale-non-latin .moon-input-header .moon-input.moon-header-title::-webkit-input-placeholder,
-.enyo-locale-non-latin .moon-input-header .moon-input.moon-header-title::-moz-input-placeholder {
-	line-height: 1.5em;
-}
-.moon-input-header-input-decorator.spotlight .moon-input::-webkit-input-placeholder,
-.moon-input-header-input-decorator.spotlight .moon-input::-moz-input-placeholder {
-	color: @moon-spotlight-text-color;
-}
-.moon-input-header-input-decorator.spotlight > .moon-input {
-	background-color: @moon-spotlight-background-color;
-	color: @moon-spotlight-text-color;
-}
-.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input {
-	background: none;
-}
-.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-webkit-input-placeholder,
-.moon-input-header-input-decorator.spotlight.moon-focused > .moon-input::-moz-input-placeholder {
-	color: @moon-input-header-placeholder-color;
+.enyo-locale-right-to-left .moon-header:not(.moon-small-header):not(.moon-medium-header) .moon-header-left {
+	float: right;
 }

--- a/lib/Input/Input.less
+++ b/lib/Input/Input.less
@@ -24,6 +24,10 @@
 }
 
 .moon-input-decorator {
+	&.spotlight {
+		color: @moon-spotlight-text-color;
+	}
+
 	.moon-focused .moon-input {
 		cursor: text;
 	}

--- a/lib/VideoPlayer/VideoPlayer.less
+++ b/lib/VideoPlayer/VideoPlayer.less
@@ -45,32 +45,32 @@
 
 /* Fullscreen CSS */
 :-webkit-full-screen.moon-video-player {
-	.full-screen-video-player;
+	.full-screen-video-player();
 }
 :-moz-full-screen.moon-video-player {
-	.full-screen-video-player;
+	.full-screen-video-player();
 }
 :-ms-full-screen.moon-video-player {
-	.full-screen-video-player;
+	.full-screen-video-player();
 }
 :-o-full-screen.moon-video-player {
-	.full-screen-video-player;
+	.full-screen-video-player();
 }
 :full-screen.moon-video-player {
-	.full-screen-video-player;
+	.full-screen-video-player();
 }
 :-webkit-full-screen-ancestor:not(iframe) {
-	.hide-full-screen-ancestor;
+	.hide-full-screen-ancestor();
 }
 :-moz-full-screen-ancestor:not(iframe) {
-	.hide-full-screen-ancestor;
+	.hide-full-screen-ancestor();
 }
 :-ms-full-screen-ancestor:not(iframe) {
-	.hide-full-screen-ancestor;
+	.hide-full-screen-ancestor();
 }
 :-o-full-screen-ancestor:not(iframe) {
-	.hide-full-screen-ancestor;
+	.hide-full-screen-ancestor();
 }
 :full-screen-ancestor:not(iframe) {
-	.hide-full-screen-ancestor;
+	.hide-full-screen-ancestor();
 }


### PR DESCRIPTION
### Issue
When we merged the changes from https://github.com/enyojs/moonstone/pull/1945, we missed the fact that there were mixed vendor-specific selectors for `InputHeader`'s styling, which will cause the browser (at least WebKit) to stop parsing the rule once an unrecognized selector is hit. This resulted in several previously-applied styles disappearing from `InputHeader`.

### Fix
This may have gone the way of over-generalization as this is primarily useful in the cases where we have vendor-specific selectors that need the same rules applied while wanting to keep things DRY, but I've added a mixin function that accepts a rule and an array of selectors, and in turn applies the rules to each of these selectors. This assumes that you are calling the mixin function (`explode-rule`) inside a selector (which I believe is necessary in terms of how LESS parsing works), and it will append the `&` to signify the selector is to be combined directly with the parent selector. Also, we may want to consider adding the full gamut of vendor prefixes, but for the sake of replicating the previous functionality, I declined to do this for the time being.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>