### PR TITLE
ENYO-2244: Stop active marquee on teardownRender

### DIFF
--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -305,6 +305,19 @@ var MarqueeSupport = {
 	* @method
 	* @private
 	*/
+	teardownRender: kind.inherit(function (sup) {
+		return function () {
+			if (this._marquee_active) {
+				this.stopMarquee();
+			}
+			sup.apply(this, arguments);
+		};
+	}),
+
+	/**
+	* @method
+	* @private
+	*/
 	destroy: kind.inherit(function (sup) {
 		return function () {
 			if (this === observer._getMarqueeOnHoverControl()) {

--- a/lib/Marquee/Marquee.js
+++ b/lib/Marquee/Marquee.js
@@ -306,8 +306,8 @@ var MarqueeSupport = {
 	* @private
 	*/
 	teardownRender: kind.inherit(function (sup) {
-		return function () {
-			if (this._marquee_active) {
+		return function (caching) {
+			if (caching && this._marquee_active) {
 				this.stopMarquee();
 			}
 			sup.apply(this, arguments);


### PR DESCRIPTION
## Issue:
- When index changed, lightPanels does teardownRender not destroy on
  popOnBack/popOnForward.
- When lightPanels teardownRender, title doesn't stop but stay its
  position.

## Fix:
- We stop marquee flow on any active marquee tardownRender.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>