### PR TITLE
PLAT-1373: Adjusts the line-height for headers to accommodate accented characters

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -108,9 +108,9 @@
 @moon-header-font-weight: normal;
 @moon-header-letter-spacing: normal;
 @moon-header-font-style: normal;
-@moon-header-line-height: normal;
-@moon-medium-header-line-height: normal;
-@moon-small-header-line-height: normal;
+@moon-header-line-height: 1.3em;
+@moon-medium-header-line-height: 1.3em;
+@moon-small-header-line-height: 1.3em;
 @moon-non-latin-header-text-line-height: 1.5em;
 @moon-non-latin-medium-header-line-height: 1.5em;
 @moon-non-latin-small-header-line-height: 1.5em;

--- a/lib/Header/Header.less
+++ b/lib/Header/Header.less
@@ -26,7 +26,6 @@
 
 	.moon-header-title {
 		line-height: @moon-header-line-height;
-		height: 156px;
 
 		.moon-marquee-text {
 			white-space: nowrap;
@@ -37,6 +36,9 @@
 	.moon-header-sub-title-below {
 		height: 45px;
 		line-height: 45px;
+	}
+	.moon-header-title-below {
+		margin-top: -9px;  // Tuck this element up under the title
 	}
 
 	&.full-bleed {


### PR DESCRIPTION
…without clipping

Title below is pulled up to account for the taller header-title height.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>