### PR TITLE
ENYO-1912: Remove aria-labelledby when user adds accessibilityLabel t…

### DIFF
--- a/lib/Button/ButtonAccessibilitySupport.js
+++ b/lib/Button/ButtonAccessibilitySupport.js
@@ -15,7 +15,7 @@ module.exports = {
 			var enabled = !this.accessibilityDisabled,
 				id = this.$.client ? this.$.client.getId() : this.getId();
 			sup.apply(this, arguments);
-			this.setAttribute('aria-labelledby', enabled ? id : null);
+			this.setAttribute('aria-labelledby', !this.accessibilityLabel && enabled ? id : null);
 		};
 	})
 };


### PR DESCRIPTION
## Issue 
When developer adds accessibilityLabel to Button, screen reader does not read accessibilityLabel text. 

## Cause
If developer adds accessibilityLabel, aria-label attribute is added to Button's dom node. 
In Button, aria-labelledby attrbute is added for reading child componet text. 
However, if aria-label and aria-labelledby exist, aria-labelledby priority is more higher than aria-label.

## Fix
remove aria-labelledby if developer adds accessibilityLabel to Button.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
