### PR TITLE
Fixes ENYO-1955

### DIFF
--- a/lib/Drawers/Drawer.js
+++ b/lib/Drawers/Drawer.js
@@ -330,7 +330,9 @@ var MoonDrawer = module.exports = kind(
 
 		// not accelerated and drawer has been rendered
 		if (options.accelerate) {
-			this.updateTop(top);
+			// The drawer may have just been shown in this frame so we need to delay applying the
+			// CSS transform until the next frame so the CSS animation takes effect.
+			utils.asyncMethod(this, 'updateTop', top);
 		} else {
 			bounds = this.getBounds();
 			this.$.animator.play({

--- a/lib/Drawers/Drawers.js
+++ b/lib/Drawers/Drawers.js
@@ -166,6 +166,7 @@ module.exports = kind(
 		//* Handlers to update the activator when the state of the contained drawers changes
 		onActivate: 'drawerActivated',
 		onDeactivate: 'drawerDeactivated',
+		onDrawerAnimationEnd: 'drawerAnimationComplete',
 		onSpotlightDown: 'spotDown',
 		onSpotlightUp: 'spotUp'
 	},
@@ -462,6 +463,13 @@ module.exports = kind(
 			// show/hide() is expensive. Use spotlightDisabled feature instead
 			this.$.client.spotlightDisabled = drawer.open;
 			this.animate(ev.height);
+		}
+	},
+
+	drawerAnimationComplete: function (sender, ev) {
+		var drawer = ev.originator instanceof MoonDrawer ? ev.originator : null;
+		if (drawer && !drawer.open && !drawer.controlsOpen) {
+			drawer.hide();
 		}
 	},
 


### PR DESCRIPTION
## Issue
In the prior implementation of Drawers, the internal enyo/Drawer would hide its client area thereby informing Spotlight that the currently spotted control was hidden and another control needed to be. With the removal of the internal enyo/Drawer, the spotted control or its ancestors were not hidden so spotlight didn't update.
## Fix
Add a hook to onDrawerAnimationEnd in moonstone/Drawers to hide the active drawer if it is completely closed.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)