### PR TITLE
check on reflow, and only check visible items

### DIFF
--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -809,7 +809,7 @@ var MarqueeItem = exports.Item = {
 		if (this.generated) {
 			this._marquee_invalidateMetrics();
 			this._marquee_detectAlignment();
-			if(this.getAbsoluteShowing()){
+			if (this.getAbsoluteShowing()) {
 				this._marquee_calcDistance();
 			}
 		}
@@ -920,7 +920,7 @@ var MarqueeItem = exports.Item = {
 	* @private
 	*/
 	_marquee_calcDistance: function () {
-		var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(), 
+		var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(),
 			rect;
 
 		if (node && this._marquee_distance == null) {

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -724,6 +724,7 @@ var MarqueeItem = exports.Item = {
 		return function () {
 			sup.apply(this, arguments);
 			this._marquee_invalidateMetrics();
+			this._marquee_calcDistance();
 		};
 	}),
 
@@ -808,7 +809,9 @@ var MarqueeItem = exports.Item = {
 		if (this.generated) {
 			this._marquee_invalidateMetrics();
 			this._marquee_detectAlignment();
-			this._marquee_calcDistance();
+			if(this.getAbsoluteShowing()){
+				this._marquee_calcDistance();
+			}
 		}
 		this._marquee_reset();
 	},
@@ -917,10 +920,10 @@ var MarqueeItem = exports.Item = {
 	* @private
 	*/
 	_marquee_calcDistance: function () {
-		var node, rect;
+		var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(), 
+			rect;
 
-		if (this._marquee_distance == null) {
-			node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode();
+		if (node && this._marquee_distance == null) {
 			rect = node.getBoundingClientRect();
 			this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
 


### PR DESCRIPTION
add back rolled back changesIssue.

Hidden Marquees would not update because the bounds of the box would be 0,0,0,0 when hidden.

Solution.

Added a check to reflow for items that are re-rendered. Guarding calcDistance for instances where there are no nodes.

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com