### PR TITLE
ENYO-2075: Move focus to header after animation ends

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -189,7 +189,7 @@
 				]},
 				{name: 'currentValue', kind: 'moon.MarqueeText', classes: 'moon-expandable-picker-current-value'}
 			]},
-			{name: 'drawer', kind: 'enyo.Drawer', resizeContainer:false, classes:'moon-expandable-list-item-client', components: [
+			{name: 'drawer', kind: 'enyo.Drawer', resizeContainer:false, classes:'moon-expandable-list-item-client', onEnd: 'spotHeader', components: [
 				{name: 'client', tag: null, kind: 'Group', onActivate: 'activated', highlander: true},
 				{name: 'helpText', kind:'moon.BodyText', canGenerate: false, classes: 'moon-expandable-picker-help-text'}
 			]}
@@ -516,9 +516,13 @@
 		*/
 		selectAndClose: function () {
 			this.setActive(false);
-			if (!enyo.Spotlight.getPointerMode() && enyo.Spotlight.getCurrent() && enyo.Spotlight.getCurrent().isDescendantOf(this)) {
+		},
+
+		spotHeader: function () {
+			if (!this.getOpen() && !enyo.Spotlight.getPointerMode() && enyo.Spotlight.getCurrent() && enyo.Spotlight.getCurrent().isDescendantOf(this)) {
 				enyo.Spotlight.spot(this.$.headerWrapper);
 			}
+			this.inherited(arguments);
 		},
 
 		/**


### PR DESCRIPTION
Issue:
- When expandable picker is opened and picker height is just little bit smaller than overwrapping scroller height.
- ExpandablePicker shows scroll thumb just while shrink animation after select item in 5way.
- This happens because the expandable picker show current label below header area on select item. And this makes picker having little bit larger height then scroller. Then the picker height is smaller than scroller after animation. So, There is no scroll thumb area after finish animation.

Fix:
- When selecting item, picker is give focus to header. and the header is calling scroll into view which is causing scroller update.
- Move spot on header call after animation ends. So, there is no scroller update while animation.

DCO-1.1-Signed-Off-By: Kunmyon Choi kunmyon.choi@lge.com