### PR TITLE
ENYO-1762: apply backgroundOpacity property to closebutton controls

### DIFF
--- a/lib/Dialog/Dialog.js
+++ b/lib/Dialog/Dialog.js
@@ -133,7 +133,7 @@ module.exports = kind(
 	* @private
 	*/
 	tools: [
-		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', showing: false},
+		{name: 'closeButton', kind: IconButton, icon: 'closex', backgroundOpacity: 'transparent', classes: 'moon-popup-close', ontap: 'closePopup', showing: false},
 		{kind: Control, classes: 'moon-dialog-client-wrapper', components: [
 			{name: 'client', kind: Control, classes: 'moon-dialog-client'},
 			{components: [

--- a/lib/Icon/Icon.less
+++ b/lib/Icon/Icon.less
@@ -59,3 +59,6 @@
 	filter: alpha(opacity=@moon-disabled-opacity-ie);
 }
 
+.moon-neutral .moon-icon {
+	color: @moon-neutral-icon-color;
+}

--- a/lib/IconButton/IconButton.less
+++ b/lib/IconButton/IconButton.less
@@ -101,3 +101,10 @@
 		background-position: center -@moon-icon-sprite-small-size;
 	}
 }
+
+.moon-neutral .moon-icon-button {
+	&:active,
+	&.pressed {
+		color: @moon-neutral-icon-color;
+	}
+}

--- a/lib/ListActions/ListActions.js
+++ b/lib/ListActions/ListActions.js
@@ -388,7 +388,7 @@ var ListActions = module.exports = kind(
 	*/
 	drawerComponents: [
 		{name: 'drawer', spotlightDisabled: true, kind: ListActionsDrawer, classes: 'list-actions-drawer', onComplete: 'drawerAnimationEnd', open: false, spotlight: 'container', spotlightModal:true, components: [
-			{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close moon-list-actions-close moon-neutral', ontap: 'expandContract', defaultSpotlightDown:'listActions'},
+			{name: 'closeButton', kind: IconButton, icon: 'closex', backgroundOpacity: 'transparent', classes: 'moon-popup-close moon-list-actions-close moon-neutral', ontap: 'expandContract', defaultSpotlightDown:'listActions'},
 			{name: 'listActionsClientContainer', kind: Control, classes: 'enyo-fit moon-list-actions-client-container moon-neutral', components: [
 				{name: 'listActions', kind: Scroller, classes: 'enyo-fit moon-list-actions-scroller', horizontal:'hidden', vertical:'hidden', onActivate: 'optionSelected', defaultSpotlightUp:'closeButton'}
 			]}

--- a/lib/Popup/Popup.js
+++ b/lib/Popup/Popup.js
@@ -170,7 +170,7 @@ module.exports = kind(
 	*/
 	tools: [
 		{name: 'client', kind: Control, classes:'enyo-fill'},
-		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', showing:false}
+		{name: 'closeButton', kind: IconButton, icon: 'closex', backgroundOpacity: 'transparent', classes: 'moon-popup-close', ontap: 'closePopup', showing:false}
 	],
 
 	/**

--- a/lib/Popup/Popup.less
+++ b/lib/Popup/Popup.less
@@ -31,14 +31,6 @@
 	right: @moon-spotlight-outset;
 	top: @moon-spotlight-outset;
 	margin: 0;
-	background-repeat: no-repeat;
-	background-position: 0 0;
-	color: @moon-popup-close-text-color;
-
-	&.pressed,
-	&:active {
-		color: @moon-neutral-icon-color;
-	}
 }
 
 .enyo-locale-right-to-left {

--- a/lib/Popup/Popup.less
+++ b/lib/Popup/Popup.less
@@ -37,7 +37,6 @@
 
 	&.pressed,
 	&:active {
-		background-color: transparent;
 		color: @moon-neutral-icon-color;
 	}
 }

--- a/lib/Popup/Popup.less
+++ b/lib/Popup/Popup.less
@@ -31,7 +31,6 @@
 	right: @moon-spotlight-outset;
 	top: @moon-spotlight-outset;
 	margin: 0;
-	background-color: transparent;
 	background-repeat: no-repeat;
 	background-position: 0 0;
 	color: @moon-popup-close-text-color;


### PR DESCRIPTION
close buttons in Popup, Dialog and ListActions controls had a css property background-color: transparent, this property is replaced with backgroundOpacity: transparent as a different approch to implement the translucency properties 

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com