### PR TITLE
ENYO-2110: Ensure that we avoid using the currentText element when computing scroll bounds when drawer is opened/closed.

### DIFF
--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -214,7 +214,7 @@
 					this.selectedIndex = (this.selectedIndex != -1) ? this.selectedIndex : [];
 				}
 				// super initialization
-				sup.apply(this, arguments);	
+				sup.apply(this, arguments);
 
 				this.selectedIndexChanged();
 				this.noneTextChanged();
@@ -368,8 +368,10 @@
 		*/
 		openChanged: function () {
 			this.inherited(arguments);
-			this.$.currentValue.setShowing(!this.open);
 			this.setActive(this.getOpen());
+			enyo.asyncMethod(this, function () {
+				this.$.currentValue.set('showing', !this.open);
+			});
 		},
 
 		/**
@@ -458,7 +460,7 @@
 		generateHelpText: function () {
 			this.$.helpText.canGenerate = true;
 			this.$.helpText.render();
-		},		
+		},
 
 		/**
 		* When an item is chosen, marks it as checked and closes the picker.
@@ -499,10 +501,10 @@
 
 			return true;
 		},
-		
+
 		/**
 		* Returns the picker items. Override point for child kinds altering the source of the items.
-		* 
+		*
 		* @private
 		*/
 		getCheckboxControls: function () {

--- a/source/ExpandablePicker.js
+++ b/source/ExpandablePicker.js
@@ -214,7 +214,7 @@
 					this.selectedIndex = (this.selectedIndex != -1) ? this.selectedIndex : [];
 				}
 				// super initialization
-				sup.apply(this, arguments);
+				sup.apply(this, arguments);	
 
 				this.selectedIndexChanged();
 				this.noneTextChanged();
@@ -458,7 +458,7 @@
 		generateHelpText: function () {
 			this.$.helpText.canGenerate = true;
 			this.$.helpText.render();
-		},
+		},		
 
 		/**
 		* When an item is chosen, marks it as checked and closes the picker.
@@ -499,10 +499,10 @@
 
 			return true;
 		},
-
+		
 		/**
 		* Returns the picker items. Override point for child kinds altering the source of the items.
-		*
+		* 
 		* @private
 		*/
 		getCheckboxControls: function () {
@@ -515,10 +515,10 @@
 		* @private
 		*/
 		selectAndClose: function () {
+			this.setActive(false);
 			if (!enyo.Spotlight.getPointerMode() && enyo.Spotlight.getCurrent() && enyo.Spotlight.getCurrent().isDescendantOf(this)) {
 				enyo.Spotlight.spot(this.$.headerWrapper);
 			}
-			this.setActive(false);
 		},
 
 		/**


### PR DESCRIPTION
### Issue
The scroll bounds for `moon.ExpandablePicker` when the drawer is expanded, are different than when the drawer is about to contract. This is due to how we are showing and hiding the `currentText` element. Before the drawer expands, this element is hidden and does not affect the scroll bounds calculations. But when the drawer is about to contract, the `currentText` element is shown first, causing the scroll height to be greater than the client height, which results in the undesired scroll arrows appearing.

### Fix
This might be incurring some technical debt, but it seems reasonable to use `asyncMethod` to delay the showing/hiding of the `currentText` element so that it does not impact the scroller calculations, and it seemed to be less obtuse (and intrusive) of a fix than the alternatives. I'm also reverting the original band-aid fix for the case where we select an item and the drawer contracts, as that is also resolved with this change.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>