### PR TITLE
Fixes ENYO-2223

### DIFF
--- a/lib/NewDataList/NewDataList.js
+++ b/lib/NewDataList/NewDataList.js
@@ -1,3 +1,5 @@
+require('moonstone');
+
 var
 	kind = require('enyo/kind'),
 	NewDataList = require('enyo/NewDataList');

--- a/lib/Scroller/Scroller.less
+++ b/lib/Scroller/Scroller.less
@@ -10,7 +10,6 @@
 .moon-scroller-viewport {
 	box-sizing: border-box;
 	height: 100%;
-	overflow: hidden;
 }
 
 /* CSS for moon.ScrollStrategy */


### PR DESCRIPTION
## Issue
Programmatic `focus()`-ing controls causes the browser to scroll the control into view using `scrollTop` and `scrollLeft` on the nearest scrolling context ancestor that would bring it into view

## Fix
Remove `overflow` from intermediate controls within scroller so that scrolling can be suppressed on the scroller.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)