### PR TITLE
ENYO-1687 : apply accessibility on moonstone checkboxItem

### DIFF
--- a/lib/Checkbox/Checkbox.js
+++ b/lib/Checkbox/Checkbox.js
@@ -101,7 +101,7 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{name: 'checkboxIcon', kind: Icon, icon: 'check'}
+		{name: 'checkboxIcon', kind: Icon, accessibilityDisabled: true, icon: 'check'}
 	],
 
 	/**

--- a/lib/CheckboxItem/CheckboxItem.js
+++ b/lib/CheckboxItem/CheckboxItem.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control');
 
 var
@@ -14,6 +15,9 @@ var
 	Marquee = require('../Marquee'),
 	MarqueeSupport = Marquee.Support,
 	MarqueeItem = Marquee.Item;
+
+var
+	CheckboxItemAccessibilitySupport = require('./CheckboxItemAccessibilitySupport');
 
 /**
 * Fires when the control is either checked or unchecked.
@@ -60,6 +64,7 @@ var
 * @class CheckboxItem
 * @extends module:enyo/Control~Control
 * @mixes module:moonstone/MarqueeSupport~MarqueeSupport
+* @mixes moonstone/CheckboxItem/CheckboxItemAccessibilitySupport~CheckboxItemAccessibilitySupport
 * @ui
 * @public
 */
@@ -79,8 +84,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins: [MarqueeSupport],
-
+	mixins: options.accessibility ? [CheckboxItemAccessibilitySupport, MarqueeSupport] : [MarqueeSupport],
 
 	/**
 	* @private
@@ -200,8 +204,8 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{name: 'client', mixins: [MarqueeItem], classes: 'moon-checkbox-item-label-wrapper'},
-		{name: 'input', kind: Checkbox, spotlight: false}
+		{name: 'client', accessibilityDisabled: true, mixins: [MarqueeItem], classes: 'moon-checkbox-item-label-wrapper'},
+		{name: 'input', kind: Checkbox, accessibilityDisabled: true, spotlight: false}
 	],
 
 	/**

--- a/lib/CheckboxItem/CheckboxItemAccessibilitySupport.js
+++ b/lib/CheckboxItem/CheckboxItemAccessibilitySupport.js
@@ -1,0 +1,38 @@
+/**
+* Provides a mixin to add accessibility support to
+* {@link module:moonstone/CheckboxItem~CheckboxItem}
+*
+* @module moonstone/CheckboxItem/CheckboxItemAccessibilitySupport
+* @private
+*/
+
+var
+	kind = require('enyo/kind');
+
+/**
+* @name CheckboxItemAccessibilitySupport
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: ['checked']}
+	],
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function () {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.setAttribute('role', enabled ? 'checkbox' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+			this.setAttribute('aria-checked', enabled ? String(this.checked) : null);
+			this.setAttribute('aria-labelledby', enabled ? this.$.client.getId() : null);
+		};
+	})
+};

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -317,7 +317,7 @@ module.exports = kind(
 	*/
 	smallChanged: function () {
 		if (this.small) {
-			var ta = this.createComponent({name: 'tapArea', classes: 'small-icon-tap-area', allowHtml: this.allowHtml, isChrome: true});
+			var ta = this.createComponent({name: 'tapArea', classes: 'small-icon-tap-area', accessibilityDisabled: this.accessibilityDisabled, allowHtml: this.allowHtml, isChrome: true});
 
 			if (this.generated) {
 				ta.render();


### PR DESCRIPTION
Apply accessibility on moonstone CheckboxItem. 


## Issue

When CheckboxItem is focused, Only child checkbox is readout.

## Cause

The CheckboxItem consists of checkbox and text item. When spotlight is focused on CheckboxItem, only child checkbox component is readout because CheckboxItem does not have checkbox role and aria-checked attribute.

Checkbox and Text Item are child component of CheckboxItem, so they do not need tabIndex and accessibility-related code and If CheckboxItem has accessibilityDisabled:true, their accessibilityDisabled value also should be true To implement this work, we added accessibilityDisabled attribute to each component source code.

In CheckboxItem, **accessibilityDisabled:true** is added to checkbox and text control regardless of accessibilityDisabled of CheckboxItem.
In Checkbox, **accessibilityDisabled:true** is added to checkbox Icon regardless of accessibilityDisabled of Checkbox.
On the other hand, In Icon, **accessibilityDisabled:this.accessibilityDisabled** is added to child component, which is created dynamically when Icon is small. Because small Icon should have tabIndex when Icon used alone and accessibilityDisabled value is false
 
## Fix
Add checkbox role and aria-checked attribute to CheckboxItem.
Set accessibilityDisabled of child components to true.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com