### PR TITLE
ENYO-2137: Reassigned tap-area to :before to avoid conflicts with con…

### DIFF
--- a/css/moonstone-mixins.less
+++ b/css/moonstone-mixins.less
@@ -7,7 +7,7 @@
 	// Take the size of the minimum tappable area, and subtract the element's current size.
 	@_tap-offset: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @element-size) / 2);
 
-	&:after {
+	&:before {
 		content: '';
 		position: absolute;
 		top: @_tap-offset;


### PR DESCRIPTION
…trols already using :after. (ToggleButton)

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>