### PR TITLE
Fixes ENYO-2141

### DIFF
--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -342,27 +342,14 @@ module.exports = kind(
 	*/
 	selectedIndexChanged: function () {
 		var selected = this.getSelected(),
-		controls = this.getCheckboxControls(),
-		index = this.getSelectedIndex();
+			controls = this.getCheckboxControls(),
+			index = this.getSelectedIndex(),
+			checked;
 
 		if (this.multipleSelection) {
 			for (var i = 0; i < controls.length; i++) {
-				var selIndex = selected.indexOf(controls[i]);
-				if (index.indexOf(i) >= 0) {
-					controls[i].setChecked(true);
-					if (selIndex == -1) {
-						selected.push(controls[i]);
-					}
-				} else {
-					controls[i].setChecked(false);
-					if (selIndex >= 0) {
-						selected.splice(selIndex, 1);
-					}
-				}
-			}
-			this.$.currentValue.setContent(this.multiSelectCurrentValue());
-			if(this.hasNode()) {
-				this.fireChangeEvent();
+				checked = index.indexOf(i) >= 0;
+				controls[i].setChecked(checked);
 			}
 		} else {
 			if (controls[index] && controls[index] !== selected) {


### PR DESCRIPTION
By both pushing the control and updating its checked state, the control
was added to the selected array twice. Instead, we'll rely on the
onActivate handler to add it to selected and just update checked.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)