### PR TITLE
ENYO-1852: Time/DatePicker closed status not properly updated with locale change

### DIFF
--- a/src/DateTimePickerBase/DateTimePickerBase.js
+++ b/src/DateTimePickerBase/DateTimePickerBase.js
@@ -328,6 +328,7 @@ module.exports = kind(
 		if (this.value) {
 			this.localeValue = dateFactory({unixtime: this.value.getTime(), timezone: "local"});
 		}
+		this.set('open', false);
 		this.initDefaults();
 		this.render();
 	}


### PR DESCRIPTION
### Issue:
When the DateTime picker is opened and then changed the locale, the picker collapsed and look like it is closed. But the arrow still points upwards (^) and the property remains as opened.

### Cause:
onLocaleChanged the picker is destroying and recreating the client control  but the open property is not resetting to false.

### Fix:
In refresh() function DateTimePickerBase, the open property resettled to false.

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com 