### PR TITLE
Fixes ENYO-1959

### DIFF
--- a/lib/ToggleSwitch/ToggleSwitch.less
+++ b/lib/ToggleSwitch/ToggleSwitch.less
@@ -21,6 +21,7 @@
 		height: inherit;
 		font-size: (@moon-toggleswitch-height * 2);
 		line-height: inherit;
+		vertical-align: top;	// The TV incorrectly positions the icon too low without this
 	}
 	&[checked] {
 		background-color: @moon-checkbox-toggle-switch-checked-bg-color;


### PR DESCRIPTION
## Issue
Misaligned ToggleSwitch icon on TV

## Fix
add vertical-align to ToggleSwitch icon

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)