### PR TITLE
Fixes ENYO-2155

### DIFF
--- a/lib/ExpandableListItem/ExpandableListItem.less
+++ b/lib/ExpandableListItem/ExpandableListItem.less
@@ -51,6 +51,10 @@
 	.moon-expandable-list-item .spotlight & {
 		color: @moon-spotlight-text-color;
 	}
+
+	.moon-neutral & {
+		color: inherit;
+	}
 }
 
 

--- a/lib/Icon/Icon.less
+++ b/lib/Icon/Icon.less
@@ -37,6 +37,10 @@
 			font-size: @moon-icon-small-size;
 		}
 	}
+
+	.moon-neutral & {
+		color: inherit;
+	}
 }
 
 .spotlight .moon-icon {


### PR DESCRIPTION
Add CSS rule for ExpandableListItems within moon-neutral containers

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)