### PR TITLE
ENYO-1904: Add Text to Speech Accessibility support to Date Picker

### DIFF
--- a/lib/DatePicker/DatePicker.js
+++ b/lib/DatePicker/DatePicker.js
@@ -6,7 +6,8 @@ require('moonstone');
 */
 
 var
-	kind = require('enyo/kind');
+	kind = require('enyo/kind'),
+	options = require('enyo/options');
 
 var
 	DateFactory = require('enyo-ilib/DateFactory');
@@ -14,7 +15,8 @@ var
 var
 	DateTimePickerBase = require('../DateTimePickerBase'),
 	$L = require('../i18n'),
-	IntegerPicker = require('../IntegerPicker');
+	IntegerPicker = require('../IntegerPicker'),
+	DatePickerAccessibilitySupport = require('./DatePickerAccessibilitySupport');
 
 /**
 * {@link module:moonstone/DatePicker~DatePicker} is a control used to allow the selection of (or simply
@@ -50,6 +52,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: DateTimePickerBase,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [DatePickerAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/DatePicker/DatePickerAccessibilitySupport.js
+++ b/lib/DatePicker/DatePickerAccessibilitySupport.js
@@ -1,0 +1,22 @@
+var
+	kind = require('enyo/kind'),
+	$L = require('../i18n');
+
+/**
+* @name DatePickerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	rendered: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.$.day.set('accessibilityLabel', $L('day'));
+			this.$.month.set('accessibilityLabel', $L('month'));
+			this.$.year.set('accessibilityLabel', $L('year'));
+		};
+	})
+};

--- a/lib/DatePicker/DatePickerAccessibilitySupport.js
+++ b/lib/DatePicker/DatePickerAccessibilitySupport.js
@@ -1,6 +1,5 @@
 var
-	kind = require('enyo/kind'),
-	$L = require('../i18n');
+	kind = require('enyo/kind');
 
 /**
 * @name DatePickerAccessibilityMixin
@@ -14,9 +13,9 @@ module.exports = {
 	rendered: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
-			this.$.day.set('accessibilityLabel', $L('day'));
-			this.$.month.set('accessibilityLabel', $L('month'));
-			this.$.year.set('accessibilityLabel', $L('year'));
+			this.$.day.set('accessibilityLabel', this.dayText);
+			this.$.month.set('accessibilityLabel', this.monthText);
+			this.$.year.set('accessibilityLabel', this.yearText);
 		};
 	})
 };

--- a/lib/DateTimePickerBase/DateTimePickerBase.js
+++ b/lib/DateTimePickerBase/DateTimePickerBase.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control'),
 	Signals = require('enyo/Signals');
 
@@ -23,7 +24,8 @@ var
 	ExpandableListItem = require('../ExpandableListItem'),
 	Item = require('../Item'),
 	Marquee = require('../Marquee'),
-	MarqueeText = Marquee.Text;
+	MarqueeText = Marquee.Text,
+	DateTimePickerBaseAccessibilitySupport = require('./DateTimePickerBaseAccessibilitySupport');
 
 /**
 * Fires when the picker's value changes.
@@ -59,6 +61,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: ExpandableListItem,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [DateTimePickerBaseAccessibilitySupport] : null,
 
 	/**
 	* @private
@@ -161,9 +168,9 @@ module.exports = kind(
 		{name: 'headerWrapper', kind: Item, classes: 'moon-date-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-datetime-header', components: [
-				{name: 'header', kind: MarqueeText}
+				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 			]},
-			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-picker-current-value'}
+			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-picker-current-value'}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes:'moon-expandable-list-item-client indented', components: [
 			{name: 'client', kind: Control, classes: 'enyo-tool-decorator moon-date-picker-client', onSpotlightLeft:'closePicker', onSpotlightSelect: 'closePicker'}

--- a/lib/DateTimePickerBase/DateTimePickerBaseAccessibilitySupport.js
+++ b/lib/DateTimePickerBase/DateTimePickerBaseAccessibilitySupport.js
@@ -1,0 +1,24 @@
+var
+	kind = require('enyo/kind'),
+	$L = require('../i18n');
+
+/**
+* @name DateTimePickerBaseAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/*
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled,
+				ids = this.$.header.getId() + ' ' + this.$.currentValue.getId();
+			sup.apply(this, arguments);
+			this.$.headerWrapper.setAttribute('aria-labelledby', enabled ? ids : null);
+			this.$.headerWrapper.set('accessibilityDisabled', this.accessibilityDisabled);
+			this.$.client.set('accessibilityDisabled', this.accessibilityDisabled);
+		};
+	})
+};

--- a/lib/DateTimePickerBase/DateTimePickerBaseAccessibilitySupport.js
+++ b/lib/DateTimePickerBase/DateTimePickerBaseAccessibilitySupport.js
@@ -1,6 +1,5 @@
 var
-	kind = require('enyo/kind'),
-	$L = require('../i18n');
+	kind = require('enyo/kind');
 
 /**
 * @name DateTimePickerBaseAccessibilityMixin

--- a/lib/IntegerPicker/IntegerPicker.js
+++ b/lib/IntegerPicker/IntegerPicker.js
@@ -8,6 +8,7 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	dom = require('enyo/dom'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control'),
 	Scroller = require('enyo/Scroller');
 
@@ -16,7 +17,8 @@ var
 
 var
 	ScrollStrategy = require('../ScrollStrategy'),
-	TouchScrollStrategy = ScrollStrategy.Touch;
+	TouchScrollStrategy = ScrollStrategy.Touch,
+	IntegerPickerAccessibilitySupport = require('./IntegerPickerAccessibilitySupport');
 
 /**
 * Fires when the currently selected value changes.
@@ -61,6 +63,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Control,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [IntegerPickerAccessibilitySupport] : null,
 
 	/**
 	* @private
@@ -208,9 +215,9 @@ module.exports = kind(
 		// we're forcing TouchScrollStrategy
 		{kind: Scroller, strategyKind: TouchScrollStrategy, thumb:false, touch:true, useMouseWheel: false, classes: 'moon-scroll-picker', components:[
 			{name: 'repeater', kind: FlyweightRepeater, classes: 'moon-scroll-picker-repeater', ondragstart: 'dragstart', onSetupItem: 'setupItem', noSelect: true, components: [
-				{name: 'item', kind: Control, classes: 'moon-scroll-picker-item'}
+				{name: 'item', kind: Control, accessibilityDisabled: true, classes: 'moon-scroll-picker-item'}
 			]},
-			{name: 'buffer', kind: Control, classes: 'moon-scroll-picker-buffer'}
+			{name: 'buffer', kind: Control, accessibilityDisabled: true, classes: 'moon-scroll-picker-buffer'}
 		]},
 		{name:'previousOverlay', kind: Control, ondown:'downPrevious', onholdpulse:'previous', classes:'moon-scroll-picker-overlay-container previous', components:[
 			{kind: Control, classes: 'moon-scroll-picker-overlay previous'},

--- a/lib/IntegerPicker/IntegerPickerAccessibilitySupport.js
+++ b/lib/IntegerPicker/IntegerPickerAccessibilitySupport.js
@@ -1,0 +1,42 @@
+var
+	kind = require('enyo/kind');
+var
+	VoiceReadout = require('enyo-webos/VoiceReadout');
+
+/**
+* @name IntegerPickerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	observers: [
+		{method: 'readChangedValue', path: ['value']}
+	],
+
+	/**
+	* @private
+	*/
+	initAccessibility: kind.inherit(function (sup) {
+		return function () {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			// Set accessibilityLabel instead of 'aria-label' directly
+			// to be able to use accessibilityHint.
+			this.set('accessibilityLabel', enabled ? this.value : null);
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	readChangedValue: function () {
+		var enabled = !this.accessibilityDisabled;
+		if (enabled) {
+			VoiceReadout.readAlert(String(this.value));
+		}
+		this.set('accessibilityLabel', enabled ? this.value : null);
+	}
+};

--- a/lib/IntegerPicker/IntegerPickerAccessibilitySupport.js
+++ b/lib/IntegerPicker/IntegerPickerAccessibilitySupport.js
@@ -1,7 +1,5 @@
 var
 	kind = require('enyo/kind');
-var
-	VoiceReadout = require('enyo-webos/VoiceReadout');
 
 /**
 * @name IntegerPickerAccessibilityMixin
@@ -12,31 +10,18 @@ module.exports = {
 	/**
 	* @private
 	*/
-	observers: [
-		{method: 'readChangedValue', path: ['value']}
+	bindings: [
+		{from: 'value', to: 'accessibilityLabel'}
 	],
 
 	/**
 	* @private
 	*/
-	initAccessibility: kind.inherit(function (sup) {
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
 		return function () {
 			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
-			// Set accessibilityLabel instead of 'aria-label' directly
-			// to be able to use accessibilityHint.
-			this.set('accessibilityLabel', enabled ? this.value : null);
+			this.setAttribute('role', enabled ? 'spinbutton' : null);
 		};
-	}),
-
-	/**
-	* @private
-	*/
-	readChangedValue: function () {
-		var enabled = !this.accessibilityDisabled;
-		if (enabled) {
-			VoiceReadout.readAlert(String(this.value));
-		}
-		this.set('accessibilityLabel', enabled ? this.value : null);
-	}
+	})
 };

--- a/lib/IntegerPicker/IntegerPickerAccessibilitySupport.js
+++ b/lib/IntegerPicker/IntegerPickerAccessibilitySupport.js
@@ -10,8 +10,8 @@ module.exports = {
 	/**
 	* @private
 	*/
-	bindings: [
-		{from: 'value', to: 'accessibilityLabel'}
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: ['value']}
 	],
 
 	/**
@@ -22,6 +22,7 @@ module.exports = {
 			var enabled = !this.accessibilityDisabled;
 			sup.apply(this, arguments);
 			this.setAttribute('role', enabled ? 'spinbutton' : null);
+			this.setAttribute('aria-valuenow', enabled ? this.value : null);
 		};
 	})
 };


### PR DESCRIPTION
Apply accessibility on DatePicker.
Basically DatePicker is combined by IntegerPickers, and we already
applied accessibility on IntergerPicker.
According to UX guide, DatePicker should be read <value> +  <day>,
<month> or <year>. I added each text 'day', 'month', 'year' to
'accessibilityLabel', scrren reader will read 'aria-valuenow' +
'aria-label.

https://jira2.lgsvl.com/browse/ENYO-1904
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>