### PR TITLE
Enyo 1800 Allow for specification of jumpIncrement in terms of value instead of percentage

### DIFF
--- a/lib/Slider/Slider.js
+++ b/lib/Slider/Slider.js
@@ -143,6 +143,16 @@ module.exports = kind(
 		enableJumpIncrement: false,
 
 		/**
+		* JumpIncrement will be percentage when it is true.
+		* In other hand, it will be value
+		*
+		* @type {Boolean}
+		* @default true
+		* @public
+		*/
+		usePercentageForJumpIncrement: false,
+
+		/**
 		* Sliders will increase or decrease as much as this percentage value in either direction
 		* when jumpIncrement button is tapped.
 		*
@@ -426,7 +436,7 @@ module.exports = kind(
 		this.popupContentChanged();
 		this.tapAreaClassesChanged();
 		this.initSliderStyles();
-		this.jumpIncrementChanged();
+		if (this.enableJumpIncrement && this.usePercentageForJumpIncrement) this.jumpIncrementChanged();
 	},
 
 	/**
@@ -1113,7 +1123,8 @@ module.exports = kind(
 	* @public
 	*/
 	previous: function () {
-		this.set('value', this.value - this._jumpIncrementAmount);
+		var jumpIncrementAmount = (this.usePercentageForJumpIncrement) ? this._jumpIncrementAmount : this.jumpIncrement;
+		this.set('value', this.value - jumpIncrementAmount);
 	},
 
 	/**
@@ -1122,6 +1133,7 @@ module.exports = kind(
 	* @public
 	*/
 	next: function () {
-		this.set('value', this.value + this._jumpIncrementAmount);
+		var jumpIncrementAmount = (this.usePercentageForJumpIncrement) ? this._jumpIncrementAmount : this.jumpIncrement;
+		this.set('value', this.value + jumpIncrementAmount);
 	}
 });


### PR DESCRIPTION
Issue
-------
Currently jump Increment based on percentage. Add an option to use value.

Fix
----
Add public property to decide jump increment unit among percentage and value.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com