### PR TITLE
ENYO-2231: Slider popup in Contextual Popup has vertical blank

### DIFF
--- a/lib/ProgressBar/ProgressBar.js
+++ b/lib/ProgressBar/ProgressBar.js
@@ -514,7 +514,7 @@ module.exports = kind(
 		this.$.drawingLeft.setAttribute('height', hRem);
 		this.$.drawingRight.setAttribute('height', hRem);
 		this.$.popupLabel.applyStyle('height', dom.unit(ri.scale(h - 7), 'rem'));
-		this.$.popup.applyStyle('height', dom.unit(ri.scale(h), 'rem'));
+		this.$.popup.applyStyle('height', dom.unit(ri.scale(h - 7), 'rem'));
 		this.$.popup.applyStyle('line-height', dom.unit(ri.scale(h - 6), 'rem'));
 	},
 
@@ -536,7 +536,7 @@ module.exports = kind(
 	* @private
 	*/
 	updatePopupLabelColor: function () {
-		this.$.popupLabel.applyStyle('background-color', this.popupColor);
+		this.$.popup.applyStyle('background-color', this.popupColor);
 	},
 
 	/**

--- a/lib/ProgressBar/ProgressBar.less
+++ b/lib/ProgressBar/ProgressBar.less
@@ -26,6 +26,7 @@
 /* Popup */
 .moon-progress-bar-popup {
 	white-space: nowrap;
+	border-radius: 72px;
 	z-index: 20;
 	left: 50%;
 


### PR DESCRIPTION
Issue:
- Slider popup has vertical noise line.

Fix:
- Make popup div round and set background color as the same as label
  color.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>