### PR TITLE
ENYO-2199 Header: Medium header CSS error

### DIFF
--- a/lib/Header/Header.less
+++ b/lib/Header/Header.less
@@ -38,7 +38,7 @@
 		line-height: 45px;
 	}
 	.moon-header-title-below {
-		margin-top: -9px;  // Tuck this element up under the title
+		margin-top: -21px;  // Tuck this element up under the title
 	}
 
 	&.full-bleed {


### PR DESCRIPTION
Issue:
When 'enyo-locale-non-latin' is set, layout of 'subTitleBelow' is duplicated with divider in medium header.
 
Fix:
modified 'margin-top' from '-9px' to '-21px'.

Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com