### PR TITLE
ENYO-2017 : Remove Icon unicode content from Icon accessibilityHint message

### DIFF
--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -326,7 +326,7 @@ module.exports = kind(
 	*/
 	smallChanged: function () {
 		if (this.small) {
-			var ta = this.createComponent({name: 'tapArea', classes: 'small-icon-tap-area', accessibilityDisabled: this.accessibilityDisabled, allowHtml: this.allowHtml, isChrome: true});
+			var ta = this.createComponent({name: 'tapArea', classes: 'small-icon-tap-area', accessibilityDisabled: true, allowHtml: this.allowHtml, isChrome: true});
 
 			if (this.generated) {
 				ta.render();

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -9,7 +9,11 @@ var
 	kind = require('enyo/kind'),
 	ri = require('enyo/resolution'),
 	path = require('enyo/pathResolver'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control');
+
+var 
+	IconAccessibilitySupport = require('./IconAccessibilitySupport');
 
 // Static private hash of all of the valid moonstone icons
 var icons = {
@@ -127,6 +131,11 @@ module.exports = kind(
 	*/
 	kind: Control,
 
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [IconAccessibilitySupport] : null,
+	
 	/**
 	* @private
 	*/

--- a/lib/Icon/IconAccessibilitySupport.js
+++ b/lib/Icon/IconAccessibilitySupport.js
@@ -1,0 +1,24 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name IconAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled,
+				label = this.accessibilityHint && this.accessibilityLabel && (this.accessibilityLabel + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						null;
+			sup.apply(this, arguments);
+			this.setAttribute('aria-label', enabled ? label : null);
+		};
+	})
+};


### PR DESCRIPTION
## Issue 
Screen reader reads Icon unicode content (e.g. &#983040 ) when developer adds accessibilityHint to Icon

## Cause
In Moonstone Icon, predefined icon(e.g. drawer, check, closex ..) is font-based Icon and set unicode text to content. However, If developer add accessibilityHint to Icon, at first, check whether or not accessibilityLabel or content exists. Thus, If accessibilityLabel does not exists and accessibilityHint is added, screen reader reads unicode content and hint message because Icon has content as unicode text

## Fix
override updateAccessibilityAttributes function so screen reader can not read unicode content.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
