### PR TITLE
ENYO-2242 Right side of ExpandableText is cut off

### DIFF
--- a/lib/ClampedText/ClampedText.less
+++ b/lib/ClampedText/ClampedText.less
@@ -2,5 +2,4 @@
 	display: -webkit-inline-box;
 	overflow: hidden;
 	-webkit-box-orient: vertical;
-	width: 100%;
 }


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Art Dahm art.dahm@lge.com