### PR TITLE
ENYO-1959 ToggleItem: toggle image layout fault

### DIFF
--- a/lib/ToggleItem/ToggleItem.less
+++ b/lib/ToggleItem/ToggleItem.less
@@ -5,6 +5,9 @@
 	.moon-checkbox.moon-toggle-switch {
 		top: (@moon-spotlight-outset + 3); /* To override top:10px set by .moon-checkbox-item .moon-checkbox so the indicator vertically middle align */
 		right: @moon-spotlight-outset;
+		.moon-icon {
+			vertical-align: top;
+		}
 	}
 }
 


### PR DESCRIPTION
## Issue
This toggle image icon issue was fixed already. (PR #2269 ) 
But this icon still is not shown correctly in TV set.

## Fix
Added 'vertical-align:top' in toggleItem.less.

Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com