### PR TITLE
ENYO-2235: Re-add the more-reasonable marqueeOnRenderDelay value.

### DIFF
--- a/lib/LightPanels/LightPanel.js
+++ b/lib/LightPanels/LightPanel.js
@@ -96,7 +96,7 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{kind: Header, name: 'header', type: 'medium'},
+		{kind: Header, name: 'header', type: 'medium', marqueeOnRenderDelay: 1000},
 		{name: 'client', classes: 'client'},
 		{name: 'spotlightPlaceholder', spotlight: false, style: 'width:0;height:0;'}
 	],


### PR DESCRIPTION
### Issue
I created a bad merge for https://github.com/enyojs/moonstone/pull/2277 by helping git merge the change from https://github.com/enyojs/moonstone/pull/2374 into the old `LightPanel` control that was eventually deprecated / had its contents gutted.

### Fix
Re-adding the fix to the new `LightPanel` control location.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>