### PR TITLE
Fixes ENYO-1496

### DIFF
--- a/lib/History/History.js
+++ b/lib/History/History.js
@@ -6,6 +6,9 @@ var
 	dispatcher = require('enyo/dispatcher'),
 	Signals = require('enyo/Signals');
 
+var
+	LunaService = require('enyo-webos/LunaService');
+
 /**
 * The `moon.History` singleton provides an abstract way of handling historical state in an app,
 * working in tandem with the native window.history mechanism. The current implementation has
@@ -68,7 +71,7 @@ var History = module.exports = kind.singleton({
 	lunaServiceComponents: [
 		{
 			name:       'getAppID',
-			kind:       'enyo.LunaService',
+			kind:       LunaService,
 			service:    'palm://com.webos.applicationManager/',
 			method:     'getForegroundAppInfo',
 			subscribe:  true,
@@ -76,7 +79,7 @@ var History = module.exports = kind.singleton({
 		},
 		{
 			name:       'getAppInfo',
-			kind:       'enyo.LunaService',
+			kind:       LunaService,
 			service:    'luna://com.webos.applicationManager/',
 			method:     'getAppInfo',
 			subscribe:  true,
@@ -88,10 +91,8 @@ var History = module.exports = kind.singleton({
 	* @private
 	*/
 	init: function() {
-		// if (enyo.LunaService) {
-		// 	this.createChrome(this.lunaServiceComponents);
-		// 	this._getAppID();
-		// }
+		this.createChrome(this.lunaServiceComponents);
+		this._getAppID();
 
 		if (this.enableBackHistoryAPI) {
 			this._initHistoryState();
@@ -117,10 +118,10 @@ var History = module.exports = kind.singleton({
 	* @private
 	*/
 	_getAppID: function () {
-		// if(scope.PalmSystem) {
-		// 	var param = {'extraInfo': true};
-		// 	this.$.getAppID.send(param);
-		// }
+		if (scope.PalmSystem) {
+			var param = {'extraInfo': true};
+			this.$.getAppID.send(param);
+		}
 	},
 
 	/**
@@ -150,11 +151,10 @@ var History = module.exports = kind.singleton({
 	* @private
 	*/
 	_getAppInfo: function (appID) {
-		// if(scope.PalmSystem) {
-		// 	var param = {};
-		// 	param.id = appID;
-		// 	this.$.getAppInfo.send(param);
-		// }
+		var param = {
+			id: appId
+		};
+		this.$.getAppInfo.send(param);
 	},
 
 	/**


### PR DESCRIPTION
## Issue
Previously, the back API could be disabled via a property within an app's appinfo.json. This was disabled in the conversion pending a decision on moonstone requiring enyo-webos.

## Fix
Add LunaService to moonstone/History

## Notes
For the near term, this makes enyo-webos a required dependency for
Moonstone. That will likely need to change in the long term. It does
not, however, limit Moonstone apps to only webOS as the calls to
LunaService are guarded by a platform check and skip non-webOS
platforms.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)