### PR TITLE
Enyo-960:[Moonstone]:ExpandableIntegerPicker is failed to set unit value

### DIFF
--- a/lib/SimpleIntegerPicker/SimpleIntegerPicker.js
+++ b/lib/SimpleIntegerPicker/SimpleIntegerPicker.js
@@ -141,6 +141,13 @@ module.exports = kind(
 	},
 
 	/**
+	* @private
+	*/
+	unitChanged: function(){
+		this.valueChanged();
+	},
+
+	/**
 	* Calculates width of the picker when the first item is rendered.
 	*
 	* @see moon.IntegerPicker.updateRepeater


### PR DESCRIPTION
Issue: When unit value is changed, its not getting reflected at picker's
value

Cause: value of picker (value + units) getting updated only when value
is changed, but it should update when unit too changed.

Fix: updating the picker's value when unit value change.

DCO-1.1-Signed-off-by: Srinivas V srinivas.v@lge.com