### PR TITLE
ENYO-2032: Accessibility: popup position is wrong.

### DIFF
--- a/lib/Popup/Popup.js
+++ b/lib/Popup/Popup.js
@@ -405,18 +405,22 @@ module.exports = kind(
 		}
 
 		if (this.showing) {
-			this.configCloseButton();
-			// Spot ourselves, unless we're already spotted
-			var current = Spotlight.getCurrent();
-			if (!current || !current.isDescendantOf(this)) {
-				if (Spotlight.isSpottable(this)) {
-					Spotlight.spot(this);
+			this.animationEnd = this.bindSafely(function (sender, ev) {
+				if (ev.originator === this) {
+					this.configCloseButton();
+					// Spot ourselves, unless we're already spotted
+					var current = Spotlight.getCurrent();
+					if (!current || !current.isDescendantOf(this)) {
+						if (Spotlight.isSpottable(this)) {
+							Spotlight.spot(this);
+						}
+						// If we're not spottable, just unspot whatever was previously spotted
+						else {
+							Spotlight.unspot();
+						}
+					}
 				}
-				// If we're not spottable, just unspot whatever was previously spotted
-				else {
-					Spotlight.unspot();
-				}
-			}
+			});
 		}
 
 		if (this.allowBackKey) {


### PR DESCRIPTION
When the popup is shown on 5 way mode, popup position is wrong.
Root cause is that if we set focus on dom node which is in hidden area,
web engine makes it scroll into showing area.
In this case when it set focus on button in the popup which is in hidden
area, web engine scroll up to show the button and then showing popup
animate works. This makes wrong position.
To resolve this, set the focus after animate end.

https://jira2.lgsvl.com/browse/ENYO-2032
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>