### PR TITLE
ENYO-1496: AppInfo-checking components in moon.History

### DIFF
--- a/lib/History/History.js
+++ b/lib/History/History.js
@@ -4,6 +4,8 @@ var
 	kind = require('enyo/kind'),
 	ready = require('enyo/ready'),
 	dispatcher = require('enyo/dispatcher'),
+	platform = require('enyo/platform'),
+	Ajax = require('enyo/Ajax'),
 	Signals = require('enyo/Signals');
 
 /**
@@ -65,34 +67,7 @@ var History = module.exports = kind.singleton({
 	/**
 	* @private
 	*/
-	lunaServiceComponents: [
-		{
-			name:       'getAppID',
-			kind:       'enyo.LunaService',
-			service:    'palm://com.webos.applicationManager/',
-			method:     'getForegroundAppInfo',
-			subscribe:  true,
-			onComplete: '_getAppIDHandler'
-		},
-		{
-			name:       'getAppInfo',
-			kind:       'enyo.LunaService',
-			service:    'luna://com.webos.applicationManager/',
-			method:     'getAppInfo',
-			subscribe:  true,
-			onComplete: '_getAppInfoHandler'
-		}
-	],
-
-	/**
-	* @private
-	*/
 	init: function() {
-		// if (enyo.LunaService) {
-		// 	this.createChrome(this.lunaServiceComponents);
-		// 	this._getAppID();
-		// }
-
 		if (this.enableBackHistoryAPI) {
 			this._initHistoryState();
 		}
@@ -100,6 +75,8 @@ var History = module.exports = kind.singleton({
 		this._popStateHandler = this.bindSafely(this.popStateHandler);
 
 		this.enableBackHistoryAPIChanged();
+
+		this._fetchAppInfo();
 	},
 
 	/**
@@ -112,63 +89,6 @@ var History = module.exports = kind.singleton({
 	},
 
 	/**
-	* When our platform is "PalmSystem", we need the appID to access the proper appinfo.json.
-	*
-	* @private
-	*/
-	_getAppID: function () {
-		// if(scope.PalmSystem) {
-		// 	var param = {'extraInfo': true};
-		// 	this.$.getAppID.send(param);
-		// }
-	},
-
-	/**
-	* After LunaService returns the appId, we can retrieve the necessary app information.
-	*
-	* @private
-	*/
-	_getAppIDHandler: function (inSender, inResponse) {
-		if(inResponse.foregroundAppInfo != null && inResponse.foregroundAppInfo !== undefined) {
-			var foregroundAppInfo = inResponse.foregroundAppInfo;
-			var appID = '';
-			for(var i=0; i<foregroundAppInfo.length; i++) {
-				if(foregroundAppInfo[i].appId !== undefined && foregroundAppInfo[i].windowType === '_WEBOS_WINDOW_TYPE_CARD') {
-					appID = foregroundAppInfo[i].appId;
-					break;
-				}
-			}
-			if(appID !== ''){
-				this._getAppInfo(appID);
-			}
-		}
-	},
-
-	/**
-	* Retrieve properties from appinfo.json.
-	*
-	* @private
-	*/
-	_getAppInfo: function (appID) {
-		// if(scope.PalmSystem) {
-		// 	var param = {};
-		// 	param.id = appID;
-		// 	this.$.getAppInfo.send(param);
-		// }
-	},
-
-	/**
-	* Determine the appropriate value of `enableBackHistoryAPI` from the app information.
-	*
-	* @private
-	*/
-	_getAppInfoHandler: function (inSender, inResponse) {
-		if(inResponse.appInfo !== undefined) {
-			this.enableBackHistoryAPI = !inResponse.appInfo.disableBackHistoryAPI;
-		}
-	},
-
-	/**
 	* @private
 	*/
 	enableBackHistoryAPIChanged: function () {
@@ -176,6 +96,30 @@ var History = module.exports = kind.singleton({
 			dispatcher.listen(window, this._eventName, this._popStateHandler);
 		} else {
 			dispatcher.stopListening(window, this._eventName, this._popStateHandler);
+		}
+	},
+
+	/**
+	* Requests a local appinfo.json on webOS devices to check for a disableBackHistoryAPI flag.
+	*
+	* @private
+	*/
+	_fetchAppInfo: function () {
+		if (platform.webos) {
+			this._appInfoReq = new Ajax({url: 'appinfo.json'});
+			this._appInfoReq.response(this._checkAppInfo, this);
+			this._appInfoReq.go();
+		}
+	},
+
+	/**
+	* If appinfo data successfully received, check for disableBackHistoryAPI flag and update settings.
+	*
+	* @private
+	*/
+	_checkAppInfo: function (inSender, inResponse) {
+		if (inResponse !== undefined) {
+			this.set('enableBackHistoryAPI', !inResponse.disableBackHistoryAPI);
 		}
 	},
 


### PR DESCRIPTION
Checks the appinfo.json for the disableBackHistoryAPI flag.

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>