### PR TITLE
ENYO-2168: Marquee doesn't recalculate distance when scroller show/hide

### DIFF
--- a/lib/ScrollStrategy/ScrollStrategy.js
+++ b/lib/ScrollStrategy/ScrollStrategy.js
@@ -163,10 +163,6 @@ var MoonScrollStrategy = module.exports = kind(
 		{kind: Signals, onSpotlightModeChanged: 'spotlightModeChanged', isChrome: true}
 	],
 
-	observers: [
-		{method: 'resize', path: ['vEnabled', 'hEnabled']}
-	],
-
 	/**
 	* @private
 	*/
@@ -796,8 +792,14 @@ var MoonScrollStrategy = module.exports = kind(
 	* @private
 	*/
 	enableDisableScrollColumns: function() {
+		var vWas = this.verticalScrollEnabled,
+			hWas = this.horizontalScrollEnabled;
 		this.enableDisableVerticalScrollControls(this.showVertical());
 		this.enableDisableHorizontalScrollControls(this.showHorizontal());
+		if ((vWas !== this.verticalScrollEnabled)
+			|| (hWas !== this.horizontalScrollEnabled)) {
+				this.resize();
+			}
 	},
 
 	/**
@@ -811,7 +813,7 @@ var MoonScrollStrategy = module.exports = kind(
 		this.$.hColumn.addRemoveClass('v-scroll-enabled', enabled);
 		this.$.pageUpControl.spotlight = enabled && this.spotlightPagingControls;
 		this.$.pageDownControl.spotlight = enabled && this.spotlightPagingControls;
-		this.set('vEnabled', enabled);
+		this.verticalScrollEnabled = enabled;
 	},
 
 	/**
@@ -825,7 +827,7 @@ var MoonScrollStrategy = module.exports = kind(
 		this.$.hColumn.addRemoveClass('h-scroll-enabled', enabled);
 		this.$.pageLeftControl.spotlight = enabled && this.spotlightPagingControls;
 		this.$.pageRightControl.spotlight = enabled && this.spotlightPagingControls;
-		this.set('hEnabled', enabled);
+		this.horizontalScrollEnabled = enabled;
 	},
 
 	/**

--- a/lib/ScrollStrategy/ScrollStrategy.js
+++ b/lib/ScrollStrategy/ScrollStrategy.js
@@ -163,6 +163,10 @@ var MoonScrollStrategy = module.exports = kind(
 		{kind: Signals, onSpotlightModeChanged: 'spotlightModeChanged', isChrome: true}
 	],
 
+	observers: [
+		{method: 'resize', path: ['vEnabled', 'hEnabled']}
+	],
+
 	/**
 	* @private
 	*/
@@ -807,6 +811,7 @@ var MoonScrollStrategy = module.exports = kind(
 		this.$.hColumn.addRemoveClass('v-scroll-enabled', enabled);
 		this.$.pageUpControl.spotlight = enabled && this.spotlightPagingControls;
 		this.$.pageDownControl.spotlight = enabled && this.spotlightPagingControls;
+		this.set('vEnabled', enabled);
 	},
 
 	/**
@@ -820,6 +825,7 @@ var MoonScrollStrategy = module.exports = kind(
 		this.$.hColumn.addRemoveClass('h-scroll-enabled', enabled);
 		this.$.pageLeftControl.spotlight = enabled && this.spotlightPagingControls;
 		this.$.pageRightControl.spotlight = enabled && this.spotlightPagingControls;
+		this.set('hEnabled', enabled);
 	},
 
 	/**


### PR DESCRIPTION
scroll thumb.

Issue:
- The moon.Scroller doesn't have a way to detect content changes.
- So, we need to bubble up onRequestSetupBonds to update scroll boundary
  and thumb state.
- The problem is even if moon.Scroller (moon.ScrollStrategy) update it's
  scroll bounds and enable scroll thumb area. All the items inside
  doesn't get any notice from scroller when scroll thumb area is
  reserved by strategy (push padding-right).

Fix:
- It need to call resize on scroller when scroll thumb state is changed,
  because the scroll content area and item width is actually changed.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>