### PR TITLE
ENYO-2160: Marquee showingChanged, distance does not recalc

### DIFF
--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -716,6 +716,9 @@
 			return function () {
 				sup.apply(this, arguments);
 				this._marquee_reset();
+				if(this.getAbsoluteShowing()){
+					this._marquee_calcDistance();	
+				}
 			};
 		}),
 

--- a/source/Marquee.js
+++ b/source/Marquee.js
@@ -713,10 +713,10 @@
 		* @private
 		*/
 		showingChangedHandler: enyo.inherit(function (sup) {
-			return function () {
+			return function (sender, event) {
 				sup.apply(this, arguments);
 				this._marquee_reset();
-				if(this.getAbsoluteShowing()){
+				if(this.showing && event.showing){
 					this._marquee_calcDistance();	
 				}
 			};


### PR DESCRIPTION
Issue.

When marquee showing is changed, it does not cause a reflow event.

Fix.

If the marquee is showing then it will recalculate distance. 


Enyo-DCO-1.1-Signed-off-by: Derek Anderson <derek.anderson@lge.com>