### PR TITLE
ENYO-1993: Add Text to Speech Accessibility support to ExpandableListItem

### DIFF
--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -8,7 +8,8 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	Control = require('enyo/Control'),
-	Group = require('enyo/Group');
+	Group = require('enyo/Group'),
+	options = require('enyo/options');
 
 var
 	Spotlight = require('spotlight');
@@ -17,7 +18,8 @@ var
 	ExpandableListDrawer = require('../ExpandableListDrawer'),
 	Item = require('../Item'),
 	Marquee = require('../Marquee'),
-	MarqueeText = Marquee.Text;
+	MarqueeText = Marquee.Text,
+	ExpandableListItemAccessibilitySupport = require('./ExpandableListItemAccessibilitySupport');
 
 /**
 * {@link module:moonstone/ExpandableListItem~ExpandableListItem}, which extends {@link module:moonstone/Item~Item}, displays a header
@@ -82,6 +84,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Control,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [ExpandableListItemAccessibilitySupport] : null,
 
 	/**
 	* @private
@@ -171,7 +178,7 @@ module.exports = kind(
 	components: [
 		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 		// widths (webkit bug)
-		{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+		{name: 'headerContainer', classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			{name: 'header', kind: MarqueeText}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [

--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -179,7 +179,7 @@ module.exports = kind(
 		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 		// widths (webkit bug)
 		{name: 'headerContainer', kind: Item, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
-			{name: 'header', kind: MarqueeText}
+			{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [
 			{name: 'client', kind: Group, tag: null}

--- a/lib/ExpandableListItem/ExpandableListItemAccessibilitySupport.js
+++ b/lib/ExpandableListItem/ExpandableListItemAccessibilitySupport.js
@@ -1,0 +1,21 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name ExpandableListItemAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.$.headerContainer.set('accessibilityLabel', this.accessibilityLabel);
+			this.$.headerContainer.setAttribute('aria-labelledby', !this.accessibilityLabel && enabled ? this.$.header.getId() : null);
+		};
+	})
+};


### PR DESCRIPTION
Apply accessibility on ExpandableListItem.

## Issue 
When developer adds accessibilityLabel to ExpandableListItem, screen reader does not read accessibilityLabel text.

## Cause
aria-label is added to expandableListItem's root dom node when developer adds accessibilityLabel. However, ExpandableListItem's child headerContainer has the spotlight focus when it is focused, so should add accessibilityLabel to this child component. Additionally, ExpandableListItem header text is child header component text, so we should set 'aria-labelledby' to this child component's Id.

## Fix
Add accessibilityLabel to child headerContainer component and set aria-labelledby to header component id.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
