### PR TITLE
Fixes ENYO-2032

### DIFF
--- a/lib/Panels/Panels.js
+++ b/lib/Panels/Panels.js
@@ -246,7 +246,7 @@ module.exports = kind(
 	*/
 	handleTools: [
 		{name: 'backgroundScrim', kind: Control, classes: 'moon-panels-background-scrim'},
-		{name: 'clientWrapper', kind: Control, classes: 'enyo-fill enyo-arranger moon-panels-client', components: [
+		{name: 'clientWrapper', kind: Control, classes: 'enyo-fill enyo-arranger moon-panels-client', accessibilityPreventScroll: true, components: [
 			{name: 'scrim', kind: Control, classes: 'moon-panels-panel-scrim', components: [
 				{name: 'branding', kind: Img, sizing: 'contain', classes: 'moon-panels-branding'}
 			]},

--- a/lib/Panels/Panels.less
+++ b/lib/Panels/Panels.less
@@ -6,7 +6,6 @@
 	height: 100%;
 	box-sizing: border-box;
 	padding: 18px 12px;
-	overflow: visible;
 	pointer-events: none;
 
 	&.moon-composite {


### PR DESCRIPTION
## Issue
When programmatically focusing the Panels handle, the browser would scroll it
to center throwing off the layout. A similar scrolling issue occurred when quickly navigating back through multiple panels.

## Fix
Setting overflow: hidden, as inherited from .enyo-arranger resolves the first issue. Adding accessibilityPreventScroll to clientWrapper resolved the second.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)