### PR TITLE
ENYO-1906: Add Text to Speech Accessibility support to Popup and Cont…

### DIFF
--- a/lib/ContextualPopup/ContextualPopup.js
+++ b/lib/ContextualPopup/ContextualPopup.js
@@ -8,6 +8,7 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	dom = require('enyo/dom'),
+	options = require('enyo/options'),
 	ri = require('enyo/resolution'),
 	util = require('enyo/utils'),
 	Control = require('enyo/Control'),
@@ -23,7 +24,8 @@ var
 	IconButton = require('../IconButton'),
 	MoonHistory = require('../History'),
 	Scrim = require('moonstone/Scrim'),
-	HistorySupport = MoonHistory.HistorySupport;
+	HistorySupport = MoonHistory.HistorySupport,
+	ContextualPopupAccessibilitySupport = require('./ContextualPopupAccessibilitySupport');
 
 /**
 * Fires when the contextual popup is to be shown.
@@ -78,7 +80,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins: [HistorySupport],
+	mixins: options.accessibility ? [HistorySupport, ContextualPopupAccessibilitySupport] : [HistorySupport],
 
 	/**
 	* @private

--- a/lib/ContextualPopup/ContextualPopupAccessibilitySupport.js
+++ b/lib/ContextualPopup/ContextualPopupAccessibilitySupport.js
@@ -1,0 +1,21 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name ContextualPopupAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.setAttribute('aria-hidden', enabled ? !this.showing : true);
+			this.setAttribute('aria-live', 'off');
+		};
+	})
+};

--- a/lib/Popup/Popup.js
+++ b/lib/Popup/Popup.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	util = require('enyo/utils'),
 	Control = require('enyo/Control'),
 	Popup = require('enyo/Popup');
@@ -19,7 +20,8 @@ var
 	Button = require('../Button'),
 	IconButton = require('../IconButton'),
 	MoonHistory = require('../History'),
-	HistorySupport = MoonHistory.HistorySupport;
+	HistorySupport = MoonHistory.HistorySupport,
+	PopupAccessibilitySupport = require('./PopupAccessibilitySupport');
 
 /**
 * {@link module:moonstone/Popup~Popup} is an {@link module:enyo/Popup~Popup} that appears at the bottom of the
@@ -46,7 +48,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins : [HistorySupport],
+	mixins: options.accessibility ? [HistorySupport, PopupAccessibilitySupport] : [HistorySupport],
 
 	/**
 	* @private

--- a/lib/Popup/PopupAccessibilitySupport.js
+++ b/lib/Popup/PopupAccessibilitySupport.js
@@ -1,0 +1,21 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name PopupAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+			this.setAttribute('aria-hidden', enabled ? !this.showing : true);
+			this.setAttribute('aria-live', 'off');
+		};
+	})
+};


### PR DESCRIPTION
…extual Popup

In moon.Popup and moon.ContextualPopup we need to prevent 'aria-live' attribute
because if popup has marquee text and it has focus, screen reader will read
all the content continuosly.
When popup is showing, set 'aria-hidden' false and when it disapeared set
'aria-hidden' true.
Set 'aria-live' to 'off' and apply 'aria-hidden'.

https://jira2.lgsvl.com/browse/ENYO-1906
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>