### PR TITLE
check on reflow, and only check visible items

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -704,6 +704,7 @@
 			return function () {
 				sup.apply(this, arguments);
 				this._marquee_invalidateMetrics();
+				this._marquee_calcDistance();
 			};
 		}),
 
@@ -788,7 +789,9 @@
 			if (this.generated) {
 				this._marquee_invalidateMetrics();
 				this._marquee_detectAlignment();
-				this._marquee_calcDistance();
+				if(this.getAbsoluteShowing()){
+					this._marquee_calcDistance();
+				}
 			}
 			this._marquee_reset();
 		},
@@ -896,10 +899,11 @@
 		* @private
 		*/
 		_marquee_calcDistance: function () {
-			var node, rect;
+			var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(), 
+				rect;
 
-			if (this._marquee_distance == null) {
-				node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode();
+			if (node && this._marquee_distance == null) {
+
 				rect = node.getBoundingClientRect();
 				this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
 				


### PR DESCRIPTION
add back rolled back changesIssue.

Hidden Marquees would not update because the bounds of the box would be 0,0,0,0 when hidden.

Solution.

Added a check to reflow for items that are re-rendered. Guarding calcDistance for instances where there are no nodes.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com