### PR TITLE
ENYO-1890: Add Text to Speech Accessibility support to Accordion

### DIFF
--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -9,13 +9,15 @@ var
 	kind = require('enyo/kind'),
 	Control = require('enyo/Control'),
 	Drawer = require('enyo/Drawer'),
-	Group = require('enyo/Group');
+	Group = require('enyo/Group'),
+	options = require('enyo/options');
 
 var
 	ExpandableListItem = require('../ExpandableListItem'),
 	Item = require('../Item'),
 	Marquee = require('../Marquee'),
-	MarqueeText = Marquee.Text;
+	MarqueeText = Marquee.Text,
+	AccordionAccessibilitySupport = require('./AccordionAccessibilitySupport');
 
 /**
 * {@link module:moonstone/Accordion~Accordion} is a {@link module:moonstone/ExpandableListItem~ExpandableListItem} with an arrow button
@@ -78,6 +80,11 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	mixins: options.accessibility ? [AccordionAccessibilitySupport] : null,	
+
+	/**
+	* @private
+	*/
 	classes: 'moon-accordion',
 
 	/**
@@ -88,7 +95,7 @@ module.exports = kind(
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths
 			// (webkit bug)
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-accordion-header', components: [
-				{name: 'header', kind: MarqueeText}
+				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 			]}
 		]},
 		{name: 'drawer', kind: Drawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [

--- a/lib/Accordion/AccordionAccessibilitySupport.js
+++ b/lib/Accordion/AccordionAccessibilitySupport.js
@@ -1,0 +1,21 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name AccordionAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.$.headerWrapper.set('accessibilityLabel', this.accessibilityLabel);
+			this.$.headerWrapper.setAttribute('aria-labelledby', !this.accessibilityLabel && enabled ? this.$.header.getId() : null);
+		};
+	})
+};


### PR DESCRIPTION
Apply accessibility on Accordion

## Issue 
When developer adds accessibilityLabel to Accordion, screen reader does not read accessibilityLabel text.

## Cause
aria-label is added to Accordion's root dom node when developer adds accessibilityLabel. However, Accordion's child headerWrapper has the spotlight focus when it is focused, so should add accessibilityLabel to this child component. Additionally, Accordion header text is child header component text, so we should set 'aria-labelledby' to this child component's Id and add accessibilityDisabled:true to this child component to prevent reading text when user clicks header component using pointer

## Fix
Add accessibilityLabel to child headerWrapper component and set aria-labelledby to header component id.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
