### PR TITLE
ENYO-1994 : Add Text to Speech Accessibility support to LightPanels

### DIFF
--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -5,13 +5,15 @@
 
 var
 	kind = require('enyo/kind'),
-	LightPanels = require('enyo/LightPanels');
+	LightPanels = require('enyo/LightPanels'),
+	options = require('enyo/options');
 
 var
 	Spotlight = require('spotlight');
 
 var
-	LightPanel = require('../LightPanel');
+	LightPanel = require('../LightPanel'),
+	LightPanelsAccessibilitySupport = require('./LightPanelsAccessibilitySupport');
 
 /**
 * A light-weight panels implementation that has basic support for side-to-side transitions
@@ -34,6 +36,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: LightPanels,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [LightPanelsAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/LightPanels/LightPanelsAccessibilitySupport.js
+++ b/lib/LightPanels/LightPanelsAccessibilitySupport.js
@@ -1,0 +1,28 @@
+var
+	kind = require('enyo/kind');
+
+var
+	VoiceReadout = require('enyo-webos/VoiceReadout');
+
+/**
+* @name LightPanelsAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	updateSpottability: kind.inherit(function (sup) {
+		return function (from, to) {		
+			var panels = this.getPanels(),
+				panelNext = panels[to];
+
+			if (panelNext && panelNext.$.header) {
+				VoiceReadout.readAlert(panelNext.$.header.getTitle());
+			}
+			sup.apply(this, arguments);
+		};
+	})
+	
+};

--- a/lib/LightPanels/LightPanelsAccessibilitySupport.js
+++ b/lib/LightPanels/LightPanelsAccessibilitySupport.js
@@ -18,8 +18,8 @@ module.exports = {
 			var panels = this.getPanels(),
 				panelNext = panels[to];
 
-			if (panelNext && panelNext.$.header) {
-				VoiceReadout.readAlert(panelNext.$.header.getTitle());
+			if (panelNext) {
+				VoiceReadout.readAlert(panelNext.getTitle());
 			}
 			sup.apply(this, arguments);
 		};


### PR DESCRIPTION
Initial add accessibility feature to LightPanels.

## Requirement
WebOS TV should read panel title when LightPanel is opened or moved according to UX requirements.

## Implementation
We added LightPanelsAccessibilitySupport to support reading a panel title.
LightPanels is spotlight container, so first child component or last spotlight component is focused when panel is opened.Then, Screen reader first reads this focused component content. However, UX requirements request that Screen reader should read panel title when panel is opened or moved. 
TV should read panel title as quickly as possible before reading focused component, so we added readAlert function to updateSpottablity. The updateSpottablity is called before indexChanged or animateTo is called. 

## Limitation
We used readAlert() of enyo-webOS library and overrided updateSpottablity to read as quickly as possible, but If panel title is long or panel is opened quickly without animation, panel title sound will be cut for reading focused child component of panel 

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
