### PR TITLE
Enyo-2283 Pop _backHistoryStack when FS windows are hided.

### DIFF
--- a/lib/VideoPlayer/VideoPlayer.js
+++ b/lib/VideoPlayer/VideoPlayer.js
@@ -1159,7 +1159,7 @@ module.exports = kind(
 				if (!this.$.videoInfoHeaderClient.getShowing()) {
 					this.showFSInfo();
 				} else {
-					if (this.allowBackKey && MoonHistory.get('enableBackHistoryAPI')) {
+					if (this.allowBackKey && !MoonHistory.get('enableBackHistoryAPI')) {
 						MoonHistory._popBackHistory();
 					}
 					this.hideFSInfo();
@@ -1178,7 +1178,7 @@ module.exports = kind(
 			if (!this.$.playerControl.getShowing()) {
 				this.showFSBottomControls();
 			} else {
-				if (this.allowBackKey && MoonHistory.get('enableBackHistoryAPI')) {
+				if (this.allowBackKey && !MoonHistory.get('enableBackHistoryAPI')) {
 					MoonHistory._popBackHistory();
 				}
 				this.hideFSBottomControls();

--- a/lib/VideoPlayer/VideoPlayer.js
+++ b/lib/VideoPlayer/VideoPlayer.js
@@ -1249,7 +1249,7 @@ module.exports = kind(
 	*/
 	hideFSControls: function(spottingHandled) {
 		if (this.isOverlayShowing()) {
-			if (this.allowBackKey && MoonHistory.get('enableBackHistoryAPI')) {
+			if (this.allowBackKey && !MoonHistory.get('enableBackHistoryAPI')) {
 				MoonHistory._popBackHistory();
 				MoonHistory._popBackHistory();
 			}

--- a/lib/VideoPlayer/VideoPlayer.js
+++ b/lib/VideoPlayer/VideoPlayer.js
@@ -1159,6 +1159,9 @@ module.exports = kind(
 				if (!this.$.videoInfoHeaderClient.getShowing()) {
 					this.showFSInfo();
 				} else {
+					if (this.allowBackKey && MoonHistory.get('enableBackHistoryAPI')) {
+						MoonHistory._popBackHistory();
+					}
 					this.hideFSInfo();
 				}
 			}
@@ -1175,6 +1178,9 @@ module.exports = kind(
 			if (!this.$.playerControl.getShowing()) {
 				this.showFSBottomControls();
 			} else {
+				if (this.allowBackKey && MoonHistory.get('enableBackHistoryAPI')) {
+					MoonHistory._popBackHistory();
+				}
 				this.hideFSBottomControls();
 			}
 			return true;
@@ -1243,6 +1249,10 @@ module.exports = kind(
 	*/
 	hideFSControls: function(spottingHandled) {
 		if (this.isOverlayShowing()) {
+			if (this.allowBackKey && MoonHistory.get('enableBackHistoryAPI')) {
+				MoonHistory._popBackHistory();
+				MoonHistory._popBackHistory();
+			}
 			this.hideFSInfo();
 			this.hideFSBottomControls();
 		}
@@ -1326,6 +1336,10 @@ module.exports = kind(
 		}
 		this.showScrim(false);
 		this.$.playerControl.setShowing(false);
+
+		if (MoonHistory.getCurrentObj() == this) {
+			MoonHistory.popBackHistory();
+		}
 	},
 
 	/**
@@ -1355,6 +1369,9 @@ module.exports = kind(
 	hideFSInfo: function() {
 		if (!this.showInfo) {
 			this.$.videoInfoHeaderClient.setShowing(false);
+		}
+		if (MoonHistory.getCurrentObj() == this) {
+			MoonHistory.popBackHistory();
 		}
 	},
 
@@ -2184,23 +2201,16 @@ module.exports = kind(
 	* @private
 	*/
 	backKeyHandler: function () {
-		// if videoInfoHeaderClient and playerControl are visible
-		// it means that we pushed video player into history stack twice.
-		// to set correct target for next back key, we should pop one instance.
 		var visibleUp = this.$.videoInfoHeaderClient.getShowing(),
 			visibleDown = this.$.playerControl.getShowing();
 
-		if (visibleUp && visibleDown
-			&& MoonHistory.getCurrentObj() == this) {
-			MoonHistory.ignorePopState();
+		if (visibleUp && visibleDown) {
 			MoonHistory._popBackHistory();
 		}
-		if (visibleUp) {
-			this.hideFSInfo();
-		}
-		if (visibleDown) {
-			this.hideFSBottomControls();
-		}
+
+		if (visibleUp) this.hideFSInfo();
+		if (visibleDown) this.hideFSBottomControls();
+
 		return true;
 	}
 });


### PR DESCRIPTION
Issue
------
Hiding of FSInfo and FSBottomControls by timeout and spotlightUp and spotlightDown event
does not pop back history stack

Cause
---------
Currently, only backKeyHandler manage history stack.

Fix
----
Add _popBackHistory() to proper logic.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com