### PR TITLE
ENYO-2164: Increase delay before starting IntegerPicker scroll...

### DIFF
--- a/lib/IntegerPicker/IntegerPicker.js
+++ b/lib/IntegerPicker/IntegerPicker.js
@@ -580,7 +580,7 @@ module.exports = kind(
 			this.updateRepeater(index, count);
 
 			this.scrollToIndex(oldIndex, false);
-			this.startJob('valueChanged-Scroller', this.bindSafely('scrollToIndex', newIndex, true), 16);
+			this.startJob('valueChanged-Scroller', this.bindSafely('scrollToIndex', newIndex, true), 33);
 		} else {
 			// if old isn't specified, setup the repeater with only this.value and jump to it
 			this.updateRepeater(newIndex);


### PR DESCRIPTION
...to work around DOM sync issue on TV. With the previous delay,
the offsetTop value reported by the DOM API for our target node
was wrong under certain circumstances (issue could be reproduced
by repeatedly clicking to increment or decrement the picker; error
case occured roughtly once every 50-100 clicks).

I'd ultimately love to see us find a way to rework IntegerPicker
such that it didn't need to use this async trick for scrolling,
since async stuff like this is inherently brittle across different
environments; but for now, the best fix seems to be simply to
increase the delay.

After some experimentation, I settled on roughly doubling the delay
from 16 to 33 ms. I was unable to repro the error case when
clicking 500+ times at this value, and there's no perceptible
difference in responsiveness.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)