### PR TITLE
ENYO-1986 [Moon.Drawers]-Control drawers's height is not updated when its expan…

### DIFF
--- a/lib/Drawers/Drawer.js
+++ b/lib/Drawers/Drawer.js
@@ -182,7 +182,8 @@ var MoonDrawer = module.exports = kind(
 	*/
 	handlers: {
 		ontransitionend: 'transitionEnded',
-		onwebkittransitionend: 'transitionEnded'
+		onwebkittransitionend: 'transitionEnded',
+		onDrawerAnimationStep: 'updateControlDrawersHeight'
 	},
 
 	/**
@@ -225,6 +226,18 @@ var MoonDrawer = module.exports = kind(
 			this.set('controlsOpen', !this.controlsOpen);
 		}
 		return true;
+	},
+
+	/**
+	* @private
+	*/
+	updateControlDrawersHeight: function(){
+		if(this.controlDrawerComponents !== null ) {
+			var value = this.calcDrawerHeight(),
+				node = this.$.controlDrawer.hasNode(),
+				cHeight = node.getBoundingClientRect().height + value;
+			this.applyStyle('height', cHeight + 'px');
+			}
 	},
 
 	/**


### PR DESCRIPTION
…dables expands.

Issue: When components inside control drawer are expanded control
drawer's height is not getting updated

Cause: issue because of regression, in new implementation of drawer's no
event is handling the height of controlDrawer when it's inside
components are expanded.

Fix: handling core drawer's animationStep to update the control height
of drawer.

Enyo-DCO-1.1-Signed-off-by: Srinivas V srinivas,v@lge.com
