### PR TITLE
ExpandableListItem: Disabled ListItem is Enabled and wrong Caret Icon offset

### DIFF
--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -173,7 +173,7 @@ module.exports = kind(
 	components: [
 		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 		// widths (webkit bug)
-		{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+		{name: 'headerContainer', kind: Item, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			{name: 'header', kind: MarqueeText}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [

--- a/lib/ExpandableListItem/ExpandableListItem.less
+++ b/lib/ExpandableListItem/ExpandableListItem.less
@@ -1,11 +1,12 @@
 /* ExpandableListItem Header*/
 .moon-expandable-list-item-header {
+  padding-right: @moon-spotlight-outset + 30px;
   margin-bottom: 0px;
   box-sizing: border-box;
   max-width: 100%;
 }
 .moon-expandable-list-header.moon-expandable-picker-header:after {
-  top: @moon-spotlight-outset + 3;
+  top: @moon-spotlight-outset;
 }
 
 /* Client Items */


### PR DESCRIPTION
### Issue:

The ListItem is enabled and unexpectedly expands and collapses even though it's disabled property is set as true.

In the ListItem header caret icon is placed down to the item header (wrong offset)

### Fix:

The ListItem header was a Control kind so it has changed to Item kind to achieve the disable feature. And the top-padding is reduced to arrange the caret icon offset.

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com