### PR TITLE
ENYO-1688 :[Accessibility] Apply accessibility on ToggleButton

### DIFF
--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -8,13 +8,15 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	util = require('enyo/utils'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control'),
 	Button = require('enyo/Button');
 
 var
 	Marquee = require('../Marquee'),
 	MarqueeSupport = Marquee.Support,
-	MarqueeText = Marquee.Text;
+	MarqueeText = Marquee.Text,
+	ButtonAccessibilitySupport = require('./ButtonAccessibilitySupport');
 
 /**
 * {@link moon.Button} is an {@link enyo.Button} with Moonstone styling applied.
@@ -48,7 +50,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins: [MarqueeSupport],
+	mixins: options.accessibility ? [ButtonAccessibilitySupport, MarqueeSupport] : [MarqueeSupport],
 
 	/**
 	* @private

--- a/lib/Button/ButtonAccessibilitySupport.js
+++ b/lib/Button/ButtonAccessibilitySupport.js
@@ -1,0 +1,19 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name ButtonAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.$.client.set('accessibilityDisabled', true);
+		};
+	})
+};

--- a/lib/ToggleButton/ToggleButton.js
+++ b/lib/ToggleButton/ToggleButton.js
@@ -7,10 +7,12 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	util = require('enyo/utils');
 
 var
-	Button = require('../Button');
+	Button = require('../Button'),
+	ToggleButtonAccessibilitySupport = require('./ToggleButtonAccessibilitySupport');
 
 /**
 * Fires when the value of the toggle button changes.
@@ -52,6 +54,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Button,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [ToggleButtonAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/ToggleButton/ToggleButtonAccessibilitySupport.js
+++ b/lib/ToggleButton/ToggleButtonAccessibilitySupport.js
@@ -1,0 +1,29 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name ToggleButtonAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('aria-pressed', this.value ? "true" : "false");
+		};
+	}),
+	
+	/**
+	* @private
+	*/
+	valueChanged: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			this.setAttribute('aria-pressed', this.value ? "true" : "false");
+		};
+	})
+};


### PR DESCRIPTION
Apply accessibility on moonstone ToggleButton
However, ToggleButton's child component has tabIndex and aria-label, so we should remove this properties because ToggleButton already has button role and related aria attributes.
Thus, apply accessibility on moonstone Button because ToggleButton extends Button.

## Issue 
Should read out toggle status when the spotlight is focused to ToggleButton

## Cause
ToggleButton requires press-and-release cycle to change their value.
To support readout toggle-status, we should add aria-pressed attribute to ToggleButton. 

## Fix
Add aria-pressed attribute to ToggleButton
Remove tablndex and aria-label from Button using accessibilityDisabled API.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com