### PR TITLE
ENYO-2199: The subTitleBelow and bottom border is too close in medium

### DIFF
--- a/lib/Header/Header.less
+++ b/lib/Header/Header.less
@@ -140,7 +140,9 @@
 /* Special override for Japanese font (LG Display_JP) which, as of 07-Feb-2014
    has a taller baseline. This corrects both Header and InputHeader. 2014-02-24
    Please remove the line-height rule below if this font file is changed. */
-.enyo-locale-non-latin.enyo-locale-ja .moon-header-title,
+.enyo-locale-non-latin.enyo-locale-ja .moon-header .moon-header-title,
+.enyo-locale-non-latin.enyo-locale-ja .moon-header.moon-medium-header .moon-header-title,
+.enyo-locale-non-latin.enyo-locale-ja .moon-header.moon-small-header .moon-header-title,
 .enyo-locale-non-latin.enyo-locale-ja .moon-input-header .moon-input-header-input-decorator > .moon-input {
 	line-height: 1.25em;
 }


### PR DESCRIPTION
header.

Issue:
- In Japan locale, header has vary small gap between subTitleBelow and
  bottom border.
- There is .enyo-locale-ja line-height fix for moon-header-title.
  But, it is overriden by other specific rule.

Fix:
- Give more specific rule on .enyo-locale-ja.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>