### PR TITLE
ENYO-2223: Prevent unwanted DOM scroll in NewDataList

### DIFF
--- a/lib/NewDataList/NewDataList.js
+++ b/lib/NewDataList/NewDataList.js
@@ -1,3 +1,5 @@
+require('moonstone');
+
 var
 	kind = require('enyo/kind'),
 	NewDataList = require('enyo/NewDataList');

--- a/lib/NewDataList/NewDataList.js
+++ b/lib/NewDataList/NewDataList.js
@@ -25,6 +25,16 @@ module.exports = kind({
 		onSpotlightLeft: 'guard5way',
 		onSpotlightFocus: 'avoidScrollOnDefaultFocus'
 	},
+	/**
+	* @private
+	*/
+	create: function() {
+		NewDataList.prototype.create.apply(this, arguments);
+		// Prevent browser engine from subversively setting
+		// scrollTop on our container when a list item receives
+		// DOM focus
+		this.$.container.accessibilityPreventScroll = true;
+	},
 	guard5way: function (sender, event) {
 		var e, l, idx, d2x, row, limitRow;
 


### PR DESCRIPTION
When accessibility is enabled, the DOM focus() method is called on
any control that receives Spotlight focus (to trigger screen
reading). Some browser engines (including WebKit and Chrome) try to
force DOM-focused elements into view by adjusting the native DOM
scrollTop property of containing elements. This causes problems for
us, because we generally mange scrolling ourselves, and usually not
using native scrollTop.

In this case, we need to prevent scrollTop from being set on the
list's container element. We use a mechanism recently added to
address similar issues elsewhere in Moonstone.

TODO: See if we can find a clean, performant way to defeat this
type of behavior in general, unless a Control specifically opts in
to allow it -- because we pretty much never want the engine to
manage scrollTop outside our control.

Bonus commit unrelated to bug: require moonstone, per convention.