### PR TITLE
ENYO-1945: Removed 'enyo.Signals' and require enyo/Signals

### DIFF
--- a/lib/DayPicker/DayPicker.js
+++ b/lib/DayPicker/DayPicker.js
@@ -6,7 +6,8 @@
 require('moonstone');
 
 var
-	kind = require('enyo/kind');
+	kind = require('enyo/kind'),
+	Signals = require('enyo/Signals');
 
 var
 	ilib = require('enyo-ilib');
@@ -129,7 +130,7 @@ module.exports = kind(
 	* @private
 	*/
 	tools: [
-		{kind: 'enyo.Signals', onlocalechange: 'handleLocaleChangeEvent'}
+		{kind: Signals, onlocalechange: 'handleLocaleChangeEvent'}
 	],
 
 	/**


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>