### PR TITLE
ENYO-1904: Add Text to Speech Accessibility support to Date Picker

### DIFF
--- a/lib/DatePicker/DatePicker.js
+++ b/lib/DatePicker/DatePicker.js
@@ -6,7 +6,8 @@ require('moonstone');
 */
 
 var
-	kind = require('enyo/kind');
+	kind = require('enyo/kind'),
+	options = require('enyo/options');
 
 var
 	DateFactory = require('enyo-ilib/DateFactory');
@@ -14,7 +15,8 @@ var
 var
 	DateTimePickerBase = require('../DateTimePickerBase'),
 	$L = require('../i18n'),
-	IntegerPicker = require('../IntegerPicker');
+	IntegerPicker = require('../IntegerPicker'),
+	DatePickerAccessibilitySupport = require('./DatePickerAccessibilitySupport');
 
 /**
 * {@link module:moonstone/DatePicker~DatePicker} is a control used to allow the selection of (or simply
@@ -50,6 +52,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: DateTimePickerBase,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [DatePickerAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/DatePicker/DatePickerAccessibilitySupport.js
+++ b/lib/DatePicker/DatePickerAccessibilitySupport.js
@@ -1,0 +1,21 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name DatePickerAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	rendered: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.$.day.set('accessibilityLabel', this.dayText);
+			this.$.month.set('accessibilityLabel', this.monthText);
+			this.$.year.set('accessibilityLabel', this.yearText);
+		};
+	})
+};

--- a/lib/DateTimePickerBase/DateTimePickerBase.js
+++ b/lib/DateTimePickerBase/DateTimePickerBase.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control'),
 	Signals = require('enyo/Signals');
 
@@ -23,7 +24,8 @@ var
 	ExpandableListItem = require('../ExpandableListItem'),
 	Item = require('../Item'),
 	Marquee = require('../Marquee'),
-	MarqueeText = Marquee.Text;
+	MarqueeText = Marquee.Text,
+	DateTimePickerBaseAccessibilitySupport = require('./DateTimePickerBaseAccessibilitySupport');
 
 /**
 * Fires when the picker's value changes.
@@ -59,6 +61,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: ExpandableListItem,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [DateTimePickerBaseAccessibilitySupport] : null,
 
 	/**
 	* @private
@@ -161,9 +168,9 @@ module.exports = kind(
 		{name: 'headerWrapper', kind: Item, classes: 'moon-date-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-datetime-header', components: [
-				{name: 'header', kind: MarqueeText}
+				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
 			]},
-			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-list-item-current-value'}
+			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-list-item-current-value'}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes:'moon-expandable-list-item-client indented', components: [
 			{name: 'client', kind: Control, classes: 'enyo-tool-decorator moon-date-picker-client', onSpotlightLeft:'closePicker', onSpotlightSelect: 'closePicker'}

--- a/lib/DateTimePickerBase/DateTimePickerBaseAccessibilitySupport.js
+++ b/lib/DateTimePickerBase/DateTimePickerBaseAccessibilitySupport.js
@@ -1,0 +1,23 @@
+var
+	kind = require('enyo/kind');
+
+/**
+* @name DateTimePickerBaseAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/*
+	* @private
+	*/
+	updateAccessibilityAttributes: kind.inherit(function (sup) {
+		return function (was, is, prop) {
+			var enabled = !this.accessibilityDisabled,
+				ids = this.$.header.getId() + ' ' + this.$.currentValue.getId();
+			sup.apply(this, arguments);
+			this.$.headerWrapper.setAttribute('aria-labelledby', enabled ? ids : null);
+			this.$.headerWrapper.set('accessibilityDisabled', this.accessibilityDisabled);
+			this.$.client.set('accessibilityDisabled', this.accessibilityDisabled);
+		};
+	})
+};


### PR DESCRIPTION
Apply accessibility on DatePicker.
Basically DatePicker is combined by IntegerPickers, and we already
applied accessibility on IntergerPicker.
According to UX guide, DatePicker should be read <value> +  <day>,
<month> or <year>. I added each text 'day', 'month', 'year' to
'accessibilityLabel', scrren reader will read 'aria-valuenow' +
'aria-label.

https://jira2.lgsvl.com/browse/ENYO-1904
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>

ENYO-1904: Add Text to Speech Accessibility support to Date Picker

change the label for day, month and year to dayText, monthText and
yearText.

https://jira2.lgsvl.com/browse/ENYO-1904
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>

ENYO-1904: remove unused $L

remove unused $L

https://jira2.lgsvl.com/browse/ENYO-1904
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>