### PR TITLE
ENYO-2255: remove accessibilityDisabled in child node.

### DIFF
--- a/lib/Accordion/Accordion.js
+++ b/lib/Accordion/Accordion.js
@@ -95,7 +95,7 @@ module.exports = kind(
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths
 			// (webkit bug)
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-accordion-header', components: [
-				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
+				{name: 'header', kind: MarqueeText}
 			]}
 		]},
 		{name: 'drawer', kind: Drawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [

--- a/lib/Button/Button.js
+++ b/lib/Button/Button.js
@@ -165,7 +165,7 @@ module.exports = kind(
 	*/
 	initComponents: function () {
 		if (!(this.components && this.components.length > 0)) {
-			this.createComponent({name: 'client', kind: MarqueeText, classes: 'button-client', isChrome: true, accessibilityDisabled: true});
+			this.createComponent({name: 'client', kind: MarqueeText, classes: 'button-client', isChrome: true});
 		}
 		if (this.small) this.smallChanged();
 		if (this.minWidth) this.minWidthChanged();

--- a/lib/CheckboxItem/CheckboxItem.js
+++ b/lib/CheckboxItem/CheckboxItem.js
@@ -190,7 +190,7 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{name: 'client', accessibilityDisabled: true, mixins: [MarqueeItem], classes: 'moon-checkbox-item-label-wrapper'},
+		{name: 'client', mixins: [MarqueeItem], classes: 'moon-checkbox-item-label-wrapper'},
 		{name: 'input', kind: Checkbox, accessibilityDisabled: true, spotlight: false}
 	],
 

--- a/lib/ExpandableInput/ExpandableInput.js
+++ b/lib/ExpandableInput/ExpandableInput.js
@@ -135,9 +135,9 @@ module.exports = kind(
 		{name: 'headerWrapper', kind: Item, classes: 'moon-expandable-list-item-wrapper', onSpotlightFocus: 'headerFocus', ondown: 'headerDown', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-input-header', components: [
-				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
+				{name: 'header', kind: MarqueeText}
 			]},
-			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-list-item-current-value'}
+			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-list-item-current-value'}
 		]},
 		{name: 'drawer', kind: Drawer, resizeContainer:false, classes:'moon-expandable-list-item-client indented', components: [
 			{name: 'inputDecorator', kind: InputDecorator, onSpotlightBlur: 'inputBlur', onSpotlightFocus: 'inputFocus', onSpotlightDown: 'inputDown', components: [

--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -180,7 +180,7 @@ module.exports = kind(
 		// headerContainer required to avoid bad scrollWidth returned in RTL for certain text
 		// widths (webkit bug)
 		{name: 'headerContainer', kind: Item, classes: 'moon-expandable-list-item-header', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
-			{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
+			{name: 'header', kind: MarqueeText}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes: 'moon-expandable-list-item-client', components: [
 			{name: 'client', kind: Group, tag: null}

--- a/lib/ExpandablePicker/ExpandablePicker.js
+++ b/lib/ExpandablePicker/ExpandablePicker.js
@@ -216,9 +216,9 @@ module.exports = kind(
 		{name: 'headerWrapper', kind: Item, classes: 'moon-expandable-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-picker-header', components: [
-				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
+				{name: 'header', kind: MarqueeText}
 			]},
-			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-list-item-current-value'}
+			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-list-item-current-value'}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes:'moon-expandable-list-item-client', onDrawerAnimationEnd: 'handleDrawerAnimationEnd', components: [
 			{name: 'client', tag: null, kind: Group, onActivate: 'activated', highlander: true},

--- a/lib/IntegerPicker/IntegerPicker.js
+++ b/lib/IntegerPicker/IntegerPicker.js
@@ -215,7 +215,7 @@ module.exports = kind(
 		// we're forcing TouchScrollStrategy
 		{kind: Scroller, strategyKind: TouchScrollStrategy, thumb:false, touch:true, useMouseWheel: false, classes: 'moon-scroll-picker', components:[
 			{name: 'repeater', kind: FlyweightRepeater, classes: 'moon-scroll-picker-repeater', ondragstart: 'dragstart', onSetupItem: 'setupItem', noSelect: true, components: [
-				{name: 'item', kind: Control, accessibilityDisabled: true, classes: 'moon-scroll-picker-item'}
+				{name: 'item', kind: Control, classes: 'moon-scroll-picker-item'}
 			]},
 			{name: 'buffer', kind: Control, accessibilityDisabled: true, classes: 'moon-scroll-picker-buffer'}
 		]},


### PR DESCRIPTION
Blink is changed to ignore the child node if it has aria-hidden even though
parent has aria-labelledby.
We need to remove accessibilityDisabled in child node if it is dispensable.

https://jira2.lgsvl.com/browse/ENYO-2255
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>