### PR TITLE
calc on reflow, and only calc when visible on setContent

### DIFF
--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -724,6 +724,7 @@ var MarqueeItem = exports.Item = {
 		return function () {
 			sup.apply(this, arguments);
 			this._marquee_invalidateMetrics();
+			this._marquee_calcDistance();
 		};
 	}),
 
@@ -808,7 +809,9 @@ var MarqueeItem = exports.Item = {
 		if (this.generated) {
 			this._marquee_invalidateMetrics();
 			this._marquee_detectAlignment();
-			this._marquee_calcDistance();
+			if(this.getAbsoluteShowing()){
+				this._marquee_calcDistance();
+			}
 		}
 		this._marquee_reset();
 	},

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -809,7 +809,7 @@ var MarqueeItem = exports.Item = {
 		if (this.generated) {
 			this._marquee_invalidateMetrics();
 			this._marquee_detectAlignment();
-			if(this.getAbsoluteShowing()){
+			if (this.getAbsoluteShowing()) {
 				this._marquee_calcDistance();
 			}
 		}


### PR DESCRIPTION
Issue.

Hidden Marquees would not update because the bounds of the box would be 0,0,0,0 when hidden.

Solution.

Added a check to reflow for items that are re-rendered.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com

2.5-upkeep https://github.com/enyojs/moonstone/pull/2217
