### PR TITLE
Fixes ENYO-2030

### DIFF
--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -94,7 +94,7 @@ module.exports = kind(
 		{name: 'headerWrapper', kind: Item, classes: 'moon-accordion-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths
 			// (webkit bug)
-			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-accordion-header', components: [
+			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-accordion-header', components: [
 				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 			]}
 		]},

--- a/lib/DateTimePickerBase/DateTimePickerBase.js
+++ b/lib/DateTimePickerBase/DateTimePickerBase.js
@@ -68,7 +68,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	classes: 'moon-expandable-picker moon-date-picker',
+	classes: 'moon-date-picker',
 
 	/**
 	* @private
@@ -160,10 +160,10 @@ module.exports = kind(
 	components: [
 		{name: 'headerWrapper', kind: Item, classes: 'moon-date-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
-			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-datetime-header', components: [
+			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-datetime-header', components: [
 				{name: 'header', kind: MarqueeText}
 			]},
-			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-picker-current-value'}
+			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-list-item-current-value'}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes:'moon-expandable-list-item-client indented', components: [
 			{name: 'client', kind: Control, classes: 'enyo-tool-decorator moon-date-picker-client', onSpotlightLeft:'closePicker', onSpotlightSelect: 'closePicker'}

--- a/lib/ExpandableInput/ExpandableInput.js
+++ b/lib/ExpandableInput/ExpandableInput.js
@@ -121,12 +121,12 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{name: 'headerWrapper', kind: Item, classes: 'moon-expandable-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ondown: 'headerDown', ontap: 'expandContract', components: [
+		{name: 'headerWrapper', kind: Item, classes: 'moon-expandable-list-item-wrapper', onSpotlightFocus: 'headerFocus', ondown: 'headerDown', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
-			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-input-header', components: [
+			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-input-header', components: [
 				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 			]},
-			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-picker-current-value'}
+			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-list-item-current-value'}
 		]},
 		{name: 'drawer', kind: Drawer, resizeContainer:false, classes:'moon-expandable-list-item-client indented', components: [
 			{name: 'inputDecorator', kind: InputDecorator, onSpotlightBlur: 'inputBlur', onSpotlightFocus: 'inputFocus', onSpotlightDown: 'inputDown', components: [

--- a/lib/ExpandableIntegerPicker/ExpandableIntegerPicker.js
+++ b/lib/ExpandableIntegerPicker/ExpandableIntegerPicker.js
@@ -148,12 +148,12 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{name: 'headerWrapper', kind: Item, classes: 'moon-expandable-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+		{name: 'headerWrapper', kind: Item, onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
-			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header', components: [
+			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header', components: [
 				{name: 'header', kind: MarqueeText}
 			]},
-			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-picker-current-value'}
+			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-list-item-current-value'}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes:'moon-expandable-list-item-client indented', components: [
 			{name: 'picker', kind: SimpleIntegerPicker, deferInitialization: true, onSelect: 'toggleActive', onChange: 'pickerValueChanged'}

--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -178,7 +178,7 @@ module.exports = kind(
 	components: [
 		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 		// widths (webkit bug)
-		{name: 'headerContainer', kind: Item, classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+		{name: 'headerContainer', kind: Item, classes: 'moon-expandable-list-item-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [

--- a/lib/ExpandableListItem/ExpandableListItem.less
+++ b/lib/ExpandableListItem/ExpandableListItem.less
@@ -1,18 +1,54 @@
 /* ExpandableListItem Header*/
 .moon-expandable-list-item-header {
+	display: inline-block;
 	margin-bottom: 0px;
 	box-sizing: border-box;
 	max-width: 100%;
 	line-height: @moon-item-line-height;
-}
-.moon-expandable-list-header.moon-expandable-picker-header:after {
-	top: 3px;
+	padding-right: @moon-spotlight-outset + 30px;
+	position: relative;
+	vertical-align: top;
+
+	&:after {
+		position: absolute;
+		top: @moon-spotlight-outset - 12px;
+		right: @moon-spotlight-outset + 1px;
+		font-family: @moon-icon-font-family;
+		content: @moon-icon-arrowlargedown;
+		font-size: @moon-expandable-caret-icon-font-size;
+	}
 }
 
