### PR TITLE
ENYO-1183: Support renderOnShow on drawer.

### DIFF
--- a/lib/Drawers/Drawer.js
+++ b/lib/Drawers/Drawer.js
@@ -234,6 +234,7 @@ var MoonDrawer = module.exports = kind(
 	*/
 	openChanged: function () {
 		if (this.open) {
+			this.showAndUpdatePosition();
 			this.doActivate({height: this.fullHeight});
 			this.$.client.spotlightDisabled = false;
 			Spotlight.spot(this.$.client);
@@ -254,6 +255,7 @@ var MoonDrawer = module.exports = kind(
 	*/
 	controlsOpenChanged: function () {
 		if (this.controlsOpen) {
+			this.showAndUpdatePosition();
 			this.doActivate({height: this.controlDrawerHeight});
 			this.$.controlDrawer.spotlightDisabled = false;
 			Spotlight.spot(this.$.controlDrawer);
@@ -265,6 +267,14 @@ var MoonDrawer = module.exports = kind(
 			this.doDeactivate({height: 0});
 		}
 		this.animatePosition();
+	},
+
+	showAndUpdatePosition: function () {
+		if (this.renderOnShow == true && !this.hasNode()) {
+			this.show();
+			this.calcDrawerHeight();
+			this.updatePosition();
+		}
 	},
 
 	/**
@@ -285,9 +295,10 @@ var MoonDrawer = module.exports = kind(
 	* @private
 	*/
 	calcDrawerHeight: function () {
-		var clientHeight = this.fullHeight;
-		if (this.controlDrawerComponents != null) {
-			this.controlDrawerHeight = this.controlDrawerHeight || this.$.controlDrawer.hasNode().getBoundingClientRect().height;
+		var clientHeight = this.fullHeight,
+			controlDrawerNode = this.$.controlDrawer.hasNode();
+		if (this.controlDrawerComponents != null && !this.controlDrawerHeight) {
+			this.controlDrawerHeight = this.controlDrawerHeight || (controlDrawerNode && controlDrawerNode.getBoundingClientRect().height) || 0;
 			clientHeight -= this.controlDrawerHeight;
 		}
 		return clientHeight;


### PR DESCRIPTION
- When drawer change it's showing status, it is checking it's node and measure controlDrawer height before open.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com