### PR TITLE
ENYO-1285 : Marquee Text is ellipsis on marquee

### DIFF
--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -923,7 +923,7 @@ var MarqueeItem = {
 		var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(),
 			rect;
 
-		if (node && this._marquee_distance == null) {
+		if (node && this._marquee_distance == null && this.getAbsoluteShowing() == true) {
 			rect = node.getBoundingClientRect();
 			this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
 

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -923,7 +923,7 @@ var MarqueeItem = {
 		var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(),
 			rect;
 
-		if (node && this._marquee_distance == null && this.getAbsoluteShowing() == true) {
+		if (node && this._marquee_distance == null && this.getAbsoluteShowing() === true) {
 			rect = node.getBoundingClientRect();
 			this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
 

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -809,9 +809,7 @@ var MarqueeItem = {
 		if (this.generated) {
 			this._marquee_invalidateMetrics();
 			this._marquee_detectAlignment();
-			if (this.getAbsoluteShowing()) {
-				this._marquee_calcDistance();
-			}
+			this._marquee_calcDistance();
 		}
 		this._marquee_reset();
 	},
@@ -923,7 +921,7 @@ var MarqueeItem = {
 		var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(),
 			rect;
 
-		if (node && this._marquee_distance == null && this.getAbsoluteShowing() === true) {
+		if (node && this._marquee_distance == null && this.getAbsoluteShowing()) {
 			rect = node.getBoundingClientRect();
 			this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
 


### PR DESCRIPTION
## Issue
marquee text is clipped only, even if content should be ellipsis in expandable picker, drawer, OverlayText...

## Fix
The reason why only clip is applied is we firstly cache the non-display control whose scrollWidth and getBoundingClientRect are zero as _marquee_distance.
We need to only cache the distance when controls are absoluty shown.

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung.lee@lge.com