### PR TITLE
ENYO-2244: Stop active marquee on teardownRender

### DIFF
--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -305,10 +305,13 @@ var MarqueeSupport = {
 	* @method
 	* @private
 	*/
-	destroy: kind.inherit(function (sup) {
+	teardownRender: kind.inherit(function (sup) {
 		return function () {
 			if (this === observer._getMarqueeOnHoverControl()) {
 				observer._setMarqueeOnHoverControl(null);
+			}
+			if (this._marquee_active) {
+				this.stopMarquee();
 			}
 			sup.apply(this, arguments);
 		};

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -307,11 +307,21 @@ var MarqueeSupport = {
 	*/
 	teardownRender: kind.inherit(function (sup) {
 		return function () {
-			if (this === observer._getMarqueeOnHoverControl()) {
-				observer._setMarqueeOnHoverControl(null);
-			}
 			if (this._marquee_active) {
 				this.stopMarquee();
+			}
+			sup.apply(this, arguments);
+		};
+	}),
+
+	/**
+	* @method
+	* @private
+	*/
+	destroy: kind.inherit(function (sup) {
+		return function () {
+			if (this === observer._getMarqueeOnHoverControl()) {
+				observer._setMarqueeOnHoverControl(null);
 			}
 			sup.apply(this, arguments);
 		};


### PR DESCRIPTION
## Issue:
- When index changed, lightPanels does teardownRender not destroy on
  popOnBack/popOnForward.
- When it is teardownRender, marquee doesn't stop marquee but stop flow
  and stay its position.

## Fix:
- We stop marquee on any active marquee teardownRender.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>