### PR TITLE
ENYO-2254: Expose States.

### DIFF
--- a/lib/LightPanels/LightPanel.js
+++ b/lib/LightPanels/LightPanel.js
@@ -199,3 +199,5 @@ module.exports = kind(
 	}
 
 });
+
+module.exports.States = States;

--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -40,3 +40,5 @@ module.exports = kind(
 });
 
 module.exports.Panel = LightPanel;
+module.exports.Direction = LightPanels.Direction;
+module.exports.Orientation = LightPanels.Orientation;


### PR DESCRIPTION
### Issue
When subkinding `moonstone/LightPanels/LightPanel`, there are cases where the state of the control needs to be examined. This requires retrieving the States hash from `enyo/LightPanels/LightPanel`.

### Fix
To improve developer ergonomics, we expose the States hash on `moonstone/LightPanels/LightPanel`. 

### Notes
I'm curious if we have an established pattern for "passing-through" a module property to a subkind, or if there is a better way of doing this.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>