### PR TITLE
ENYO-1899 : Add Text to Speech Accessibility support to SelectableItem

### DIFF
--- a/lib/CheckboxItem/CheckboxItemAccessibilitySupport.js
+++ b/lib/CheckboxItem/CheckboxItemAccessibilitySupport.js
@@ -32,7 +32,7 @@ module.exports = {
 			this.setAttribute('role', enabled ? 'checkbox' : null);
 			this.setAttribute('tabindex', enabled ? 0 : null);
 			this.setAttribute('aria-checked', enabled ? String(this.checked) : null);
-			this.setAttribute('aria-labelledby', enabled ? this.$.client.getId() : null);
+			this.setAttribute('aria-labelledby', !this.accessibilityLabel && enabled ? this.$.client.getId() : null);
 		};
 	})
 };

--- a/lib/Item/Item.js
+++ b/lib/Item/Item.js
@@ -7,12 +7,14 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
-	Control = require('enyo/Control');
+	Control = require('enyo/Control'),
+	options = require('enyo/options');
 
 var
 	Marquee = require('../Marquee'),
 	MarqueeSupport = Marquee.Support,
-	MarqueeItem = Marquee.Item;
+	MarqueeItem = Marquee.Item,
+	ItemAccessibilitySupport = require('./ItemAccessibilitySupport');
 
 /**
 * {@link module:moonstone/Item~Item} is a focusable Moonstone-styled control that can display
@@ -46,7 +48,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins: [MarqueeSupport, MarqueeItem],
+	mixins: options.accessibility ? [ItemAccessibilitySupport, MarqueeSupport, MarqueeItem] : [MarqueeSupport, MarqueeItem],
 
 	/**
 	* @private

--- a/lib/Item/ItemAccessibilitySupport.js
+++ b/lib/Item/ItemAccessibilitySupport.js
@@ -1,0 +1,28 @@
+/**
+* Provides a mixin to add accessibility support to
+* {@link module:moonstone/Item~Item}
+*
+* @module moonstone/Item/ItemAccessibilitySupport
+* @private
+*/
+
+var
+	kind = require('enyo/kind');
+
+/**
+* @name  ItemAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.setAttribute('aria-labelledby', !this.accessibilityLabel && enabled ? this.getId() : null);
+		};
+	})
+};

--- a/lib/SelectableItem/SelectableItem.js
+++ b/lib/SelectableItem/SelectableItem.js
@@ -7,10 +7,12 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
-	utils = require('enyo/utils');
+	utils = require('enyo/utils'),
+	options = require('enyo/options');
 
 var
-	Item = require('../Item');
+	Item = require('../Item'),
+	SelectableItemAccessibilitySupport = require('./SelectableItemAccessibilitySupport');
 
 /**
 * Fires when the item is tapped. No event-specific data is sent with this event.
@@ -47,6 +49,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Item,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [SelectableItemAccessibilitySupport] : null,
 	
 	/**
 	* @private

--- a/lib/SelectableItem/SelectableItemAccessibilitySupport.js
+++ b/lib/SelectableItem/SelectableItemAccessibilitySupport.js
@@ -32,7 +32,6 @@ module.exports = {
 			this.setAttribute('role', enabled ? 'radio' : null);
 			this.setAttribute('tabindex', enabled ? 0 : null);
 			this.setAttribute('aria-checked', enabled ? String(this.selected) : null);
-			this.setAttribute('aria-labelledby', !this.accessibilityLabel && enabled ? this.getId() : null);
 		};
 	})
 };

--- a/lib/SelectableItem/SelectableItemAccessibilitySupport.js
+++ b/lib/SelectableItem/SelectableItemAccessibilitySupport.js
@@ -32,7 +32,7 @@ module.exports = {
 			this.setAttribute('role', enabled ? 'radio' : null);
 			this.setAttribute('tabindex', enabled ? 0 : null);
 			this.setAttribute('aria-checked', enabled ? String(this.selected) : null);
-			this.setAttribute('aria-labelledby', enabled ? this.getId() : null);
+			this.setAttribute('aria-labelledby', !this.accessibilityLabel && enabled ? this.getId() : null);
 		};
 	})
 };

--- a/lib/SelectableItem/SelectableItemAccessibilitySupport.js
+++ b/lib/SelectableItem/SelectableItemAccessibilitySupport.js
@@ -1,0 +1,38 @@
+/**
+* Provides a mixin to add accessibility support to
+* {@link module:moonstone/SelectableItem~SelectableItem}
+*
+* @module moonstone/SelectableItem/SelectableItemAccessibilitySupport
+* @private
+*/
+
+var
+	kind = require('enyo/kind');
+
+/**
+* @name SelectableItemAccessibilitySupport
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: ['selected']}
+	],
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function () {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.setAttribute('role', enabled ? 'radio' : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+			this.setAttribute('aria-checked', enabled ? String(this.selected) : null);
+			this.setAttribute('aria-labelledby', enabled ? this.getId() : null);
+		};
+	})
+};


### PR DESCRIPTION
## Issue 
Screen reader does not read SelectableItem content and status when SelectableItem is focused  

## Cause
SelectableItem looks like general radioItem, which has text and radio mark. To support accessibility, we have to add aria-related role and attribute. In SelectableItem, role is 'radio' and it needs 'aria-checked' attribute to inform whether or not SelectableItem is checked. In Addtion to, SelectableItem extends moonstone Item, which can have child components like icon or simple control, so we have to add aria-labelledby attribute for reading child content to moonstone Item.

## Fix
add radio role , aria-checked and aria-labelledby attribute to SelectableItemAccessibilitySupport mixin

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com