### PR TITLE
ENYO-2224: Improve 5-way scrolling in Scrollable / NewDataList

### DIFF
--- a/lib/NewDataList/NewDataList.js
+++ b/lib/NewDataList/NewDataList.js
@@ -23,22 +23,40 @@ module.exports = kind({
 		onSpotlightLeft: 'guard5way',
 		onSpotlightFocus: 'avoidScrollOnDefaultFocus'
 	},
+	/**
+	* Prevent accelerating 5-way focus events from trying
+	* to spot elements that don't yet have DOM nodes.
+	*
+	* @private
+	*/
 	guard5way: function (sender, event) {
 		var e, l, idx, d2x, row, limitRow;
 
+		// Only need to guard if we are accelerating
 		if (!Spotlight.Accelerator.isAccelerating()) return false;
 
 		e = event.type;
+
+		// Figure out the index of the last de-virtualized element
+		// in the direction we're currently scrolling; anything
+		// further out doesn't yet have a DOM node
 		l = (e === 'onSpotlightUp' || e === 'onSpotlightLeft') ? 
 			this.first :
 			this._last;
 
+		// Get the index of the currently focused element
 		idx = event.index;
-		d2x = this.dim2extent;
 
+		// In case we're in a grid layout, we need to translate
+		// these indices into the corresponding row / column
+		d2x = this.dim2extent;
 		row = Math.floor(idx / d2x);
 		limitRow = Math.floor(l / d2x);
 
+		// If we're in the last de-virtualized row, the element we
+		// would focus from here doesn't yet have a DOM node, so
+		// we return true to prevent an attempt to focus. We'll wait
+		// for the next accelerated 5-way event and try again...
 		return (row === limitRow);
 	},
 	/**

--- a/lib/NewDataList/NewDataList.js
+++ b/lib/NewDataList/NewDataList.js
@@ -20,8 +20,7 @@ module.exports = kind({
 		onSpotlightUp: 'guard5way',
 		onSpotlightRight: 'guard5way',
 		onSpotlightDown: 'guard5way',
-		onSpotlightLeft: 'guard5way',
-		onSpotlightFocus: 'avoidScrollOnDefaultFocus'
+		onSpotlightLeft: 'guard5way'
 	},
 	/**
 	* Prevent accelerating 5-way focus events from trying
@@ -87,25 +86,22 @@ module.exports = kind({
 			if (item) Spotlight.spot(item);
 		}
 	},
-	avoidScrollOnDefaultFocus: function (sender, event) {
-		var fv;
-		// When focusType is 'default', Spotlight is trying to focus
-		// a Control in response to something other than a point or a
-		// 5-way move. For example, this can happen during
-		// initialization, when the pointer is hidden, or when the app
-		// regains focus.
-		//
-		// In the case where a list element is being focused by default,
-		// we short-circuit the action because the element is
-		// potentially not in view, and focusing would cause it to
-		// scroll it into view for no reason apparent to the user.
-		// Instead, we just focus the first visible list element.
-		if (event.focusType === 'default' && typeof event.index === 'number') {
-			fv = this.getFullyVisibleItems()[0] || this.getVisibleItems()[0];
-			if (fv) {
-				Spotlight.spot(fv);
-				return true;
-			}
+	/**
+	* Called by moonstone/Scrollable.filterFocus()
+	* @private
+	*/
+	eventIsFromScrollingChild: function (event) {
+		return (typeof event.index === 'number');
+	},
+	/**
+	* Called by moonstone/Scrollable.filterFocus()
+	* @private
+	*/
+	spotFirstVisibleChild: function() {
+		var fv = this.getFullyVisibleItems()[0] || this.getVisibleItems()[0];
+		if (fv) {
+			Spotlight.spot(fv);
+			return true;
 		}
 	}
 });

--- a/lib/Scrollable/Scrollable.js
+++ b/lib/Scrollable/Scrollable.js
@@ -44,6 +44,7 @@ var Scrollable = {
 		onSpotlightFocus: 'filterFocus'
 	},
 
