### PR TITLE
ENYO-1864: Utilize module instead of string kind name.

### DIFF
--- a/lib/DayPicker/DayPicker.js
+++ b/lib/DayPicker/DayPicker.js
@@ -6,7 +6,8 @@
 require('moonstone');
 
 var
-	kind = require('enyo/kind');
+	kind = require('enyo/kind'),
+	Signals = require('enyo/Signals');
 
 var
 	ilib = require('enyo-ilib');
@@ -129,7 +130,7 @@ module.exports = kind(
 	* @private
 	*/
 	tools: [
-		{kind: 'enyo.Signals', onlocalechange: 'handleLocaleChangeEvent'}
+		{kind: Signals, onlocalechange: 'handleLocaleChangeEvent'}
 	],
 
 	/**


### PR DESCRIPTION
### Issue
We missed updating `moon.DayPicker` to utilize the `Signals` module.

### Fix
Updated to use the `Signals` module instead of the string kind name.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>