### PR TITLE
ENYO-2218: ListActions are stacked vertically, not horizontally

### DIFF
--- a/lib/ListActions/ListActions.js
+++ b/lib/ListActions/ListActions.js
@@ -429,7 +429,6 @@ var ListActions = module.exports = kind(
 		}
 		this.disabledChanged();
 		this.listActionsChanged();
-		this.drawerNeedsResize = true;
 	},
 
 	/**
@@ -466,6 +465,7 @@ var ListActions = module.exports = kind(
 	listActionsChanged: function() {
 		var owner = this.hasOwnProperty('listActions') ? this.getInstanceOwner() : this;
 		this.listActions = this.listActions || [];
+		this.drawerNeedsResize = true;
 		this.renderListActionComponents(owner);
 	},
 
@@ -485,6 +485,8 @@ var ListActions = module.exports = kind(
 		var listAction, i;
 
 		this.listActionComponents = [];
+		this.$.listActions.destroyClientControls();
+
 		for (i = 0; (listAction = this.listActions[i]); i++) {
 			this.listActionComponents.push(this.createListActionComponent(listAction, owner));
 		}
@@ -555,9 +557,6 @@ var ListActions = module.exports = kind(
 	*/
 	beforeOpenDrawer: function(standardHeight, type) {
 		this.standardHeight = standardHeight;
-		if (type !== 'large') {
-			this.set('stacked', false);
-		}
 	},
 
 	//TODO: Remove the onListActionOpenChanged event. It will be deprecated in favor of the onShow/onHide events
@@ -648,8 +647,17 @@ var ListActions = module.exports = kind(
 	* @private
 	*/
 	shouldStack: function() {
+		var i, optionGroup,
+		    nVisibleActions = 0;
+
+		for (i = 0; (optionGroup = this.listActionComponents[i]); i++) {
+			if (optionGroup.showing) {
+				nVisibleActions++;
+			}
+		}
+
 		// Assumption: min-width of all listActionsComponents set to 300px in CSS
-		return this.$.listActions.getBounds().width < (300 * this.listActionComponents.length);
+		return this.$.listActions.getBounds().width < (ri.scale(300) * nVisibleActions);
 	},
 
 	/**
@@ -667,6 +675,7 @@ var ListActions = module.exports = kind(
 			this.unStackMeUp();
 			this.$.listActions.setVertical('hidden');
 		}
+
 		this.resetScroller = true;
 		this.$.listActions.resize();
 	},
@@ -676,6 +685,10 @@ var ListActions = module.exports = kind(
 	*/
 	stackMeUp: function() {
 		var optionGroup, i;
+
+		if (this.standardHeight) {
+			this.$.drawer.applyStyle('height', dom.unit( ri.scale(this.standardHeight), 'rem'));
+		}
 
 		for (i = 0; (optionGroup = this.listActionComponents[i]); i++) {
 			// Stacked contols get natural height (which prevents scrolling), such that they stack


### PR DESCRIPTION
### Issue:
ListAction checks if actions are arranged vertically or horizontally by comparing total width. However it takes all the components even if their visibility is set to false so it returns incorrect result. Also it doesn't care about resolution independence

### Fix:
Calculate total width by taking only actions whose visibility is set to true and use ri.scale to get proper result based on resolution.

Enyo-DCO-1.1-Signed-Off-By: Hunkyo Jung (hunkyo.jung@lge.com)