### PR TITLE
ENYO-1891: Add Text to Speech Accessibility support to Integer Picker

### DIFF
--- a/lib/IntegerPicker/IntegerPicker.js
+++ b/lib/IntegerPicker/IntegerPicker.js
@@ -8,6 +8,7 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	dom = require('enyo/dom'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control'),
 	Scroller = require('enyo/Scroller');
 
@@ -16,7 +17,8 @@ var
 
 var
 	ScrollStrategy = require('../ScrollStrategy'),
-	TouchScrollStrategy = ScrollStrategy.Touch;
+	TouchScrollStrategy = ScrollStrategy.Touch,
+	IntegerPickerAccessibilitySupport = require('./IntegerPickerAccessibilitySupport');
 
 /**
 * Fires when the currently selected value changes.
@@ -61,6 +63,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Control,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [IntegerPickerAccessibilitySupport] : null,
 
 	/**
 	* @private
@@ -208,9 +215,9 @@ module.exports = kind(
 		// we're forcing TouchScrollStrategy
 		{kind: Scroller, strategyKind: TouchScrollStrategy, thumb:false, touch:true, useMouseWheel: false, classes: 'moon-scroll-picker', components:[
 			{name: 'repeater', kind: FlyweightRepeater, classes: 'moon-scroll-picker-repeater', ondragstart: 'dragstart', onSetupItem: 'setupItem', noSelect: true, components: [
-				{name: 'item', kind: Control, classes: 'moon-scroll-picker-item'}
+				{name: 'item', kind: Control, accessibilityDisabled: true, classes: 'moon-scroll-picker-item'}
 			]},
-			{name: 'buffer', kind: Control, classes: 'moon-scroll-picker-buffer'}
+			{name: 'buffer', kind: Control, accessibilityDisabled: true, classes: 'moon-scroll-picker-buffer'}
 		]},
 		{name:'previousOverlay', kind: Control, ondown:'downPrevious', onholdpulse:'previous', classes:'moon-scroll-picker-overlay-container previous', components:[
 			{kind: Control, classes: 'moon-scroll-picker-overlay previous'},

--- a/lib/IntegerPicker/IntegerPickerAccessibilitySupport.js
+++ b/lib/IntegerPicker/IntegerPickerAccessibilitySupport.js
@@ -1,0 +1,28 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name IntegerPickerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: ['value']}
+	],
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function () {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.setAttribute('role', enabled ? 'spinbutton' : null);
+			this.setAttribute('aria-valuenow', enabled ? this.value : null);
+		};
+	})
+};


### PR DESCRIPTION
In case using 'aria-live' there is an issue that it reads 'aria-label'
three times.
Blink team suggested using 'spinbutton' role on integer picker, so
applic 'spinbutton' role.
Note that 'spinbutton' role doesn't work on chrome vox.

https://jira2.lgsvl.com/browse/ENYO-1891
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>