### PR TITLE
ENYO-1880: Add ability to change indices without transition animation.

### DIFF
--- a/lib/LightPanel/LightPanel.js
+++ b/lib/LightPanel/LightPanel.js
@@ -152,7 +152,8 @@ module.exports = kind(
 	*/
 	postTransition: function () {
 		if (!this.$.client.children.length) {
-			this.createComponents(this.clientComponents);
+			var owner = this.hasOwnProperty('clientComponents') ? this.getInstanceOwner() : this;
+			this.createComponents(this.clientComponents, {owner: owner});
 			this.$.client.render();
 			this.$.client.addClass('populated');
 		}

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -59,8 +59,8 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	indexChanged: function () {
-		this.updateSpottability.apply(this, arguments);
+	indexChanged: function (was, is) {
+		this.updateSpottability(was, is);
 		LightPanels.prototype.indexChanged.apply(this, arguments);
 	},
 

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -51,10 +51,26 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	indexChanged: function (previousIndex) {
+	animateTo: function (index) {
+		this.updateSpottability(this.index, index);
+		LightPanels.prototype.animateTo.apply(this, arguments);
+	},
+
+	/**
+	* @private
+	*/
+	indexChanged: function () {
+		this.updateSpottability.apply(this, arguments);
+		LightPanels.prototype.indexChanged.apply(this, arguments);
+	},
+
+	/**
+	* @private
+	*/
+	updateSpottability: function (from, to) {
 		var panels = this.getPanels(),
-			panelPrev = panels[previousIndex],
-			panelNext = panels[this.index];
+			panelPrev = panels[from],
+			panelNext = panels[to];
 
 		if (panelPrev) {
 			panelPrev.spotlightDisabled = true;
@@ -65,7 +81,6 @@ module.exports = kind(
 		if (panelNext) {
 			panelNext.spotlightDisabled = false;
 		}
-		LightPanels.prototype.indexChanged.apply(this, arguments);
 	},
 
 	/**


### PR DESCRIPTION
### Issue
Based on the changes from https://github.com/enyojs/enyo/pull/1216, we need to update spottability when we utilize `animateTo`, in addition to when the `indexChanged` handler is run.

### Fix
We have factored out spottability update code into its own method, and call that from the appropriate methods.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>