### PR TITLE
ENYO-2193: Stop marquee when tearing down as part of a cached view.

### DIFF
--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -339,6 +339,17 @@ var MarqueeSupport = {
 	}),
 
 	/**
+	* @method
+	* @private
+	*/
+	teardownRender: kind.inherit(function (sup) {
+		return function (cache) {
+			sup.apply(this, arguments);
+			if (cache) this.stopMarquee();
+		};
+	}),
+
+	/**
 	* Handles external requests to kick off {@link module:moonstone/Marquee~MarqueeSupport#marqueeStart}.
 	*
 	* @private


### PR DESCRIPTION
### Issue
When a `Marquee` control is part of a "cached" view that is torn down and re-rendered, the control does not resume marqueeing from the start i.e. as if it was first rendered.

### Fix
For the case where our `Marquee` control is being torn down as part of a cached view, we make a call to `stopMarquee` to effectively clean-up the state.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>