### PR TITLE
ENYO-1858: Accessibility: After I select an option of the expandable …

### DIFF
--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -216,9 +216,9 @@ module.exports = kind(
 		{name: 'headerWrapper', kind: Item, classes: 'moon-expandable-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header', components: [
-				{name: 'header', kind: MarqueeText}
+				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 			]},
-			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-picker-current-value'}
+			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-picker-current-value'}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes:'moon-expandable-list-item-client', onDrawerAnimationEnd: 'handleDrawerAnimationEnd', components: [
 			{name: 'client', tag: null, kind: Group, onActivate: 'activated', highlander: true},

--- a/lib/ExpandablePicker/ExpandablePickerAccessibilitySupport.js
+++ b/lib/ExpandablePicker/ExpandablePickerAccessibilitySupport.js
@@ -12,9 +12,10 @@ module.exports = {
 	*/
 	updateAccessibilityAttributes: kind.inherit(function (sup) {
 		return function (was, is, prop) {
-			var enabled = !this.accessibilityDisabled;
+			var enabled = !this.accessibilityDisabled,
+				ids = this.$.header.getId() + ' ' + this.$.currentValue.getId();
 			sup.apply(this, arguments);
-			this.$.headerWrapper.setAttribute('aria-labelledby', enabled ? this.$.headerWrapper.getId() : null);
+			this.$.headerWrapper.setAttribute('aria-labelledby', enabled ? ids : null);
 			this.$.headerWrapper.set('accessibilityDisabled', this.accessibilityDisabled);
 			this.$.client.set('accessibilityDisabled', this.accessibilityDisabled);
 			this.$.helpText.set('accessibilityDisabled', this.accessibilityDisabled);

--- a/lib/ExpandablePicker/ExpandablePickerAccessibilitySupport.js
+++ b/lib/ExpandablePicker/ExpandablePickerAccessibilitySupport.js
@@ -10,18 +10,14 @@ module.exports = {
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
-		return function (props) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.$.currentValue.observe('content', this.changeLabel, this);
-			this.changeLabel();
+			this.$.headerWrapper.setAttribute('aria-labelledby', enabled ? this.$.headerWrapper.getId() : null);
+			this.$.headerWrapper.set('accessibilityDisabled', this.accessibilityDisabled);
+			this.$.client.set('accessibilityDisabled', this.accessibilityDisabled);
+			this.$.helpText.set('accessibilityDisabled', this.accessibilityDisabled);
 		};
-	}),
-
-	/**
-	* @private
-	*/
-	changeLabel: function() {
-		this.set('accessibilityHint', this.$.currentValue.getContent());
-	}
+	})
 };


### PR DESCRIPTION
…picker, I can't hear any sound.

- Blink skip focasable child when parent is focused, so to be able to
read
child innertext I set the 'aria-labelledby' on parent node
headerWrapper.
- It doesn't need aria attributes on children components because they
can get the focus, so add accessibilityDisabled true on each child
component of ExpandablePicker

https://jira2.lgsvl.com/browse/ENYO-1858
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>