### PR TITLE
ENYO-2110: ExpandablePicker scroll thumb visible during collapse animation when navigating up to header.

### DIFF
--- a/source/ExpandableListItem.js
+++ b/source/ExpandableListItem.js
@@ -151,7 +151,7 @@
 		components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 			// widths (webkit bug)
-			{name: 'headerContainer', classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+			{name: 'headerContainer', classes: 'moon-expandable-list-item-header moon-expandable-picker-header moon-expandable-list-header', onSpotlightFocus: 'headerFocus', spotlightFocused: enyo.nop, ontap: 'expandContract', components: [
 				{name: 'header', kind: 'moon.MarqueeText'}
 			]},
 			{name: 'drawer', kind: 'enyo.Drawer', resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [
@@ -254,12 +254,12 @@
 		headerFocus: function (inSender, inEvent) {
 			var direction = inEvent && inEvent.dir;
 
-			if (this.getOpen() && this.getAutoCollapse() && direction === 'UP') {
-				this.setActive(false);
+			if (inEvent.originator === this.$.headerContainer) {
+				this.bubble('onRequestScrollIntoView');
 			}
 
-			if (inEvent.originator === this.$.header) {
-				this.bubble('onRequestScrollIntoView');
+			if (this.getOpen() && this.getAutoCollapse() && direction === 'UP') {
+				this.setActive(false);
 			}
 		},
 

--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -182,7 +182,7 @@
 		* @private
 		*/
 		components: [
-			{name: 'headerWrapper', kind: 'moon.Item', classes: 'moon-expandable-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
+			{name: 'headerWrapper', kind: 'moon.Item', classes: 'moon-expandable-picker-header-wrapper', onSpotlightFocus: 'headerFocus', spotlightFocused: enyo.nop, ontap: 'expandContract', components: [
 				// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 				{name: 'headerContainer', classes: 'moon-expandable-list-item-header moon-expandable-picker-header', components: [
 					{name: 'header', kind: 'moon.MarqueeText'}
@@ -553,6 +553,25 @@
 			}
 			this.$.client.setHighlander(!this.multipleSelection);
 			this.selectedChanged();
+		},
+
+		/**
+		* If drawer is currently open, and event was sent via keypress (i.e., it has a direction),
+		* process header focus.
+		*
+		* @fires moon.Scroller#onRequestScrollIntoView
+		* @private
+		*/
+		headerFocus: function (inSender, inEvent) {
+			var direction = inEvent && inEvent.dir;
+
+			if (inEvent.originator === this.$.headerWrapper) {
+				this.bubble('onRequestScrollIntoView');
+			}
+
+			if (this.getOpen() && this.getAutoCollapse() && direction === 'UP') {
+				this.setActive(false);
+			}
 		}
 	});
 


### PR DESCRIPTION
Issue:
- When header (moon.Item) is focused, onRequestScrollIntoView is
  triggered by onSpotlightFocused.
- The onRequestScrollIntoView is fired while the drawer is animating
  closed, which triggers alertThumbs as the scroll viewport is smaller
  than the original content size.

Fix:
- Remove duplicated call of onRequestScrollIntoView from
  headerWrapper and moon.Item.
- Change call order of onRequestScrollIntoView and setActive.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>