### PR TITLE
PLAT-1995: Reset TimePicker dropdown

### DIFF
--- a/lib/TimePicker/TimePicker.js
+++ b/lib/TimePicker/TimePicker.js
@@ -638,6 +638,8 @@ var TimePicker = module.exports = kind(
 			}
 		}
 		this.$.currentValue.setContent(this.formatValue());
+		this.$.hour.scrollToValue();
+		this.$.minute.scrollToValue();
 	},
 
 	/**


### PR DESCRIPTION
PLAT-1995: The time picker value's which is under the time is not changed to default after selecting 'Reset' time option

Call scrollToValue for hour and minute components