### PR TITLE
ENYO-1903: Add Text to Speech Accessibility support to Expandable Input

### DIFF
--- a/lib/ExpandableInput/ExpandableInput.js
+++ b/lib/ExpandableInput/ExpandableInput.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control'),
 	Drawer = require('enyo/Drawer');
 
@@ -19,7 +20,8 @@ var
 	Input = require('../Input'),
 	InputDecorator = require('../InputDecorator'),
 	Marquee = require('../Marquee'),
-	MarqueeText = Marquee.Text;
+	MarqueeText = Marquee.Text,
+	ExpandableInputAccessibilitySupport = require('./ExpandableInputAccessibilitySupport');
 
 /**
 * Fires when the current text changes. This passes through {@link module:enyo/Input~Input#onChange}.
@@ -51,6 +53,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: ExpandableListItem,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [ExpandableInputAccessibilitySupport] : null,
 
 	/**
 	* @private
@@ -117,9 +124,9 @@ module.exports = kind(
 		{name: 'headerWrapper', kind: Item, classes: 'moon-expandable-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ondown: 'headerDown', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-input-header', components: [
-				{name: 'header', kind: MarqueeText}
+				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 			]},
-			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-picker-current-value'}
+			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-picker-current-value'}
 		]},
 		{name: 'drawer', kind: Drawer, resizeContainer:false, classes:'moon-expandable-list-item-client indented', components: [
 			{name: 'inputDecorator', kind: InputDecorator, onSpotlightBlur: 'inputBlur', onSpotlightFocus: 'inputFocus', onSpotlightDown: 'inputDown', components: [

--- a/lib/ExpandableInput/ExpandableInputAccessibilitySupport.js
+++ b/lib/ExpandableInput/ExpandableInputAccessibilitySupport.js
@@ -1,0 +1,31 @@
+var
+	kind = require('enyo/kind');
+var
+	$L = require('../i18n');
+/**
+* @name ExpandableInputAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: ['value']}
+	],
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled,
+				text = this.$.header.getContent() + ' ' + this.currentValueText() + ' ' + $L('edit box');
+			sup.apply(this, arguments);
+			this.$.headerWrapper.set('accessibilityLabel', enabled ? text : null);
+			this.$.headerWrapper.set('accessibilityDisabled', this.accessibilityDisabled);
+			this.$.inputDecorator.set('accessibilityDisabled', this.accessibilityDisabled);
+		};
+	})
+};


### PR DESCRIPTION
According to UX guide it should read
<header> + <current value> + <edit box>,
so I added 'aria-label' combining all of them.

https://jira2.lgsvl.com/browse/ENYO-1903
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>