### PR TITLE
Fixes ENYO-2142

### DIFF
--- a/lib/SimpleIntegerPicker/SimpleIntegerPicker.js
+++ b/lib/SimpleIntegerPicker/SimpleIntegerPicker.js
@@ -7,10 +7,12 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
-	dom = require('enyo/dom');
+	dom = require('enyo/dom'),
+	options = require('enyo/options');
 
 var
-	IntegerPicker = require('../IntegerPicker');
+	IntegerPicker = require('../IntegerPicker'),
+	SimpleIntegerPickerAccessibilitySupport = require('./SimpleIntegerPickerAccessibilitySupport');
 
 /**
 * Fires when the currently selected item changes.
@@ -70,6 +72,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: IntegerPicker,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [SimpleIntegerPickerAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/SimpleIntegerPicker/SimpleIntegerPickerAccessibilitySupport.js
+++ b/lib/SimpleIntegerPicker/SimpleIntegerPickerAccessibilitySupport.js
@@ -1,0 +1,16 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name SimpleIntegerPickerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	bindings: [
+		{from: 'unit', to: 'accessibilityLabel'}
+	]
+};


### PR DESCRIPTION
SimpleIntegerPicker has unit property, so set unit text to
accessibilityLabel.

Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>