### PR TITLE
ENYO-1725: enyo.Video: setPlaybackRate should be called ahead of play in a certain case

### DIFF
--- a/src/VideoPlayer/VideoPlayer.js
+++ b/src/VideoPlayer/VideoPlayer.js
@@ -2031,7 +2031,9 @@ module.exports = kind(
 	* @private
 	*/
 	_play: function(sender, e) {
-		this.sendFeedback('Play');
+		if(e.playbackRate != this.playbackRateHash.slowRewind[0] && e.playbackRate != this.playbackRateHash.slowForward[0]){
+			this.sendFeedback('Play');
+		}
 	},
 
 	/**


### PR DESCRIPTION
## Issue
This is related to "https://github.com/enyojs/enyo/pull/1194"
added flag, "isNeedPlay", in enyo.Video,  to make node play after setPlaybackRate.
With above modification, we need to change moon.VideoFeedback also.

Flow of moon.VideoFeedback is like below.
1. this.setPlaybackRate(this.selectPlaybackRate(this._speedIndex));
"setPlaybackRate" -> "doSlowforward" in "ratechange" function in enyo.Video
-> through moon.VideoPlayer, sendFeedback("Slowforward") to moon.VideoFeedback
So, feedText in moon.VideFeedback displays Slowforward info now.
2. node.play();
"doPlay" in enyo.Video
-> through moon.VideoPlayer, sendFeedback("Play") to moon.VideoFeedback
So, feedText in moon.VideFeedback displays Play info now.
The feedText should display Slowforward info.

## Fix
I added below code in moon.VideoPlayer.

if(e.playbackRate != this.playbackRateHash.slowRewind[0] && e.playbackRate != this.playbackRateHash.slowForward[0]){
   this.sendFeedback('Play');
  }

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee (suhyung2.lee@lge.com)