### PR TITLE
ENYO-2075: Switch order of setting active state and header spotting.

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -214,7 +214,7 @@
 					this.selectedIndex = (this.selectedIndex != -1) ? this.selectedIndex : [];
 				}
 				// super initialization
-				sup.apply(this, arguments);	
+				sup.apply(this, arguments);
 
 				this.selectedIndexChanged();
 				this.noneTextChanged();
@@ -458,7 +458,7 @@
 		generateHelpText: function () {
 			this.$.helpText.canGenerate = true;
 			this.$.helpText.render();
-		},		
+		},
 
 		/**
 		* When an item is chosen, marks it as checked and closes the picker.
@@ -499,10 +499,10 @@
 
 			return true;
 		},
-		
+
 		/**
 		* Returns the picker items. Override point for child kinds altering the source of the items.
-		* 
+		*
 		* @private
 		*/
 		getCheckboxControls: function () {
@@ -515,10 +515,10 @@
 		* @private
 		*/
 		selectAndClose: function () {
-			this.setActive(false);
 			if (!enyo.Spotlight.getPointerMode() && enyo.Spotlight.getCurrent() && enyo.Spotlight.getCurrent().isDescendantOf(this)) {
 				enyo.Spotlight.spot(this.$.headerWrapper);
 			}
+			this.setActive(false);
 		},
 
 		/**

--- a/source/MoonScrollStrategy.js
+++ b/source/MoonScrollStrategy.js
@@ -172,7 +172,7 @@
 			}
 
 			enyo.TouchScrollStrategy.prototype.rendered._inherited.apply(this, arguments);
-			
+
 			if (measure) {
 				this._measureScrollColumns();
 			}
@@ -185,11 +185,11 @@
 		* available space for list controls. These metrics are derived via some LESS
 		* calculations, so to avoid brittleness we choose to measure them from the DOM
 		* rather than mirror the calculations in JavaScript.
-		* 
+		*
 		* Upon request, we do the measurement here (the first time a scroller is rendered)
 		* and cache the values in static properties, to avoid re-measuring each time we need
 		* the metrics.
-		* 
+		*
 		* @private
 		*/
 		_measureScrollColumns: function() {
@@ -690,7 +690,7 @@
 
 		/**
 		* Decorate spotlight events from paging controls so user can 5-way out of container
-		* 
+		*
 		* @private
 		*/
 		spotPaging: function (sender, event) {
@@ -719,10 +719,6 @@
 				bubble = false;
 			if (!enyo.Spotlight.getPointerMode() || event.scrollInPointerMode === true) {
 				originator = event.originator;
-				showVertical = this.showVertical();
-				showHorizontal = this.showHorizontal();
-				this.scrollBounds = this._getScrollBounds();
-				this.setupBounds();
 				showVertical = this.showVertical();
 				showHorizontal = this.showHorizontal();
 				this.scrollBounds = this._getScrollBounds();
@@ -964,7 +960,7 @@
 
 			controlBounds.right = document.body.offsetWidth - controlBounds.right;
 			absoluteBounds.right = document.body.offsetWidth - absoluteBounds.right;
-			
+
 			// Make absolute controlBounds relative to scroll position
 			controlBounds.top += scrollBounds.top;
 			if (this.rtl) {


### PR DESCRIPTION
### Issue
In 5-way mode, when selecting an item in an `ExpandablePicker`, we are explicitly spotting the header, which bubbles the `onRequestScrollIntoView` event if the picker is open, causing an undesired appearance of the vertical scroll thumb.

### Fix
We have switched the order of the calls in `selectAndClose` such that we update the active state *after* spotting the header. This allows for the spotting of the header to not overlap with the animated close of the drawer. Specifically, the animation of the drawer caused the scroller's `bottomBoundary` to be non-zero, which is a gating condition for triggering `alertThumbs` in `MoonScrollStrategy`.

I also went back through the history of `ExpandablePicker` to make sure we had not specifically changed the order of these calls to fix any specific issues. I tested it on the target device and did not observe any side effects.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>