-/* Client Items */
-.moon-expandable-list-item.open .moon-expandable-list-item-client {
-	margin-bottom: 12px;
+/* Current Value */
+.moon-expandable-list-item-current-value {
+	font-family: @moon-expandable-value-font-family;
+	color: @moon-expandable-picker-text-color;
+	margin-top: -6px;	// Negative value to compensate for the taller line-height needed for tall-glyph charecters
+
+	.enyo-locale-right-to-left & {
+		padding-left: 0;
+	}
+
+	.enyo-locale-non-latin & {
+		.enyo-locale-non-latin .moon-body-text;
+	}
+
+	.moon-expandable-list-item .spotlight & {
+		color: @moon-white;
+	}
 }
+
+
+/* Client Items */
+.moon-expandable-list-item.open {
+	.moon-expandable-list-item-client {
+		margin-bottom: 12px;
+	}
+	.moon-expandable-list-item-header:after {
+		content: @moon-icon-arrowlargeup;
+	}
+}
+
 .moon-expandable-list-item-client {
 	.moon-item {
 		.moon-body-text;

--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -218,7 +218,7 @@ module.exports = kind(
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header', components: [
 				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 			]},
-			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-picker-current-value'}
+			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-list-item-current-value'}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes:'moon-expandable-list-item-client', onDrawerAnimationEnd: 'handleDrawerAnimationEnd', components: [
 			{name: 'client', tag: null, kind: Group, onActivate: 'activated', highlander: true},

--- a/lib/ExpandablePicker/ExpandablePicker.less
+++ b/lib/ExpandablePicker/ExpandablePicker.less
@@ -2,18 +2,7 @@
 .moon-expandable-picker-header {
 	margin: 0px;
 	display: inline-block;
-	padding-right: @moon-spotlight-outset + 30px;
-	position: relative;
-	vertical-align: top;
 
-	&:after {
-		position: absolute;
-		top: @moon-spotlight-outset - 12px;
-		right: @moon-spotlight-outset + 1px;
-		font-family: @moon-icon-font-family;
-		content: @moon-icon-arrowlargedown;
-		font-size: @moon-expandable-caret-icon-font-size;
-	}
 	&.spotlight {
 		color: @moon-white;
 	}
@@ -27,29 +16,6 @@
 		left: @moon-spotlight-outset + 1px;
 		right: auto;
 	}
-}
-
-/* Header Open */
-.moon-expandable-list-item.open {
-	.moon-expandable-picker-header:after {
-		content: @moon-icon-arrowlargeup;
-	}
-}
-
-/* Current Value */
-.moon-expandable-picker-current-value {
-	font-family: @moon-expandable-value-font-family;
-	color: @moon-expandable-picker-text-color;
-	margin-top: -6px;	// Negative value to compensate for the taller line-height needed for tall-glyph charecters
-}
-.enyo-locale-right-to-left .moon-expandable-picker-current-value {
-	padding-left: 0;
-}
-.moon-expandable-list-item .spotlight .moon-expandable-picker-current-value {
-	color: @moon-white;
-}
-.enyo-locale-non-latin .moon-expandable-picker-current-value {
-	.enyo-locale-non-latin .moon-body-text;
 }
 
 /* Help Text */


### PR DESCRIPTION
## Issue
Most (all?) of the kinds extending moonstone/ExpandableListItem are incorrectly reusing CSS classes from moonstone/ExpandablePicker resulting in incorrect styling when moonstone/ExpandablePicker is not included in a build.

## Fix
Refactor moonstone/ExpandablePicker css into moonstone/ExpandableListItem which the former extends

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)