### PR TITLE
ENYO-2127: Accessibility: The TypeError occurs in the calendar

### DIFF
--- a/lib/SimplePicker/SimplePickerAccessibilitySupport.js
+++ b/lib/SimplePicker/SimplePickerAccessibilitySupport.js
@@ -42,7 +42,7 @@ module.exports = {
 	updateAccessibilityAttributes: kind.inherit(function (sup) {
 		return function (was, is, prop) {
 			sup.apply(this, arguments);
-			this.$.client.setAttribute('aria-valuetext', this.selected.content);
+			this.$.client.setAttribute('aria-valuetext', this.selected ? this.selected.content : null);
 		};
 	})
 };


### PR DESCRIPTION
This issue occurs because no null check for this.selected on
SimplePickerAccessibilitySupport.
Add null check for this.selected.

https://jira2.lgsvl.com/browse/ENYO-2127
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>