### PR TITLE
Enyo-2276 Pop backHistory stack when remoteBackKey is handled

### DIFF
--- a/lib/History/History.js
+++ b/lib/History/History.js
@@ -288,8 +288,7 @@ var History = module.exports = kind.singleton({
 	* @private
 	*/
 	remoteBackKeyHandler: function (inSender, inEvent) {
-		//if (inEvent.keySymbol == 'back' && this._currentObj && this._currentObj.getShowing()) {
-		if (inEvent.keyCode == 66 && this._currentObj && this._currentObj.getShowing()) {	
+		if (inEvent.keySymbol == 'back' && this._currentObj && this._currentObj.getShowing()) {
 			this._callBackKeyHandler();
 			this._popBackHistory();
 		}

--- a/lib/History/History.js
+++ b/lib/History/History.js
@@ -254,10 +254,8 @@ var History = module.exports = kind.singleton({
 		case 'silence':
 		//Popstate event should be ignored on following 2 conditions.
 		//1. When App is loaded, onpopstate event fired with null state.
-		//2. history.go(-1) triggers onpopstate event but it should be ignored.
-			window.ignoreFirstPopupEvent = false;
+		//2. history.go(-1) triggers onpopstate event but it should be ignored.			
 			this._ignorePopState = false;
-			this._popBackHistory();
 			break;
 		case 'invisible':
 		//Current back key target is on history and have handler too.
@@ -291,8 +289,9 @@ var History = module.exports = kind.singleton({
 	*/
 	remoteBackKeyHandler: function (inSender, inEvent) {
 		if (inEvent.keySymbol == 'back' && this._currentObj && this._currentObj.getShowing()) {
+			if (this.enableBackHistoryAPI) this.ignorePopState();
 			this._callBackKeyHandler();
-			this.ignorePopState();
+			this._popBackHistory();
 		}
 		return true;
 	}

--- a/lib/History/History.js
+++ b/lib/History/History.js
@@ -288,8 +288,8 @@ var History = module.exports = kind.singleton({
 	* @private
 	*/
 	remoteBackKeyHandler: function (inSender, inEvent) {
-		if (inEvent.keySymbol == 'back' && this._currentObj && this._currentObj.getShowing()) {
-			if (this.enableBackHistoryAPI) this.ignorePopState();
+		//if (inEvent.keySymbol == 'back' && this._currentObj && this._currentObj.getShowing()) {
+		if (inEvent.keyCode == 66 && this._currentObj && this._currentObj.getShowing()) {	
 			this._callBackKeyHandler();
 			this._popBackHistory();
 		}

--- a/lib/History/History.js
+++ b/lib/History/History.js
@@ -241,7 +241,7 @@ var History = module.exports = kind.singleton({
 		// TODO: We cannot prevent popstate event triggerd from history.go() or history.forward()
 		// If user call those event directly, moonstone controls may have unexpected behavior.
 		var state = !this._currentObj ? 'empty'
-					: (this._ignorePopState || window.ignoreFirstPopupEvent) ? 'silence'
+					: this._ignorePopState ? 'silence'
 					: !this._currentObj.getShowing() ? 'invisible'
 					: 'active';
 


### PR DESCRIPTION
issue
------
In webOS on TV, using historyAPI and using remote back key are exclusive.
So remoteBackKeyHandler is called, onpopState event is not triggered.
Due to that, _handlingBackAction flag could not return to false.

cause
-------
_handligBackAction = false is placed in onpostate handler

fix
---
Move out above logic to remoteBackKeyHandler method

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com