### PR TITLE
ENYO-1762: apply backgroundOpacity property to closebutton controls

### DIFF
--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -74,8 +74,6 @@
 @moon-progress-bar-bg-color: #a6a6a6;
 @moon-progress-bar-popup-text-color: @moon-white;
 @moon-progress-bg-color: #262626;
-@moon-popup-close-text-color: @moon-white;
-@moon-popup-close-spotlight-color: @moon-spotlight-color;
 
 @moon-panels-scrim-always-viewing-bg-color: rgba(0, 0, 0, 0.75);
 @moon-panels-scrim-activity-bg-color: rgba(0, 0, 0, 1);

--- a/css/moonstone-variables-light.less
+++ b/css/moonstone-variables-light.less
@@ -73,8 +73,6 @@
 @moon-progress-bar-bg-color: #7d7d7d;
 @moon-progress-bar-popup-text-color: #fff;
 @moon-progress-bg-color: #323232;
-@moon-popup-close-text-color: white;
-@moon-popup-close-spotlight-color: @moon-spotlight-color;
 
 @moon-panels-scrim-always-viewing-bg-color: @moon-background-color;
 @moon-panels-scrim-activity-bg-color: @moon-background-color;

--- a/lib/Dialog/Dialog.js
+++ b/lib/Dialog/Dialog.js
@@ -143,7 +143,7 @@ module.exports = kind(
 	* @private
 	*/
 	tools: [
-		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', showing: false},
+		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', backgroundOpacity: 'transparent', ontap: 'closePopup', showing: false},
 		{kind: Control, classes: 'moon-dialog-client-wrapper', components: [
 			{name: 'client', kind: Control, classes: 'moon-dialog-client'},
 			{components: [

--- a/lib/ListActions/ListActions.js
+++ b/lib/ListActions/ListActions.js
@@ -399,7 +399,7 @@ var ListActions = module.exports = kind(
 	*/
 	drawerComponents: [
 		{name: 'drawer', spotlightDisabled: true, kind: ListActionsDrawer, classes: 'list-actions-drawer', onComplete: 'drawerAnimationEnd', open: false, spotlight: 'container', spotlightModal:true, components: [
-			{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close moon-list-actions-close moon-neutral', ontap: 'expandContract', defaultSpotlightDown:'listActions'},
+			{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close moon-list-actions-close moon-neutral', backgroundOpacity: 'transparent', ontap: 'expandContract', defaultSpotlightDown:'listActions'},
 			{name: 'listActionsClientContainer', kind: Control, classes: 'enyo-fit moon-list-actions-client-container moon-neutral', components: [
 				{name: 'listActions', kind: Scroller, classes: 'enyo-fit moon-list-actions-scroller', horizontal:'hidden', vertical:'hidden', onActivate: 'optionSelected', defaultSpotlightUp:'closeButton'}
 			]}

--- a/lib/Popup/Popup.js
+++ b/lib/Popup/Popup.js
@@ -172,7 +172,7 @@ module.exports = kind(
 	*/
 	tools: [
 		{name: 'client', kind: Control, classes:'enyo-fill'},
-		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', showing:false}
+		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', backgroundOpacity: 'transparent', ontap: 'closePopup', showing:false}
 	],
 
 	/**

--- a/lib/Popup/Popup.less
+++ b/lib/Popup/Popup.less
@@ -31,14 +31,12 @@
 	right: @moon-spotlight-outset;
 	top: @moon-spotlight-outset;
 	margin: 0;
-	background-color: transparent;
 	background-repeat: no-repeat;
 	background-position: 0 0;
 	color: @moon-popup-close-text-color;
 
 	&.pressed,
 	&:active {
-		background-color: transparent;
 		color: @moon-neutral-icon-color;
 	}
 }


### PR DESCRIPTION
close buttons in Popup, Dialog and ListActions controls had a css property background-color: transparent, this property is replaced with backgroundOpacity: transparent as a different approch to implement the translucency properties

removed @moon-popup-close-text-color and @moon-popup-close-spotlight-color from the dark and light variables LESS files

DCO-1.1-Signed-Off-By: Anish TD anish.td@lge.com