### PR TITLE
ENYO-2124: IconButton active state remains while hold and drag

### DIFF
--- a/lib/IconButton/IconButton.less
+++ b/lib/IconButton/IconButton.less
@@ -46,7 +46,7 @@
 	}
 
 	&.active:not(.spotlight),
-	&:active,
+	&:active.spotlight,
 	&.pressed,
 	&.hover:hover:not(.disabled):active {
 		color: @moon-icon-button-font-color;


### PR DESCRIPTION
Issue:
Button is showing active state while hold and drag to outside of button

Fix:
Use .spotlight with :active to show active state

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>