### PR TITLE
ENYO-1382: Expandable List Item font size needs to be 27px

### DIFF
--- a/css/moonstone-dark.css
+++ b/css/moonstone-dark.css
@@ -1465,9 +1465,9 @@ html {
 }
 .moon-expandable-list-item-client .moon-item {
   font-family: "MuseoSans 300";
-  font-size: 1.375rem;
+  font-size: 1.125rem;
   color: #a6a6a6;
-  line-height: 1.625rem;
+  line-height: 1.375rem;
 }
 .moon-expandable-list-item-client .moon-item a:link {
   color: #cf0652;


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>