### PR TITLE
ENYO-1725: [Panels] If user uses setIndex() in creation time, it does not work

### DIFF
--- a/lib/Panels/Panels.js
+++ b/lib/Panels/Panels.js
@@ -780,7 +780,7 @@ module.exports = kind(
 			return;
 		}
 
-		if (this.toIndex !== null) {
+		if (this.toIndex != null) {
 			return;
 		}
 


### PR DESCRIPTION
## Issue
app devs cannot set index of panels in creation time.

## Cause
setIndex() in Panels.js, there is usage of strict comparison.

## Fix
made to non-strict comparison. Because this.toIndex will be used as only null or truthy value, I think we do not need strict comparison

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung.lee@lge.com