### PR TITLE
DRD-12481 : Change accessibility label content

### DIFF
--- a/lib/VideoPlayer/VideoPlayerAccessibilitySupport.js
+++ b/lib/VideoPlayer/VideoPlayerAccessibilitySupport.js
@@ -16,10 +16,10 @@ module.exports = {
 	initAccessibility: kind.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
-			this.$.jumpBack.set('accessibilityLabel', $L('Jump Back'));
+			this.$.jumpBack.set('accessibilityLabel', $L('Previous'));
 			this.$.rewind.set('accessibilityLabel', $L('Rewind'));
 			this.$.fastForward.set('accessibilityLabel', $L('Fast Forward'));
-			this.$.jumpForward.set('accessibilityLabel', $L('Jump Forward'));
+			this.$.jumpForward.set('accessibilityLabel', $L('Next'));
 			this.$.moreButton.set('accessibilityLabel', $L('More'));
 		};
 	}),
@@ -43,7 +43,7 @@ module.exports = {
 		return function (props) {
 			sup.apply(this, arguments);
 			var index = this.$.controlsContainer.getIndex();
-			var label = index === 0 ? $L('More') : $L('Less');
+			var label = index === 0 ? $L('More') : $L('Back');
 			this.$.moreButton.set('accessibilityLabel', label);
 		};
 	})


### PR DESCRIPTION
## Issue 
The name of the playback control buttons are read differently from UX.
UX requirement is reading
"previous", "rewind", "play/pause", "fast forward", "next" on playback icon

## Cause
The UX guideline is updated after applying accessibility on playback control buttons.  

## Fix
Change accessibility label content with changed name of UX guideline ( UX_2016_webOS_Initial_Audio Guidance_v1.0.4_150618.pdf )

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
