### PR TITLE
Enyo-2034 Close popup using activated method

### DIFF
--- a/src/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/src/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -96,6 +96,8 @@ module.exports = kind(
 				this.activator.addClass('active');
 				this.requestShowPopup();
 			}
+		} else {
+			this.requestHidePopup();
 		}
 	},
 

--- a/src/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/src/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -89,6 +89,7 @@ module.exports = kind(
 			this.activator = inEvent.originator;
 			// if this ContextualPopup is already activated
 			if (this.popupActivated) {
+				this.requestHidePopup();
 				inEvent.originator.active = false;
 				this.popupActivated = false;
 			} else {


### PR DESCRIPTION
Issue
-------
Activate method could not close Popup

Cause
--------
This is a regression issue of modular work.
Added line was missing during modulization.

Fix
----
Restore missing line

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com