### PR TITLE
ENYO-1687 : Apply accessibility on moonstone CheckboxItem

### DIFF
--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -7,11 +7,13 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	ri = require('enyo/resolution'),
 	Checkbox = require('enyo/Checkbox');
 
 var
-	Icon = require('../Icon');
+	Icon = require('../Icon'),
+	CheckboxAccessibilitySupport = require('./CheckboxAccessibilitySupport');
 
 /**
 * {@link moon.Checkbox} is a box that, when tapped, shows or hides a checkmark
@@ -37,6 +39,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Checkbox,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [CheckboxAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/Checkbox/CheckboxAccessibilitySupport.js
+++ b/lib/Checkbox/CheckboxAccessibilitySupport.js
@@ -1,0 +1,29 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name CheckboxAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+	
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.$.checkboxIcon.set('accessibilityDisabled', true);
+		};
+	}),
+	
+	/**
+	* @private
+	*/
+	accessibilityDisabledChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.$.checkboxIcon.set('accessibilityDisabled', this.accessibilityDisabled);
+		};
+	})
+};

--- a/lib/CheckboxItem/CheckboxItem.js
+++ b/lib/CheckboxItem/CheckboxItem.js
@@ -85,7 +85,6 @@ module.exports = kind(
 	*/
 	mixins: options.accessibility ? [CheckboxItemAccessibilitySupport, MarqueeSupport] : [MarqueeSupport],
 
-
 	/**
 	* @private
 	* @lends moon.CheckboxItem.prototype

--- a/lib/CheckboxItem/CheckboxItem.js
+++ b/lib/CheckboxItem/CheckboxItem.js
@@ -7,13 +7,15 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control');
 
 var
 	Checkbox = require('../Checkbox'),
 	Marquee = require('../Marquee'),
 	MarqueeSupport = Marquee.Support,
-	MarqueeItem = Marquee.Item;
+	MarqueeItem = Marquee.Item,
+	CheckboxItemAccessibilitySupport = require('./CheckboxItemAccessibilitySupport');
 
 /**
 * Fires when the control is either checked or unchecked.
@@ -81,7 +83,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins: [MarqueeSupport],
+	mixins: options.accessibility ? [CheckboxItemAccessibilitySupport, MarqueeSupport] : [MarqueeSupport],
 
 
 	/**

--- a/lib/CheckboxItem/CheckboxItemAccessibilitySupport.js
+++ b/lib/CheckboxItem/CheckboxItemAccessibilitySupport.js
@@ -1,0 +1,29 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name CheckboxItemAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('role', 'checkbox');
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	checkedChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
+		};
+	})
+};

--- a/lib/CheckboxItem/CheckboxItemAccessibilitySupport.js
+++ b/lib/CheckboxItem/CheckboxItemAccessibilitySupport.js
@@ -14,6 +14,8 @@ module.exports = {
 		return function (props) {
 			sup.apply(this, arguments);
 			this.setAttribute('role', 'checkbox');
+			this.$.client.set('accessibilityDisabled', true);
+			this.$.input.set('accessibilityDisabled', true);
 		};
 	}),
 
@@ -23,7 +25,20 @@ module.exports = {
 	checkedChanged: kind.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
-			this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
+			if (!this.accessibilityDisabled) {
+				this.setAttribute('aria-checked', this.checked ? 'true' : 'false');		
+			}
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	accessibilityDisabledChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.$.client.set('accessibilityDisabled', this.accessibilityDisabled);
+			this.$.input.set('accessibilityDisabled', this.accessibilityDisabled);
 		};
 	})
 };

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -8,8 +8,12 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	ri = require('enyo/resolution'),
+	options = require('enyo/options'),
 	path = require('enyo/pathResolver'),
 	Control = require('enyo/Control');
+
+var 
+	IconAccessibilitySupport = require('./IconAccessibilitySupport');
 
 // Static private hash of all of the valid moonstone icons
 var icons = {
@@ -128,6 +132,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Control,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [IconAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/Icon/IconAccessibilitySupport.js
+++ b/lib/Icon/IconAccessibilitySupport.js
@@ -13,11 +13,14 @@ module.exports = {
 	iconChanged: kind.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
-			if (this.get('small')) {
-				this.$.tapArea.setAttribute('aria-label', null);
-			} else {
-				this.setAttribute('aria-label', null);
-			} 
+			var label = this.accessibilityHint ? this.accessibilityHint : null;
+			if (!this.accessibilityLabel) {
+				if (this.get('small')) {
+					this.$.tapArea.setAttribute('aria-label', label);
+				} else {
+					this.setAttribute('aria-label', label);
+				}	
+			}			
 		};
 	})
 };

--- a/lib/Icon/IconAccessibilitySupport.js
+++ b/lib/Icon/IconAccessibilitySupport.js
@@ -13,6 +13,11 @@ module.exports = {
 	iconChanged: kind.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
+			// Font-based Icons set content value to font hash code. 
+			// If accessibilityHint is set and content exists, screen reader reads accessibilityHint with content. 
+			// To support this, accessibilityHint is implemented with aria-label including content and accessibilityHint content. 
+			// However, this content value is font hash code in Font-base Icon. 
+			// Therefore, we should set aria-label to only accessibilityHint content without this font hash code.
 			var label = this.accessibilityHint ? this.accessibilityHint : null;
 			if (!this.accessibilityLabel) {
 				if (this.get('small')) {
@@ -21,6 +26,18 @@ module.exports = {
 					this.setAttribute('aria-label', label);
 				}	
 			}			
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	accessibilityDisabledChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			if (this.get('small')) {
+				this.$.tapArea.set('accessibilityDisabled', this.accessibilityDisabled);
+			}
 		};
 	})
 };

--- a/lib/Icon/IconAccessibilitySupport.js
+++ b/lib/Icon/IconAccessibilitySupport.js
@@ -1,0 +1,23 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name IconAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	iconChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			if (this.get('small')) {
+				this.$.tapArea.setAttribute('aria-label', null);
+			} else {
+				this.setAttribute('aria-label', null);
+			} 
+		};
+	})
+};


### PR DESCRIPTION
1) Apply accessibilty on moonstone CheckboxItem.
2) Apply accessiblity on moonstone Icon because CheckboxItem's dom has aria-label which includes font hash-code content.
3) Add accessibility on moonstone Checkbox because CheckboxItem consists of Checkbox and content which have aria-label and tabIndex, so we should remove aria-label and tabIndex of children because CheckboxItem has already aria-label and tabIndex.

## Issue 
1) When CheckboxItem is focused, Only checkboxItem's content is read out. 
2) When font-based Icon is focused, Font hash-code content is read out. 
3) When CheckboxItem's child is focused in touch devices, this child component's aria-label is readout.

## Cause
1) The CheckboxItem consists of checkbox and text item. When spotlight is focused on CheckboxItem, the dom which is focused has aria-label including only the content of this text item. In this case, CheckboxItem should work like checkbox.
2) To support font-based Icon, Icon sets the font hash-code to dom content value. In this case, If accessiblity feature is true, added aria-label is made using Icon's content value and aria-label is read out.
3) Enyo Control adds tabIndex and aria-label to all components which have content, so Checkbox and content have aria-label and tabIndex.

## Fix
1) Add checkbox role and aria-checked attribute.
2) Remove font hash-code value of aria-label.
3) Remove aria-label and tabIndex from child component of CheckboxItem using accessibilityDisabled API 

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com