### PR TITLE
ENYO-2231: Slider popup in Contextual Popup has vertical blank

### DIFF
--- a/lib/ProgressBar/ProgressBar.less
+++ b/lib/ProgressBar/ProgressBar.less
@@ -37,7 +37,7 @@
 	}
 
 	.moon-progress-bar-popup-left {
-		margin: 0 -1apx 0 0;
+		margin: 0 -2apx 0 0;
 	}
 
 	.moon-progress-bar-popup-center {
@@ -45,7 +45,7 @@
 	}
 
 	.moon-progress-bar-popup-right {
-		margin: 0 0 0 -1apx;
+		margin: 0 0 0 -2apx;
 	}
 
 	.moon-progress-bar-popup-label {


### PR DESCRIPTION
## Issue
Slider popup has vertical noise line.

## Fix
increase left/right part margin of progress-bar-popup to cover vertical blank line

Signed-off-by: Sungbae Cho sb.cho@lge.com