### PR TITLE
ENYO-2178-marquee distance is not properly updated when changing con…

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -713,6 +713,7 @@
 		showingChangedHandler: enyo.inherit(function (sup) {
 			return function () {
 				sup.apply(this, arguments);
+				if(this.showing) this._marquee_calcDistance();
 				this._marquee_reset();
 			};
 		}),


### PR DESCRIPTION
…tent during control is hidden

If content of the marquee is changed while control is hidden, marquee
distance is not calculated to apply proper classes.
So while changing the showing status, marquee distance is calculated.
Enyo-DCO-1.1-Signed-Off-By:  Rajyavardhan P <rajyavardhan.p@lge.com>