### PR TITLE
ENYO-1910: Add Text to Speech Accessibility support to Input

### DIFF
--- a/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
+++ b/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
@@ -1,6 +1,9 @@
 var
 	kind = require('enyo/kind');
 
+var
+	$L = require('../i18n');
+
 /**
 * @name InputDecoratorAccessibilityMixin
 * @mixin
@@ -10,14 +13,34 @@ module.exports = {
 	/**
 	* @private
 	*/
-	handlers: {
-		onSpotlightFocused  : 'spotlightFocusedHandler'
-	},
+	spotlightFocusedHandler: kind.inherit(function (sup) {
+		return function (oSender, oEvent) {
+			var text = '',
+				oInput = this.getInputControl(),
+				enabled = !oInput.accessibilityDisabled;
+
+			this.setAttribute('aria-live', this.accessibilityDisabled ? null : 'polite');
+			if (enabled && oInput) {
+				text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('edit box');
+			}
+			this.set('accessibilityLabel', text);
+
+			sup.apply(this, arguments);
+
+			// return true to stop the event bubble so the accessibility code in spotlight doesn't
+			// force a focus() thereby activating the internal <input>
+			return true;
+		};
+	}),
 
 	/**
 	* @private
 	*/
-	spotlightFocusedHandler: function (oSender, oEvent) {
-		return true;
-	}
+	spotlightBlurHandler: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.setAttribute('aria-live', null);
+			this.set('accessibilityLabel', null);
+		};
+	})
 };


### PR DESCRIPTION
Apply accessibility on InputDecorator.

Read placeholder of current input using readAlert api
when spotlight focused. The reason why we use readAlert is
if we set focus on input it becomes to editable mode,
but we just want to just move spotlight focus.

https://jira2.lgsvl.com/browse/ENYO-1910
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>