### PR TITLE
ENYO-1892: Add Text to Speech Accessibility support to SimplePicker

### DIFF
--- a/lib/SimplePicker/SimplePicker.js
+++ b/lib/SimplePicker/SimplePicker.js
@@ -8,13 +8,15 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	dom = require('enyo/dom'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control');
 
 var
 	IconButton = require('../IconButton'),
 	Marquee = require('../Marquee'),
 	MarqueeSupport = Marquee.Support,
-	MarqueeText	= Marquee.Text;
+	MarqueeText	= Marquee.Text,
+	SimplePickerAccessibilitySupport = require('./SimplePickerAccessibilitySupport');
 
 /**
 * Fires when the currently selected item changes.
@@ -85,7 +87,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins: [MarqueeSupport],
+	mixins: options.accessibility ? [MarqueeSupport, SimplePickerAccessibilitySupport] : [MarqueeSupport],
 
 	/**
 	* @private
@@ -173,7 +175,7 @@ module.exports = kind(
 	*/
 	components: [
 		{name: 'buttonLeft',  kind: IconButton, backgroundOpacity: 'transparent', classes: 'moon-simple-picker-button left', icon:'arrowlargeleft', onSpotlightSelect: 'left', ondown: 'downLeft', onholdpulse:'left', defaultSpotlightDisappear: 'buttonRight'},
-		{name: 'clientWrapper', kind: Control, classes:'moon-simple-picker-client-wrapper', components: [
+		{name: 'clientWrapper', accessibilityDisabled: true, kind: Control, classes:'moon-simple-picker-client-wrapper', components: [
 			{name: 'client', kind: Control, classes: 'moon-simple-picker-client'}
 		]},
 		{name: 'buttonRight', kind: IconButton, backgroundOpacity: 'transparent', classes: 'moon-simple-picker-button right', icon:'arrowlargeright', onSpotlightSelect: 'right', ondown: 'downRight', onholdpulse:'right', defaultSpotlightDisappear: 'buttonLeft'}

--- a/lib/SimplePicker/SimplePicker.js
+++ b/lib/SimplePicker/SimplePicker.js
@@ -175,7 +175,7 @@ module.exports = kind(
 	*/
 	components: [
 		{name: 'buttonLeft',  kind: IconButton, backgroundOpacity: 'transparent', classes: 'moon-simple-picker-button left', icon:'arrowlargeleft', onSpotlightSelect: 'left', ondown: 'downLeft', onholdpulse:'left', defaultSpotlightDisappear: 'buttonRight'},
-		{name: 'clientWrapper', accessibilityDisabled: true, kind: Control, classes:'moon-simple-picker-client-wrapper', components: [
+		{name: 'clientWrapper', kind: Control, classes:'moon-simple-picker-client-wrapper', components: [
 			{name: 'client', kind: Control, classes: 'moon-simple-picker-client'}
 		]},
 		{name: 'buttonRight', kind: IconButton, backgroundOpacity: 'transparent', classes: 'moon-simple-picker-button right', icon:'arrowlargeright', onSpotlightSelect: 'right', ondown: 'downRight', onholdpulse:'right', defaultSpotlightDisappear: 'buttonLeft'}

--- a/lib/SimplePicker/SimplePickerAccessibilitySupport.js
+++ b/lib/SimplePicker/SimplePickerAccessibilitySupport.js
@@ -1,0 +1,41 @@
+var
+	kind = require('enyo/kind');
+var
+	$L = require('../i18n');
+
+/**
+* @name SimplePickerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	bindings: [
+		{from: 'selected.content', to: '.$.buttonLeft.accessibilityLabel'},
+		{from: 'selected.content', to: '.$.buttonRight.accessibilityLabel'},
+		{from: 'selected.content', to: 'accessibilityLabel'}
+	],
+
+	initAccessibility: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			sup.apply(this, arguments);
+			this.$.buttonLeft.set('accessibilityHint', $L('press ok button to change the value'));
+			this.$.buttonRight.set('accessibilityHint', $L('press ok button to change the value'));
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.set('accessibilityLive', enabled? true : null);
+			this.$.buttonLeft.set('accessibilityDisabled', !enabled);
+			this.$.buttonRight.set('accessibilityDisabled', !enabled);
+		};
+	})
+};

--- a/lib/SimplePicker/SimplePickerAccessibilitySupport.js
+++ b/lib/SimplePicker/SimplePickerAccessibilitySupport.js
@@ -12,15 +12,25 @@ module.exports = {
 	/**
 	* @private
 	*/
-	bindings: [
-		{from: 'selected.content', to: '.$.buttonLeft.accessibilityLabel'},
-		{from: 'selected.content', to: '.$.buttonRight.accessibilityLabel'},
-		{from: 'selected.content', to: 'accessibilityLabel'}
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: ['selected']}
 	],
 
+	/**
+	* @private
+	*/
+	bindings: [
+		{from: 'selected.content', to: '.$.buttonLeft.accessibilityLabel'},
+		{from: 'selected.content', to: '.$.buttonRight.accessibilityLabel'}
+	],
+
+	/**
+	* @private
+	*/
 	initAccessibility: kind.inherit(function (sup) {
 		return function (was, is, prop) {
 			sup.apply(this, arguments);
+			this.$.client.setAttribute('role', 'spinbutton');
 			this.$.buttonLeft.set('accessibilityHint', $L('press ok button to change the value'));
 			this.$.buttonRight.set('accessibilityHint', $L('press ok button to change the value'));
 		};
@@ -31,11 +41,8 @@ module.exports = {
 	*/
 	updateAccessibilityAttributes: kind.inherit(function (sup) {
 		return function (was, is, prop) {
-			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			this.set('accessibilityLive', enabled? true : null);
-			this.$.buttonLeft.set('accessibilityDisabled', !enabled);
-			this.$.buttonRight.set('accessibilityDisabled', !enabled);
+			this.$.client.setAttribute('aria-valuetext', this.selected.content);
 		};
 	})
 };


### PR DESCRIPTION
Blink will support 'aria-valuetext' for spinbutton, so we apply
spinbutton role for SimplePicker.
We don't need to manage children controls accessibilityDisabled
because if it set 'aria-hidden' true on parent, children will be
hidden as well.

https://jira2.lgsvl.com/browse/ENYO-1892
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>