### PR TITLE
ENYO-1621: Marquee distance is not properly updated at first time, so marquee does not flow entirely

### DIFF
--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -850,6 +850,7 @@ var MarqueeItem = exports.Item = {
 		// Lazy creation of _this.$.marqueeText_
 		if (!this.$.marqueeText) {
 			this._marquee_createMarquee();
+			distance = this._marquee_calcDistance();
 		}
 
 		this._marquee_addAnimationStyles(distance);


### PR DESCRIPTION
Changes from https://github.com/enyojs/moonstone/pull/2134.