### PR TITLE
ENYO-2229: Marquee rolls unexpectedly when display changes

### DIFF
--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -738,6 +738,10 @@ var MarqueeItem = {
 			this._marquee_reset();
 			if(this.showing && event.showing){
 				this._marquee_calcDistance();	
+			} else {
+				//if the marquee isn't showing we should reset
+				//it's spotlight focus.
+				this._marquee_spotlightBlur();
 			}
 		};
 	}),

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -739,9 +739,14 @@ var MarqueeItem = {
 			if(this.showing && event.showing){
 				this._marquee_calcDistance();	
 			} else {
+				
 				//if the marquee isn't showing we should reset
-				//it's spotlight focus.
-				if(this._marquee_spotlightBlur) this._marquee_spotlightBlur();
+				//it's spotlight focus
+				if (this._marquee_puppetMaster) {
+					this._marquee_puppetMaster._marquee_spotlightBlur();
+				} else if(this._marquee_spotlightBlur) {
+					this._marquee_spotlightBlur();
+				}
 			}
 		};
 	}),

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -741,7 +741,7 @@ var MarqueeItem = {
 			} else {
 				//if the marquee isn't showing we should reset
 				//it's spotlight focus.
-				this._marquee_spotlightBlur();
+				if(this._marquee_spotlightBlur) this._marquee_spotlightBlur();
 			}
 		};
 	}),

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -737,14 +737,12 @@ var MarqueeItem = {
 			sup.apply(this, arguments);
 			this._marquee_reset();
 			if(this.showing && event.showing){
-				this._marquee_calcDistance();	
+				this._marquee_calcDistance();
 			} else {
-				
-				//if the marquee isn't showing we should reset
-				//it's spotlight focus
+				//if the marquee isn't showing we should reset its spotlight focus
 				if (this._marquee_puppetMaster) {
 					this._marquee_puppetMaster._marquee_spotlightBlur();
-				} else if(this._marquee_spotlightBlur) {
+				} else if (this._marquee_spotlightBlur) {
 					this._marquee_spotlightBlur();
 				}
 			}


### PR DESCRIPTION
Issue.

When the marquee is hidden, the animation jobs are not cancelled. 

Fix.

When the marquee is hidden, remove focus, and stop the marquee.


Enyo-DCO-1.1-Signed-off-by: Derek Anderson <derek.anderson@lge.com>