### PR TITLE
ENYO-1761: Toggle Item might be shifted down on TV

### DIFF
--- a/lib/ToggleSwitch/ToggleSwitch.less
+++ b/lib/ToggleSwitch/ToggleSwitch.less
@@ -10,9 +10,11 @@
 	text-align: left;
 
 	.moon-icon {
+		position: absolute;
 		visibility: visible;
 		cursor: default;
 		background-color: transparent;
+		top: 0;
 		left: 0;
 		color: @moon-checkbox-toggle-switch-color;
 		width: @moon-toggleswitch-height;


### PR DESCRIPTION
### Issue:
Toggle Item shifted down on TV but not in browser
### Fix:
For some mysterious reason, 'position: relative' on tv caused icon to be shifted down on tv but not browser. 'position: absolute' worked on both.

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan <krishna.rangarajan@lge.com>