### PR TITLE
ENYO-2259: ExpandablePicker have no margin at bottom when there is no current value.

### DIFF
--- a/lib/ExpandableListItem/ExpandableListItem.less
+++ b/lib/ExpandableListItem/ExpandableListItem.less
@@ -38,8 +38,9 @@
 	font-weight: @moon-expandable-value-font-weight;
 	font-style: @moon-expandable-value-font-style;
 	color: @moon-expandable-picker-text-color;
-	margin-top: -12px;	// Negative value to compensate for the taller line-height needed for tall-glyph charecters
-
+	&:not(:empty) {
+		margin-top: -12px;	// Negative value to compensate for the taller line-height needed for tall-glyph charecters
+	}
 	.enyo-locale-right-to-left & {
 		padding-left: 0;
 	}


### PR DESCRIPTION
Issue:
- ExpandablePicker current value have margin-top as 12px by default.

Fix:
- We add conditional margin-top only enabled when there is content.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>