### PR TITLE
ENYO-1895: Add Text to Speech Accessibility support to Slider

### DIFF
--- a/lib/Slider/Slider.js
+++ b/lib/Slider/Slider.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control'),
 	Animator = require('enyo/Animator');
 
@@ -16,6 +17,9 @@ var
 var
 	ProgressBar = require('../ProgressBar'),
 	IconButton = require('../IconButton');
+
+var
+	SliderAccessibilitySupport = require('./SliderAccessibilitySupport');
 
 /**
 * Fires when bar position is set.
@@ -70,6 +74,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: ProgressBar,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [SliderAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/Slider/SliderAccessibilitySupport.js
+++ b/lib/Slider/SliderAccessibilitySupport.js
@@ -1,0 +1,62 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name SliderAccessibilityMixin
+* @
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	bindings: [
+		{from: 'disabled', to: 'accessibilityDisabled'}
+	],
+
+	/**
+	* @private
+	*/
+	rendered: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+
+			// Avoid reading aria-valuenow or aria-valuetext when it rendered.
+			this.setAttribute('aria-hidden', 'true');
+
+			this.setAttribute('role', enabled ? 'slider' : null);
+			this.setAttribute('aria-valuenow', enabled ? this.value : null);
+			this.setAttribute('aria-valuetext', enabled ? this.popupContent : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	spotFocused: kind.inherit(function (sup) {
+		return function (oSender, oEvent) {
+			if (!this.accessibilityDisabled) {
+				this.setAttribute('aria-hidden', 'false');
+			}
+
+			sup.apply(this, arguments);
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	animatorComplete: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled;
+			sup.apply(this, arguments);
+
+			this.setAttribute('role', enabled ? 'slider' : null);
+			this.setAttribute('aria-valuenow', enabled ? this.value : null);
+			this.setAttribute('aria-valuetext', enabled ? this.popupContent : null);
+			this.setAttribute('tabindex', enabled ? 0 : null);
+		};
+	})
+};


### PR DESCRIPTION
I tried to apply aria attributes on valueChanged, but there are some
issues that if value is changed before animator complete TV reads
the value multiple times.
Set aria-valuenow and aria-valuetext in animatorComplete.
Initialize aria attributes on rendered to get popupContent.
When it initialized we set aria-hidden true to avoid first reading
that if aria-valuenow is set screen reader reads the value, and then
set it false when it spotFocused.

https://jira2.lgsvl.com/browse/ENYO-1895
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>