### PR TITLE
ENYO-1886: All GridListImageItems should be measured the same way.

### DIFF
--- a/lib/GridListImageItem/GridListImageItem.less
+++ b/lib/GridListImageItem/GridListImageItem.less
@@ -6,6 +6,7 @@
 	display: inline-block;
 	overflow: hidden;
 	border: 6px solid transparent;
+	box-sizing: border-box;
 
 	.caption {
 		.moon-sub-header-text;


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>