### PR TITLE
ENYO-1619: Adjusted heights of components to better support tall glyphs

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -104,7 +104,7 @@
 @moon-non-latin-font-family-light: "Moonstone LG Display Light";
 @moon-non-latin-font-family-bold: "Moonstone LG Display Bold";
 
-@moon-header-font-family: "Moonstone Miso";
+@moon-header-font-family: @moon-alt-font-family;
 @moon-header-font-weight: normal;
 @moon-header-letter-spacing: normal;
 @moon-header-font-style: normal;
@@ -128,13 +128,13 @@
 @moon-sub-header-line-height: 2em;
 @moon-sub-header-below-font-family: @moon-font-family-light;
 
-@moon-super-header-font-family: "Moonstone Miso";
+@moon-super-header-font-family: @moon-alt-font-family;
 @moon-super-header-font-weight: normal;
 @moon-super-header-letter-spacing: normal;
 @moon-super-header-font-style: normal;
 @moon-super-header-line-height: normal;
 
-@moon-body-font-family: "MuseoSans 300";
+@moon-body-font-family: @moon-font-family-light;
 @moon-body-font-weight: normal;
 @moon-body-letter-spacing: 0;
 @moon-body-font-style: normal;
@@ -146,6 +146,8 @@
 @moon-divider-font-weight: normal;
 @moon-divider-font-style: normal;
 @moon-divider-letter-spacing: 0;
+
+@moon-expandable-value-font-family: @moon-font-family-light;
 
 @moon-button-font-family: "Moonstone Miso Bold";
 @moon-button-font-weight: normal;
@@ -248,7 +250,7 @@
 
 // Items
 // ---------------------------------------
-@moon-item-line-height: 1.2em;
+@moon-item-line-height: 1.7em;
 @moon-item-indent: 36px;
 
 // Divider

--- a/lib/Accordion/Accordion.less
+++ b/lib/Accordion/Accordion.less
@@ -7,7 +7,3 @@
 	padding-right: 0;
 	padding-left: @moon-spotlight-outset + 30;
 }
-.moon-accordion .moon-accordion-header-wrapper {
-	height: 1.2em;
-}
-

