### PR TITLE
ENYO-2158: Fix guard code in `avoidScrollOnDefaultFocus`

### DIFF
--- a/lib/NewDataList/NewDataList.js
+++ b/lib/NewDataList/NewDataList.js
@@ -82,7 +82,7 @@ module.exports = kind({
 		// potentially not in view, and focusing would cause it to
 		// scroll it into view for no reason apparent to the user.
 		// Instead, we just focus the first visible list element.
-		if (event.focusType === 'default' && event.index) {
+		if (event.focusType === 'default' && typeof event.index === 'number') {
 			fv = this.getFullyVisibleItems()[0] || this.getVisibleItems()[0];
 			if (fv) {
 				Spotlight.spot(fv);


### PR DESCRIPTION
Old guard code didn't account for the case where `event.index` was
zero.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)