### PR TITLE
ENYO-1885: Extend NewDataList.scrollToItem...

### DIFF
--- a/lib/NewDataList/NewDataList.js
+++ b/lib/NewDataList/NewDataList.js
@@ -41,6 +41,34 @@ module.exports = kind({
 
 		return (row === limitRow);
 	},
+	/**
+	* Scrolls to a list item (specified by index).
+	*
+	* In addition to the standard scrolling options, you can specify
+	* `focus: true` if you want the item you're scrolling to to be
+	* Spotlight focused. Currently, setting `focus: true` forces the
+	* scroll behavior to be `instant`, meaning that the scroller will
+	* jump to the item (with no animation).
+	* 
+	* @see module:enyo/NewDataList~NewDataList.scrollToItem
+	* @param {number} index - The (zero-based) index of the item to scroll to
+	* @param {Object} opts - Scrolling options (see module:enyo/Scrollable~Scrollable.scrollTo)
+	* @public
+	*/
+	scrollToItem: function(index, opts) {
+		var item;
+
+		if (opts && opts.focus) {
+			opts.behavior = 'instant';
+		}
+
+		NewDataList.prototype.scrollToItem.apply(this, arguments);
+
+		if (opts && opts.focus && !Spotlight.getPointerMode()) {
+			item = this.childForIndex(index);
+			if (item) Spotlight.spot(item);
+		}
+	},
 	avoidScrollOnDefaultFocus: function (sender, event) {
 		var fv;
 		// When focusType is 'default', Spotlight is trying to focus


### PR DESCRIPTION
...to add a `focus` option. When `focus` is true, the item will
be Spotlight focused in addition to being scrolled into view.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)