### PR TITLE
ENYO-2118: Added a tap-area mixin

### DIFF
--- a/css/moonstone-mixins.less
+++ b/css/moonstone-mixins.less
@@ -1,11 +1,30 @@
-.moon-item-icon-tap-area-adjust {
+//
+// Handy Information
+// http://lesscss.org/features/#mixins-feature-not-outputting-the-mixin
+//
+
+.moon-taparea(@element-size) when (@moon-button-small-tap-area-height > @element-size) {
+	// Take the size of the minimum tappable area, and subtract the element's current size.
+	@_tap-offset: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @element-size) / 2);
+
+	&:after {
+		content: '';
+		position: absolute;
+		top: @_tap-offset;
+		right: @_tap-offset;
+		bottom: @_tap-offset;
+		left: @_tap-offset;
+	}
+}
+
+.moon-item-icon-tap-area-adjust() {
 	&.small > .small-icon-tap-area {
 		left: -@moon-spotlight-outset;
 		right: -@moon-spotlight-outset;
 	}
 }
 
-.full-screen-video-player {
+.full-screen-video-player() {
 	position: static !important;
 	display: block !important;
 	margin: 0;
@@ -15,7 +34,7 @@
 	}
 }
 
-.hide-full-screen-ancestor {
+.hide-full-screen-ancestor() {
 	position: absolute !important;
 	overflow: visible !important;
 	padding: 0 !important;

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -48,7 +48,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins: options.accessibility ? [ButtonAccessibilitySupport, MarqueeSupport] : [MarqueeSupport], 
+	mixins: options.accessibility ? [ButtonAccessibilitySupport, MarqueeSupport] : [MarqueeSupport],
 
 	/**
 	* @private
@@ -166,7 +166,6 @@ module.exports = kind(
 	initComponents: function () {
 		if (!(this.components && this.components.length > 0)) {
 			this.createComponent({name: 'client', kind: MarqueeText, classes: 'button-client', isChrome: true, accessibilityDisabled: true});
-			this.createComponent({name: 'tapArea', kind: Control, classes: 'button-tap-area', isChrome: true});
 		}
 		if (this.small) this.smallChanged();
 		if (this.minWidth) this.minWidthChanged();

--- a/lib/Button/Button.less
+++ b/lib/Button/Button.less
@@ -63,6 +63,7 @@
 		vertical-align: top;
 		text-align: center;
 	}
+	.moon-taparea(@moon-button-height);
 
 	.button-client {
 		-webkit-transform: translateZ(0);
@@ -73,15 +74,6 @@
 
 	&.min-width {
 		min-width: @moon-button-large-min-width;
-	}
-
-	> .button-tap-area {
-		position: absolute;
-		border-radius: @moon-button-border-radius;
-		top: -(@moon-button-border-width);
-		bottom: -(@moon-button-border-width);
-		left: -(@moon-button-border-width);
-		right: -(@moon-button-border-width);
 	}
 
 	&.small {
@@ -96,13 +88,7 @@
 			min-width: @moon-button-small-min-width;
 		}
 
-		> .button-tap-area {
-			border-radius: 0;
-			top: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);
-			bottom: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);
-			left: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);
-			right: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);
-		}
+		.moon-taparea(@moon-button-small-height);
 	}
 
 	// Button-non-disabled rules

--- a/lib/Icon/Icon.js
+++ b/lib/Icon/Icon.js
@@ -12,7 +12,7 @@ var
 	options = require('enyo/options'),
 	Control = require('enyo/Control');
 
-var 
+var
 	IconAccessibilitySupport = require('./IconAccessibilitySupport');
 
 // Static private hash of all of the valid moonstone icons
@@ -135,7 +135,7 @@ module.exports = kind(
 	* @private
 	*/
 	mixins: options.accessibility ? [IconAccessibilitySupport] : null,
-	
+
 	/**
 	* @private
 	*/
@@ -307,11 +307,7 @@ module.exports = kind(
 		// If the icon isn't in our known set, apply our custom font class
 		this.addRemoveClass('font-lg-icons', !icons[icon]);
 
-		if (this.get('small')) {
-			this.$.tapArea.set('content', iconEntity);
-		} else {
-			this.set('content', iconEntity);
-		}
+		this.set('content', iconEntity);
 
 		if (icons[old]) {
 			this.removeClass(this.getIconClass(old));
@@ -325,17 +321,6 @@ module.exports = kind(
 	* @private
 	*/
 	smallChanged: function () {
-		if (this.small) {
-			var ta = this.createComponent({name: 'tapArea', classes: 'small-icon-tap-area', accessibilityDisabled: true, allowHtml: this.allowHtml, isChrome: true});
-
-			if (this.generated) {
-				ta.render();
-			}
-		} else {
-			if (this.$.tapArea) {
-				this.$.tapArea.destroy();
-			}
-		}
 		this.addRemoveClass('small', this.small);
 		// Now that our content area is ready, assign the icon
 		this.iconChanged();

--- a/lib/Icon/Icon.less
+++ b/lib/Icon/Icon.less
@@ -1,5 +1,6 @@
 /* Icon.css */
-.moon-icon, .moon-icon-toggle {
+.moon-icon,
+.moon-icon-toggle {
 	width: @moon-icon-size;
 	height: @moon-icon-size;
 	background-position: center -((@moon-icon-sprite-size - @moon-icon-size) / 2);
@@ -15,6 +16,8 @@
 	position: relative;
 	color: @moon-icon-font-color;
 
+	.moon-taparea(@moon-icon-size);
+
 	&.small {
 		background-position: center -((@moon-icon-sprite-small-size - @moon-icon-small-size) / 2);
 		background-size: @moon-icon-sprite-small-size (@moon-icon-sprite-small-size * 2);
@@ -22,16 +25,8 @@
 		height: @moon-icon-small-size;
 		font-size: (@moon-icon-small-size * 2);
 		line-height: @moon-icon-small-size;
-		> .small-icon-tap-area {
-			position: absolute;
-			top: @moon-icon-tap-area-offset;
-			bottom: @moon-icon-tap-area-offset;
-			left: @moon-icon-tap-area-offset;
-			right: @moon-icon-tap-area-offset;
-			// Always use the same color that was assigned to the parent: inherit.
-			color: inherit;
-			line-height: (@moon-icon-small-size - (@moon-icon-tap-area-offset * 2));
-		}
+
+		.moon-taparea(@moon-icon-small-size);
 	}
 
 	&.font-lg-icons {

--- a/lib/ToggleSwitch/ToggleSwitch.less
+++ b/lib/ToggleSwitch/ToggleSwitch.less
@@ -1,4 +1,4 @@
-/* ToggleSwitch.css */
+/* ToggleSwitch */
 .moon-checkbox.moon-toggle-switch {
 	border-radius: (@moon-toggleswitch-height / 2);
 	width: @moon-toggleswitch-width;
@@ -6,12 +6,14 @@
 	line-height: @moon-toggleswitch-height;
 	background-color: @moon-checkbox-toggle-switch-bg-color;
 	font-family: @moon-icon-font-family;
-	overflow: hidden;
+	position: relative;
 	text-align: left;
+	cursor: default;
+
+	.moon-taparea(@moon-toggleswitch-height);
 
 	.moon-icon {
 		visibility: visible;
-		cursor: default;
 		background-color: transparent;
 		left: 0;
 		color: @moon-checkbox-toggle-switch-color;
@@ -19,14 +21,6 @@
 		height: inherit;
 		font-size: (@moon-toggleswitch-height * 2);
 		line-height: inherit;
-
-		.small-icon-tap-area {
-			height: inherit;
-			line-height: inherit;
-			font-size: inherit;
-			top: 0;
-			bottom: 0;
-		}
 	}
 	&[checked] {
 		background-color: @moon-checkbox-toggle-switch-checked-bg-color;


### PR DESCRIPTION
Added a tap-area mixin to universally add tap-area support to controls which need it, by simply adding a single line which includes their current size.
Removed vestigial JS logic and control code to handle adding and removing of tap-areas.
Directly affected controls: Icon, Button, ToggleSwitch
Also updated all other mixins to not output themselves directly as CSS, and instead only the contents will be output when being mixed-into another control's rule-set.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>