### PR TITLE
ENYO-2251: Modify VideoPlayerAccessibilitySupport to read VideoInfo

### DIFF
--- a/lib/VideoPlayer/VideoPlayerAccessibilitySupport.js
+++ b/lib/VideoPlayer/VideoPlayerAccessibilitySupport.js
@@ -13,6 +13,13 @@ module.exports = {
 	/**
 	* @private
 	*/
+	observers: [
+		{method: 'readVideoInfo', path: '$.videoInfoHeaderClient.showing'}
+	],
+
+	/**
+	* @private
+	*/
 	initAccessibility: kind.inherit(function (sup) {
 		return function (props) {
 			sup.apply(this, arguments);
@@ -46,6 +53,28 @@ module.exports = {
 			var label = index === 0 ? $L('More') : $L('Back');
 			this.$.moreButton.set('accessibilityLabel', label);
 		};
-	})
+	}),
 
+	/**
+	* @private
+	*/
+	readVideoInfo: function () {
+		this.$.videoInfoHeaderClient.set('accessibilityAlert', this.$.videoInfoHeaderClient.get('showing'));
+		this.$.videoInfoHeaderClient.setAttribute('aria-live', this.$.videoInfoHeaderClient.get('showing') ? 'off' : null);
+		if (!this.$.videoInfoHeaderClient.get('showing')) {
+			this.$.videoInfoHeaderClient.set('accessibilityDisabled', false);
+		}
+	},
+
+	/**
+	* @private
+	*/
+	hideFSBottomControls: kind.inherit(function (sup) {
+		return function (props) {
+			sup.apply(this, arguments);
+			if (this.$.videoInfoHeaderClient.get('showing')) {
+				this.$.videoInfoHeaderClient.set('accessibilityDisabled', true);
+			}
+		};
+	})
 };


### PR DESCRIPTION
## Issue 
When the videoplayer playback controls are hideden, screen reader reads channel & video information.

## Cause
The moonstone videoPlayer is spottable component, so screen reader reads content including child component.
If you click down button, player control is shown and spotlight focus is moved to player control.
If you click up button, channel & video information is shown. At that time, if you click down button again, player control is hidden and spotlight focus is moved to moonstone videoPlayer.
Then, screen reader reads channel & video information content because moonstone videoPlayer is channel & video information's parent and spotlight focused.

## Fix
Add accessibilityDisabled: true when player control is hidden.
In addtion, person In charge of UX requests that screen reader reads channel & video information when it is shown, so I add accessibilityAlert:true when it is shown.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
