### PR TITLE
ENYO-1285 : Marquee Not Ellipse

### DIFF
--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -400,6 +400,10 @@ module.exports = kind(
 		this.inherited(arguments);
 		this.$.currentValue.setShowing(!this.open);
 		this.setActive(this.getOpen());
+		
+		if(this.open) {
+			this.$.drawer.render();	
+		}
 	},
 
 	/**


### PR DESCRIPTION
Issue.

When a marquee is within a parent, that has a 0,0,0,0 Bounds, the the marquee also reports a 0,0,0,0 bounds.

Fix.

As the drawer to re-render after being opened, so that we will ask the children of the drawer to fire a reflow.