--- a/lib/Checkbox/Checkbox.less
+++ b/lib/Checkbox/Checkbox.less
@@ -1,13 +1,13 @@
 /* Checkbox.css */
 .moon-checkbox {
 	cursor: pointer;
-	height: @moon-checkbox-icon-height;
+
 	.moon-icon {
 		visibility: hidden;
 		margin: 0;
 		padding: 0;
 	}
-	&[checked]  .moon-icon {
+	&[checked] .moon-icon {
 		visibility: visible;
 	}
 }

--- a/lib/CheckboxItem/CheckboxItem.less
+++ b/lib/CheckboxItem/CheckboxItem.less
@@ -5,12 +5,12 @@
 	// Checkbox
 	.moon-checkbox {
 		position: absolute;
-		top: @moon-spotlight-outset - 3;
+		top: 0;
 		right: @moon-spotlight-outset - 3;
 	}
 	// Label
 	.moon-checkbox-item-label-wrapper {
-		height: @moon-item-line-height;
+		line-height: inherit;
 		margin-right: @moon-item-indent;
 	}
 
@@ -35,11 +35,6 @@
 
 .moon-neutral .moon-checkbox[checked]:after {
 	color: @moon-white;
-}
-
-/* Special treatment inside of ExpandablePicker (checkbox nudged up) */
-.moon-expandable-picker .moon-checkbox-item .moon-checkbox {
-	top: @moon-spotlight-outset;
 }
 
 /* Right to left */

--- a/lib/Dialog/Dialog.less
+++ b/lib/Dialog/Dialog.less
@@ -3,7 +3,8 @@
 	padding: 24px 42px 42px;
 }
 .moon-dialog-title {
-	margin-bottom: 12px;
+	line-height: 1.3em;
+	margin-bottom: 6px;
 }
 .moon-dialog-client-wrapper {
 	min-height: 108px;

--- a/lib/Divider/Divider.less
+++ b/lib/Divider/Divider.less
@@ -1,7 +1,7 @@
 .moon-divider {
 	.moon-divider-border;
-	margin: 0 @moon-spotlight-outset (2 * @moon-spotlight-outset) @moon-spotlight-outset;
-	padding-bottom: 3px;
+	margin: 0 @moon-spotlight-outset (1.5 * @moon-spotlight-outset) @moon-spotlight-outset;
+	line-height: 1.6em;
 }
 .moon-neutral .moon-divider {
 	.moon-neutral-divider-border;

--- a/lib/ExpandableListItem/ExpandableListItem.less
+++ b/lib/ExpandableListItem/ExpandableListItem.less
@@ -1,31 +1,37 @@
 /* ExpandableListItem Header*/
 .moon-expandable-list-item-header {
-  margin-bottom: 0px;
-  box-sizing: border-box;
-  max-width: 100%;
+	margin-bottom: 0px;
+	box-sizing: border-box;
+	max-width: 100%;
+	line-height: @moon-item-line-height;
 }
 .moon-expandable-list-header.moon-expandable-picker-header:after {
-  top: @moon-spotlight-outset + 3;
+	top: 3px;
 }
 
 /* Client Items */
 .moon-expandable-list-item.open .moon-expandable-list-item-client {
-  margin-bottom: 12px;
+	margin-bottom: 12px;
 }
-.moon-expandable-list-item-client .moon-item {
-	.moon-body-text;
+.moon-expandable-list-item-client {
+	.moon-item {
+		.moon-body-text;
+		line-height: @moon-item-line-height;
+
+		&.spotlight {
+			color: @moon-white;
+		}
+		&:last-child {
+			margin-bottom: 0px;
+		}
+	}
+	&.indented {
+		padding-left: @moon-item-indent + @moon-spotlight-outset;
+	}
 }
+
 .enyo-locale-non-latin .moon-expandable-list-item-client .moon-item {
 	.enyo-locale-non-latin .moon-body-text;
-}
-.moon-expandable-list-item-client .moon-item.spotlight {
-	color: @moon-white;
-}
-.moon-expandable-list-item-client .moon-item:last-child {
-	margin-bottom: 0px;
-}
-.moon-expandable-list-item-client.indented {
-	padding-left: @moon-item-indent + @moon-spotlight-outset;
 }
 .enyo-locale-right-to-left .moon-expandable-list-item-client.indented {
 	padding-left: 0;

--- a/lib/ExpandablePicker/ExpandablePicker.less
+++ b/lib/ExpandablePicker/ExpandablePicker.less
@@ -4,6 +4,7 @@
 	display: inline-block;
 	padding-right: @moon-spotlight-outset + 30px;
 	position: relative;
+	vertical-align: top;
 
 	&:after {
 		position: absolute;
@@ -12,7 +13,6 @@
 		font-family: @moon-icon-font-family;
 		content: @moon-icon-arrowlargedown;
 		font-size: @moon-expandable-caret-icon-font-size;
-		line-height: @moon-icon-small-size;
 	}
 	&.spotlight {
 		color: @moon-white;
@@ -38,9 +38,9 @@
 
 /* Current Value */
 .moon-expandable-picker-current-value {
-	.moon-body-text;
+	font-family: @moon-expandable-value-font-family;
 	color: @moon-expandable-picker-text-color;
-	margin: 0px;
+	margin-top: -6px;	// Negative value to compensate for the taller line-height needed for tall-glyph charecters
 }
 .enyo-locale-right-to-left .moon-expandable-picker-current-value {
 	padding-left: 0;

--- a/lib/FormCheckbox/FormCheckbox.less
+++ b/lib/FormCheckbox/FormCheckbox.less
@@ -7,20 +7,22 @@
 
 	.moon-checkbox {
 		position: absolute;
-		top: 6px;
+		top: 50%;
+		-webkit-transform: translateY(-50%);
+		transform: translateY(-50%);
 		left: @moon-spotlight-outset;
-		width: @moon-checkbox-width + @moon-spotlight-outset;
-		height: @moon-checkbox-width + @moon-spotlight-outset;
+		width: (@moon-checkbox-width + @moon-spotlight-outset);
+		height: (@moon-checkbox-width + @moon-spotlight-outset);
 		border-radius: @moon-button-border-radius;
 		background-color: @moon-form-checkbox-bg-color;
-		line-height: @moon-checkbox-width + @moon-spotlight-outset;
+		line-height: (@moon-checkbox-width + @moon-spotlight-outset);
 		text-align: center;
 	}
 	.moon-checkbox .moon-icon {
 		padding-bottom: 3px;
 	}
 	.moon-checkbox-item-label-wrapper {
-		padding: 12px 12px;
+		padding: 3px @moon-spotlight-outset;
 		margin-left: @moon-checkbox-width + @moon-spotlight-outset;
 	}
 }
@@ -31,7 +33,7 @@
 
 		.moon-checkbox-item-label-wrapper {
 			margin-left: auto;
-			margin-right: @moon-checkbox-width + 2*@moon-spotlight-outset;
+			margin-right: (@moon-checkbox-width + 2*@moon-spotlight-outset);
 		}
 		.moon-checkbox {
 			right: @moon-spotlight-outset;

--- a/lib/Header/Header.less
+++ b/lib/Header/Header.less
@@ -35,7 +35,8 @@
 
 	.moon-header-title-below,
 	.moon-header-sub-title-below {
-		height: 48px;
+		height: 45px;
+		line-height: 45px;
 	}
 
 	&.full-bleed {
@@ -67,7 +68,8 @@
 
 		.moon-header-title-below,
 		.moon-header-sub-title-below {
-			height: 42px;
+			height: 39px;
+			line-height: 39px;
 		}
 	}
 
@@ -156,4 +158,26 @@
 }
 .enyo-locale-right-to-left .moon-header:not(.moon-small-header):not(.moon-medium-header) .moon-header-left {
 	float: right;
+}
+
+.enyo-locale-non-latin {
+	// Languages with combining accent characters
+	&.enyo-locale-th, // Thai - Test Chars: ฟิ้ไััุุ
+	&.enyo-locale-ar, // Arabic
+	&.enyo-locale-fa, // Farsi
+	&.enyo-locale-ur, // Urdu
+	&.enyo-locale-ku, // Kurdish
+	&.enyo-locale-he, // Hebrew
+	&.enyo-locale-hi, // Hindi
+	&.enyo-locale-ta, // Tamil
+	&.enyo-locale-te, // Telugu
+	&.enyo-locale-kn, // Kannada
+	&.enyo-locale-ml, // Malayalam
+	&.enyo-locale-mr, // Marathi
+	&.enyo-locale-bn, // Bengali
+	&.enyo-locale-pa {// Panjabi
+		.moon-header .moon-header-title {
+			height: 159px;
+		}
+	}
 }

--- a/lib/ImageItem/ImageItem.less
+++ b/lib/ImageItem/ImageItem.less
@@ -4,19 +4,21 @@
 	min-width: 540px;
 	margin-top: 0px;
 	padding-top: 0px;
+	padding-bottom: @moon-spotlight-outset;
 	height: 204px;
 	overflow: hidden;
-}
-.moon-imageitem img {
-	width: 132px;
-	height: 192px;
-	padding: 0px;
-	margin: 12px 60px 12px 0px;
-	display: inline-block;
-	float: left;
-}
-.moon-imageitem.align-right img {
-	float: right;
-	margin-right: 0px;
-	margin-left: 60px;
+
+	img {
+		width: 132px;
+		height: 192px;
+		padding: 0px;
+		margin: @moon-spotlight-outset 60px @moon-spotlight-outset 0px;
+		display: inline-block;
+		float: left;
+	}
+	&.align-right img {
+		float: right;
+		margin-right: 0px;
+		margin-left: 60px;
+	}
 }

--- a/lib/Item/Item.less
+++ b/lib/Item/Item.less
@@ -2,7 +2,7 @@
 .moon-item {
 	.moon-text-base (@moon-item-font-size);
 	line-height: @moon-item-line-height;
-	padding: @moon-spotlight-outset;
+	padding: 3px @moon-spotlight-outset;
 	position: relative;
 
 	&.spotlight {

--- a/lib/ItemOverlay/ItemOverlay.less
+++ b/lib/ItemOverlay/ItemOverlay.less
@@ -2,6 +2,8 @@
 .moon-item {
 	.moon-item-overlay {
 		float: left;
+		line-height: 1em;
+		margin-top: 0.3em;
 
 		&.right {
 			float: right;

--- a/lib/LabeledTextItem/LabeledTextItem.less
+++ b/lib/LabeledTextItem/LabeledTextItem.less
@@ -8,7 +8,6 @@
 .moon-labeledtextitem .label {
 	.moon-sub-header-text;
 	color: @moon-label-text-color;
-	margin-bottom: 6px;
 }
 .enyo-locale-non-latin .moon-labeledtextitem .label {
 	.enyo-locale-non-latin .moon-sub-header-text;
@@ -26,6 +25,7 @@
 	color: @moon-labeled-item-text-color;
 	line-height: @moon-body-line-height;
 	text-transform: none;
+	margin-bottom: (@moon-spotlight-outset - 3px);
 }
 .enyo-locale-non-latin .moon-labeledtextitem .text {
 	.enyo-locale-non-latin .moon-body-text;

--- a/lib/RadioItem/RadioItem.less
+++ b/lib/RadioItem/RadioItem.less
@@ -2,18 +2,20 @@
 .moon-radio-item {
 	display: inline-block;
 	max-width: 240px;
-	margin: 0 @moon-radio-item-gap 0 0;
-	padding: 12px @moon-spotlight-outset 12px @moon-item-indent + @moon-spotlight-outset;
+	margin-right: @moon-radio-item-gap;
+	padding-left: (@moon-item-indent + @moon-spotlight-outset);
 
 	&:before {
 		content: '';
 		position: absolute;
 		left: @moon-spotlight-outset;
-		top: 18px;
-		width: @moon-selectable-item-indicator-width - 2 * @moon-radio-item-indicator-border;
-		height: @moon-selectable-item-indicator-height - 2 * @moon-radio-item-indicator-border;
+		top: 50%;
+		-webkit-transform: translateY(-50%);
+		transform: translateY(-50%);
+		width: (@moon-selectable-item-indicator-width - 2 * @moon-radio-item-indicator-border);
+		height: (@moon-selectable-item-indicator-height - 2 * @moon-radio-item-indicator-border);
 		border: solid @moon-radio-item-indicator-border @moon-spotlight-text-color;
-		border-radius: @moon-selectable-item-indicator-width / 2;
+		border-radius: (@moon-selectable-item-indicator-width / 2);
 		background-color: @moon-button-disabled-text-color;
 	}
 
@@ -22,14 +24,17 @@
 			background-color: @moon-accent;
 		}
 	}
-}
 
-.enyo-locale-right-to-left .moon-radio-item {
-	margin: 0 0 0 @moon-radio-item-gap;
-	padding: 12px @moon-item-indent + @moon-spotlight-outset 12px @moon-spotlight-outset;
+	.enyo-locale-right-to-left & {
+		margin-left: @moon-radio-item-gap;
+		margin-right: 0;
+		padding-left: @moon-spotlight-outset;
+		padding-right: (@moon-item-indent + @moon-spotlight-outset);
 
-	&:before {
-		left: auto;
-		right: @moon-spotlight-outset;
+		&:before {
+			left: auto;
+			right: @moon-spotlight-outset;
+		}
 	}
 }
+

--- a/lib/SelectableItem/SelectableItem.less
+++ b/lib/SelectableItem/SelectableItem.less
@@ -1,15 +1,17 @@
 /* SelectableItem.css */
 .moon-selectable-item.selected {
-	padding: 12px @moon-spotlight-outset 12px @moon-item-indent + @moon-spotlight-outset;
+	padding-left: (@moon-item-indent + @moon-spotlight-outset);
 
 	&:before {
 		content: '';
 		position: absolute;
 		left: @moon-spotlight-outset;
-		top: 18px;
+		top: 50%;
+		-webkit-transform: translateY(-50%);
+		transform: translateY(-50%);
 		width: @moon-selectable-item-indicator-width;
 		height: @moon-selectable-item-indicator-height;
-		border-radius: @moon-selectable-item-indicator-width / 2;
+		border-radius: (@moon-selectable-item-indicator-width / 2);
 		background-color: @moon-accent;
 	}
 
@@ -22,7 +24,8 @@
 	.moon-selectable-item {
 
 		&.selected {
-			padding: 12px @moon-item-indent + @moon-spotlight-outset 12px @moon-spotlight-outset;
+			padding-left: @moon-spotlight-outset;
+			padding-right: (@moon-item-indent + @moon-spotlight-outset);
 
 			&:before {
 				left: auto;


### PR DESCRIPTION
These changes did not need to be locale-specific as they should not drastically alter the appearance of non-tall-glyph-locales.
Tested with the Thai tall glyph: `ฎิ์`

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>