### PR TITLE
ENYO-1981: Call inherited methods of the parent kind.

### DIFF
--- a/lib/LightPanels/LightPanel.js
+++ b/lib/LightPanels/LightPanel.js
@@ -132,6 +132,8 @@ module.exports = kind(
 	* @public
 	*/
 	preTransition: function () {
+		LightPanel.prototype.preTransition.apply(this, arguments);
+
 		var current = Spotlight.getCurrent(),
 			isChild = current && current.isDescendantOf(this);
 
@@ -160,6 +162,8 @@ module.exports = kind(
 	* @public
 	*/
 	postTransition: function () {
+		LightPanel.prototype.postTransition.apply(this, arguments);
+
 		if (this.state == States.ACTIVE) this.spotlightDisabled = false;
 
 		if (!this.$.client.children.length) {


### PR DESCRIPTION
### Issue
We are subkinding `enyo/LightPanel` for our implementation of `moonstone/LightPanel`, and should execute the super methods for our lifecycle methods.

### Fix
We execute the super methods for `preTransition` and `postTransition`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>