### PR TITLE
ENYO-1688 : apply accessibility on moonstone ToggleButton

### DIFF
--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -9,12 +9,14 @@ var
 	kind = require('enyo/kind'),
 	util = require('enyo/utils'),
 	Control = require('enyo/Control'),
-	Button = require('enyo/Button');
+	Button = require('enyo/Button'),
+	options = require('enyo/options');
 
 var
 	Marquee = require('../Marquee'),
 	MarqueeSupport = Marquee.Support,
-	MarqueeText = Marquee.Text;
+	MarqueeText = Marquee.Text,
+	ButtonAccessibilitySupport = require('./ButtonAccessibilitySupport');
 
 /**
 * {@link module:moonstone/Button~Button} is an {@link module:enyo/Button~Button} with Moonstone styling applied.
@@ -46,7 +48,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins: [MarqueeSupport],
+	mixins: options.accessibility ? [ButtonAccessibilitySupport, MarqueeSupport] : [MarqueeSupport], 
 
 	/**
 	* @private
@@ -163,7 +165,7 @@ module.exports = kind(
 	*/
 	initComponents: function () {
 		if (!(this.components && this.components.length > 0)) {
-			this.createComponent({name: 'client', kind: MarqueeText, classes: 'button-client', isChrome: true});
+			this.createComponent({name: 'client', kind: MarqueeText, classes: 'button-client', isChrome: true, accessibilityDisabled: true});
 			this.createComponent({name: 'tapArea', kind: Control, classes: 'button-tap-area', isChrome: true});
 		}
 		if (this.small) this.smallChanged();

--- a/lib/Button/ButtonAccessibilitySupport.js
+++ b/lib/Button/ButtonAccessibilitySupport.js
@@ -1,0 +1,21 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name ButtonAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function () {
+			var enabled = !this.accessibilityDisabled,
+				id = this.$.client ? this.$.client.getId() : this.getId();
+			sup.apply(this, arguments);
+			this.setAttribute('aria-labelledby', enabled ? id : null);
+		};
+	})
+};

--- a/lib/ToggleButton/ToggleButton.js
+++ b/lib/ToggleButton/ToggleButton.js
@@ -7,10 +7,12 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
-	util = require('enyo/utils');
+	util = require('enyo/utils'),
+	options = require('enyo/options');
 
 var
-	Button = require('../Button');
+	Button = require('../Button'),
+	ToggleButtonAccessibilitySupport = require('./ToggleButtonAccessibilitySupport');
 
 /**
 * Fires when the value of the toggle button changes.
@@ -50,6 +52,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Button,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [ToggleButtonAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/ToggleButton/ToggleButtonAccessibilitySupport.js
+++ b/lib/ToggleButton/ToggleButtonAccessibilitySupport.js
@@ -1,0 +1,27 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name ToggleButtonAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: 'value'}
+	],
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.setAttribute('aria-pressed', enabled ? String(this.value) : null);
+		};
+	})
+};


### PR DESCRIPTION
Apply accessibility on moonstone ToggleButton
However, ToggleButton's child component has tabIndex, so we should remove it because ToggleButton already has button role and related aria attributes.
Thus, add **accessibilityDisabled:true** to moonstone Button because ToggleButton extends Button.

## Issue

Should read out toggle status when the spotlight is focused to ToggleButton

## Cause

ToggleButton requires press-and-release cycle to change their value.
To support readout toggle-status, we should add aria-pressed attribute to ToggleButton.

## Fix

Add aria-pressed attribute to ToggleButton
Remove tablndex from Button using accessibilityDisabled API.
In addition, add aria-labelledby attribute because screen reader does not reads when child component has tabindex.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com