### PR TITLE
ENYO-1991: Add Text to Speech Accessibility support to TimePicker

### DIFF
--- a/lib/TimePicker/HourMinutePickerBaseAccessibilitySupport.js
+++ b/lib/TimePicker/HourMinutePickerBaseAccessibilitySupport.js
@@ -1,0 +1,29 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name HourMinutePickerBaseAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: ['value']}
+	],
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			if (this.date && this.range) {
+				var value = this.format(this.value % this.range);
+				this.setAttribute('aria-valuenow', value);
+			}
+		};
+	})
+};

--- a/lib/TimePicker/MeridiemPickerAccessibilitySupport.js
+++ b/lib/TimePicker/MeridiemPickerAccessibilitySupport.js
@@ -1,0 +1,26 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name MeridiemPickerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	observers: [
+		{method: 'updateAccessibilityAttributes', path: ['value']}
+	],
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.setAttribute('aria-valuetext', this.meridiems[this.value]);
+		};
+	})
+};

--- a/lib/TimePicker/TimePicker.js
+++ b/lib/TimePicker/TimePicker.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	platform = require('enyo/platform'),
 	Control = require('enyo/Control');
 
@@ -18,7 +19,10 @@ var
 var
 	DateTimePickerBase = require('../DateTimePickerBase'),
 	$L = require('../i18n'),
-	IntegerPicker = require('../IntegerPicker');
+	IntegerPicker = require('../IntegerPicker'),
+	MeridiemPickerAccessibilitySupport = require('./MeridiemPickerAccessibilitySupport'),
+	HourMinutePickerBaseAccessibilitySupport = require('./HourMinutePickerBaseAccessibilitySupport'),
+	TimePickerAccessibilitySupport = require('./TimePickerAccessibilitySupport');
 
 /**
 * {@link module:moonstone/TimePicker~MeridiemPicker} is a helper kind used by {@link module:moonstone/TimePicker~TimePicker}.
@@ -41,6 +45,11 @@ var MeridiemPicker = kind(
 	* @private
 	*/
 	kind: IntegerPicker,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [MeridiemPickerAccessibilitySupport] : null,
 
 	/**
 	* @private
@@ -122,6 +131,11 @@ var HourMinutePickerBase = kind(
 	* @private
 	*/
 	kind: IntegerPicker,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [HourMinutePickerBaseAccessibilitySupport] : null,
 
 	/**
 	* @private
@@ -297,6 +311,11 @@ var TimePicker = module.exports = kind(
 	* @private
 	*/
 	kind: DateTimePickerBase,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [TimePickerAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/TimePicker/TimePickerAccessibilitySupport.js
+++ b/lib/TimePicker/TimePickerAccessibilitySupport.js
@@ -1,0 +1,23 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name TimePickerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/*
+	* @private
+	*/
+	rendered: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			sup.apply(this, arguments);
+			this.$.hour.set('accessibilityLabel', this.hourText);
+			this.$.minute.set('accessibilityLabel', this.minuteText);
+			if (this.$.meridiem) {
+				this.$.meridiem.set('accessibilityLabel', this.meridiemText);
+			}
+		};
+	})
+};


### PR DESCRIPTION
apply accessiblity on TimePicker
- add accessibilityLabel for hourText, minuteText and meridiemText.
- add MeridiemPicker mixin to support meridiems text.
- add HourMinutePickerBase mixin to support formatted hour.

https://jira2.lgsvl.com/browse/ENYO-1991
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>