### PR TITLE
ENYO-2220, ENYO-2221: ScrollControls styling

### DIFF
--- a/lib/PagingControl/PagingControl.less
+++ b/lib/PagingControl/PagingControl.less
@@ -1,3 +1,11 @@
+/* 
+	TODO: Clean up and move rules here to ScrollControls.less
+	when new scroller implementation (based on Scrollable mixin) is complete.
+
+	For now, to avoid copy-paste and redundant bug-fix work, we are directly
+	including this .less file from the ScrollControls package.json.
+*/
+
 /* Scroller Page Controls */
 .moon-icon-button.moon-paging-button {
 	position: absolute;

--- a/lib/ScrollControls/ScrollControls.less
+++ b/lib/ScrollControls/ScrollControls.less
@@ -1,0 +1,14 @@
+/* 
+	TODO: Clean up and move rules here from Scroller.less and PagingControl.less
+	when new scroller implementation (based on Scrollable mixin) is complete.
+
+	For now, to avoid copy-paste and redundant bug-fix work, we are directly
+	including those .less files from the ScrollControls package.json.
+*/
+
+/* ScrollControls.less */
+
+.moon-scroller-v-column,
+.moon-scroller-h-column {
+	z-index: 100;
+}

--- a/lib/ScrollControls/package.json
+++ b/lib/ScrollControls/package.json
@@ -1,3 +1,8 @@
 {
-	"main": "ScrollControls.js"
+	"main": "ScrollControls.js",
+	"styles": [
+		"ScrollControls.less",
+		"../Scroller/Scroller.less",
+		"../PagingControl/PagingControl.less"
+	]
 }

--- a/lib/Scroller/Scroller.less
+++ b/lib/Scroller/Scroller.less
@@ -1,4 +1,10 @@
-/* TODO: Clean up / reduce this file after new scroller implementation is completely integrated. */
+/* 
+	TODO: Clean up and move rules here to ScrollControls.less
+	when new scroller implementation (based on Scrollable mixin) is complete.
+
+	For now, to avoid copy-paste and redundant bug-fix work, we are directly
+	including this .less file from the ScrollControls package.json.
+*/
 
 .moon-scroller-client-wrapper,
 .moon-scroller-viewport {


### PR DESCRIPTION
* Make ScrollControls explicitly depend on styles from Scroller
  and PagingControl (as a temporary measure). Until now, this
  dependency has been implicit, which causes ScrollControls to be
  laid out improperly when used in an app that doesn't also include
  Scroller and PagingControl.

* Apply a positive z-index to ScrollControls' scroll columns, so
  that they reliably appear above scroller contents.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)