+	// Override ScrollMath params
 	scrollMath: {kind: ScrollMath, kFrictionDamping: 0.93},
 
 	/**
@@ -170,6 +171,12 @@ var Scrollable = {
 		};
 	}),
 
+	/**
+	* Extends the base implementation provided by the enyo Scrollable mixin
+	* with Moonstone-specific functionality.
+	*
+	* @private
+	*/
 	_suppressMouseEvents: kind.inherit(function (sup) {
 		return function () {
 			var c;

--- a/lib/Scrollable/Scrollable.js
+++ b/lib/Scrollable/Scrollable.js
@@ -4,6 +4,7 @@
 */
 var
 	kind = require('enyo/kind'),
+	utils = require('enyo/utils'),
 	ScrollMath = require('enyo/ScrollMath');
 
 var
@@ -28,13 +29,33 @@ var Scrollable = {
 		behavior: 'smooth'
 	},
 
+	// TODO: At least in the case of onSpotlightFocus, we
+	// probably need to do something to ensure that we don't
+	// have a conflict between the handler declared in the mixin
+	// and any handler that might be declared in the kind that
+	// uses the mixin. Possibilities include a) a hack like the
+	// one currently employed in MarqueeSupport; b) a generalized
+	// mechanism based on the same approach; or c) support in
+	// general for multiple handlers for the same event, so that
+	// base kinds, subkinds and instances can all register for
+	// handlers independently.
 	handlers: {
-		onRequestScrollIntoView: 'handleRequestScrollIntoView'
-		// TODO: See `avoidScrollOnDefaultFocus()`
-		//onSpotlightFocus: 'avoidScrollOnDefaultFocus'
+		onRequestScrollIntoView: 'handleRequestScrollIntoView',
+		onSpotlightFocus: 'filterFocus'
 	},
 
 	scrollMath: {kind: ScrollMath, kFrictionDamping: 0.93},
+
+	/**
+	* @private
+	*/
+	create: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			// Save default options so they can be restored after runtime changes
+			this._scrollIntoViewOptions = utils.clone(this.scrollIntoViewOptions);
+		};
+	}),
 
 	/**
 	* Responds to child components' requests to be scrolled into view.
@@ -44,12 +65,21 @@ var Scrollable = {
 	handleRequestScrollIntoView: function (sender, event) {
 		var bubble = false,
 			def = this.scrollIntoViewOptions,
-			opts = {
-				block: event.scrollFullPage ? 'farthest' : def.block,
-				behavior: def.behavior
-			};
+			opts;
+		// Only scroll in 5-way mode or when explicitly requested to scroll in pointer mode
 		if (!Spotlight.getPointerMode() || event.scrollInPointerMode === true) {
 			if (this.canScrollX || this.canScrollY) {
+				opts = {
+					// If the event explicitly requests a full-page scroll, then we do so...
+					block: event.scrollFullPage ? 'farthest' : (
+						// ...otherwise, we honor the option set on the scroller for one-off
+						// requests, but force smaller scroll increments when Spotlight
+						// accelerating, since this produces smoother continuous scrolling
+						// in 5-way mode.
+						Spotlight.Accelerator.isAccelerating() ? 'nearest' : def.block
+					),
+					behavior: def.behavior
+				};
 				this.scrollToControl(event.originator, opts);
 			} else {
 				// If we don't need to scroll, bubble onRequestScrollIntoView so that
@@ -60,25 +90,85 @@ var Scrollable = {
 		return !bubble;
 	},
 
-	// TODO: Implement. For now, only handling the more specific
-	//       case in moonstone/NewDataList
-	/*avoidScrollOnDefaultFocus: function (sender, event) {
-		// When focusType is 'default', Spotlight is trying to focus
-		// a Control in response to something other than a point or a
-		// 5-way move. For example, this can happen during
-		// initialization, when the pointer is hidden, or when the app
-		// regains focus.
-		//
-		// In the case where a scroller child is being focused by
-		// default, we short-circuit the action because the child is
-		// potentially not in view, and focusing would cause it to
-		// scroll it into view for no reason apparent to the user.
-		// Instead, we should focus a child we know to be visible.
-		if (event.focusType === 'default' !this.isScrollControl(event.originator)) {
-			// Find and spot a suitable scroller child here.
-			return true;
+	/**
+	* @private
+	*/
+	filterFocus: function (sender, event) {
+		var prev,
+			defBlock;
+
+		switch (event.focusType) {
+			case 'point':
+				break;
+			case '5-way':
+				// If 5-way focus is coming from outside the scroller or from a scroll control,
+				// we want to scroll the smallest distance possible to avoid a jarring experience;
+				// otherwise, we respect the provided options
+				if ((prev = event.previous)) {
+					defBlock = this._scrollIntoViewOptions.block;
+					this.scrollIntoViewOptions.block = (this.isScrollingChild(prev)) ? defBlock : 'nearest';
+				}
+				break;
+			case 'default':
+				// When focusType is 'default', Spotlight is trying to focus
+				// a Control in response to something other than a point or a
+				// 5-way move. For example, this can happen during
+				// initialization, when the pointer is hidden, or when the app
+				// regains focus.
+				//
+				// In the case where a scroller child is being focused by
+				// default, we short-circuit the action because the child is
+				// potentially not in view, and focusing would cause it to
+				// scroll it into view for no reason apparent to the user.
+				// Instead, we should focus a child we know to be visible.
+				if (this.eventIsFromScrollingChild(event)) {
+					return this.spotFirstVisibleChild();
+				}
+				break;
+			default:
+				return false;
 		}
-	},*/
+	},
+
+	/**
+	* This check is factored out of `filterFocus()` so that the logic can be
+	* overridden by the kind that includes the `Scrollable` mixin. For example,
+	* NewDataList can perform this check more efficiently than we can do it here
+	* in the general case.
+	*
+	* @private
+	*/
+	eventIsFromScrollingChild: kind.inherit(function (sup) {
+		return function (event) {
+			if (sup === utils.nop) {
+				return this.isScrollingChild(event.originator);
+			}
+			else {
+				return sup.apply(this, arguments);
+			}
+		};
+	}),
+
+	/**
+	* This behavior is factored out of `filterFocus()` so that the logic can be
+	* overridden by the kind that includes the `Scrollable` mixin. For example,
+	* NewDataList can identify the first visible child more efficiently than we
+	* can do it here in the general case.
+	*
+	* @private
+	*/
+	spotFirstVisibleChild: kind.inherit(function (sup) {
+		return function () {
+			if (sup === utils.nop) {
+				// TODO: Implement. For now, only handling the more specific
+				// case in moonstone/NewDataList.
+				return false;
+			}
+			else {
+				return sup.apply(this, arguments);
+			}
+		};
+	}),
 
 	_suppressMouseEvents: kind.inherit(function (sup) {
 		return function () {


### PR DESCRIPTION
* When doing continuous / accelerated 5-way scrolling, scroll an
element at a time instead of a page at a time. This produces
smoother scrolling.

* When 5-way focusing an element inside a scroller and focus was
previously outside the scroller or on one of the scroll controls,
minimize the distance scrolled to bring the element into view. This
produces a less jarring effect.

These changes necessitated some refactoring of existing logic for
filtering onSpotlightFocus events. The new factoring is explained
with inline comments.

The changes also depend on a new feature in Spotlight. The
onSpotlightFocus and onSpotlightFocused events now indicate
which element was previously focused, which enables handlers to
discriminate on that basis as necessary.

Bonus commits (not related to task) add some previously missing
inline comments / docs.

Depends on Spotlight PR: https://github.com/enyojs/spotlight/pull/191