### PR TITLE
ENYO-1880: Add an alternative index updating mechanism that can accept additional options.

### DIFF
--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -49,12 +49,20 @@ module.exports = kind(
 	},
 
 	/**
-	* @private
+	* Changes to the specific index, accepting a number of additional options.
+	*
+	* @param {Number} to - The index of the panel we wish to transition to.
+	* @param {module:enyo/LightPanels~UpdateIndexOptions} [opts] - Additional options to be used
+	*	when updating the panel index.
+	* @param {Number} [from] - If known, the index we are transitioning from.
+	* @public
 	*/
-	indexChanged: function (previousIndex) {
+	updateIndex: function (to, opts, from) {
+		from = from != null ? from : this.index;
+
 		var panels = this.getPanels(),
-			panelPrev = panels[previousIndex],
-			panelNext = panels[this.index];
+			panelPrev = panels[from],
+			panelNext = panels[to];
 
 		if (panelPrev) {
 			panelPrev.spotlightDisabled = true;
@@ -65,7 +73,8 @@ module.exports = kind(
 		if (panelNext) {
 			panelNext.spotlightDisabled = false;
 		}
-		LightPanels.prototype.indexChanged.apply(this, arguments);
+
+		LightPanels.prototype.updateIndex.apply(this, arguments);
 	},
 
 	/**


### PR DESCRIPTION
### Issue
We are performing some `Spotlight` operations when the index changes. Due to the changes in https://github.com/enyojs/enyo/pull/1216, these operations need to be performed when `updateIndex` is run.

### Fix
We moved these operations to `updateIndex` and refactored things a little bit.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>