### PR TITLE
ENYO-2116: Ensure that we avoid using the currentText element when computing scroll bounds when drawer is opened/closed.

### DIFF
--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -526,10 +526,10 @@ module.exports = kind(
 	* @private
 	*/
 	selectAndClose: function () {
+		this.setActive(false);
 		if (!Spotlight.getPointerMode() && Spotlight.getCurrent() && Spotlight.getCurrent().isDescendantOf(this)) {
 			Spotlight.spot(this.$.headerWrapper);
 		}
-		this.setActive(false);
 	},
 
 	/**

--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -8,6 +8,7 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	options = require('enyo/options'),
+	asyncMethod = require('enyo/utils').asyncMethod,
 	Component = require('enyo/Component'),
 	Control = require('enyo/Control'),
 	Group = require('enyo/Group');
@@ -383,8 +384,10 @@ module.exports = kind(
 	*/
 	openChanged: function () {
 		this.inherited(arguments);
-		this.$.currentValue.setShowing(!this.open);
 		this.setActive(this.getOpen());
+		asyncMethod(this, function () {
+			this.$.currentValue.setShowing(!this.open);
+		});
 	},
 
 	/**


### PR DESCRIPTION
Changes from https://github.com/enyojs/moonstone/pull/2385.