### PR TITLE
ENYO-1636: Make ExpandableListItem header moon.Item

### DIFF
--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -171,7 +171,7 @@ module.exports = kind(
 	components: [
 		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 		// widths (webkit bug)
-		{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+		{name: 'headerContainer', kind: Item, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			{name: 'header', kind: MarqueeText}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [


### PR DESCRIPTION
Issue:
- ExpandableListItem header is currently set as a control.
- Disabled control is focusable.

Fix:
- Change header kind as moon.Item so it can get spotlight focus.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>