### PR TITLE
ENYO-1129: Accessibility: Readout text when focus on moonstone compon…

### DIFF
--- a/lib/InputDecorator/InputDecorator.js
+++ b/lib/InputDecorator/InputDecorator.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	ToolDecorator = require('enyo/ToolDecorator');
 
 var
@@ -15,7 +16,8 @@ var
 var
 	Input = require('../Input'),
 	RichText = require('../RichText'),
-	TextArea = require('../TextArea');
+	TextArea = require('../TextArea'),
+	InputDecoratorAccessibilitySupport = require('./InputDecoratorAccessibilitySupport');
 
 /**
 * {@link moon.InputDecorator} is a control that provides input styling. Any controls
@@ -67,6 +69,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: ToolDecorator,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [InputDecoratorAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
+++ b/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
@@ -1,0 +1,23 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name InputDecoratorAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	handlers: {
+		onSpotlightFocused  : 'spotlightFocusedHandler'
+	},
+
+	/**
+	* @private
+	*/
+	spotlightFocusedHandler: function (oSender, oEvent) {
+		return true;
+	}
+};


### PR DESCRIPTION
…ents

When an object gets spotlight focus it should also have webkit focus to
read aria attributes. But in case Input, hovering over an input makes it
editable status because of webkit focus and can not see the spotlight.
This needs more analysis but I think it should be considered when
implementing Input accessibility support, so at this time I just add
code to stop propagation spotlightFocused event in InputDecorator to set
back previous working.

https://jira2.lgsvl.com/browse/ENYO-1129
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>