### PR TITLE
ENYO-2235: Use a more reasonable value for marqueeOnRenderDelay.

### DIFF
--- a/lib/LightPanel/LightPanel.js
+++ b/lib/LightPanel/LightPanel.js
@@ -102,7 +102,7 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{kind: Header, name: 'header', type: 'medium'},
+		{kind: Header, name: 'header', type: 'medium', marqueeOnRenderDelay: 1000},
 		{name: 'client', classes: 'client'}
 	],
 


### PR DESCRIPTION
### Issue
The default value for `moonstone/Header`'s `marqueeOnRenderDelay` of `10000` was being used.

### Fix
This value has been adjusted to a more-reasonable `1000` so that it begins shortly after we transition to / show a panel.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>