### PR TITLE
ENYO-2232 : TimePicker dstOffset is not working properly on TV.

### DIFF
--- a/lib/TimePicker/TimePicker.js
+++ b/lib/TimePicker/TimePicker.js
@@ -602,14 +602,6 @@ var TimePicker = module.exports = kind(
 	},
 
 	/**
-	* webOS TVs which rounds down when setting the hour to the skipped hour of DST
-	* whereas other implementations round up. 
-	*
-	* @private
-	*/
-	dstOffset: platform.webos? 3600000 : -3600000,
-
-	/**
 	* @private
 	*/
 	updateHours: function (hour) {
@@ -620,7 +612,7 @@ var TimePicker = module.exports = kind(
 		// in the rare case that the value didn't change because it was snapped back to the
 		// same value due to DST rules, push it back another hour.
 		if (valueTime == this.value.getTime()) {
-			this.value = new Date(valueTime + this.dstOffset);
+			this.value = new Date(valueTime - 3600000);
 		}
 
 		this.set('value', this.value, {force: true});


### PR DESCRIPTION
### Issue:
TimePicker dstOffset is not working properly on dreadlocks.
Dreadlocks support round up already, so we do not need one hour round up again.

### Fix:
removed one hour round up which is webOS specific.

Enyo-DCO-1.1-Signed-Off-By: Suhyung Lee (suhyung2.lee@lge.com)