### PR TITLE
ENYO-2284: spotlight jumps to unexpected position on auto collapse

### DIFF
--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -168,7 +168,6 @@ module.exports = kind(
 	* @private
 	*/
 	handlers: {
-		onSpotlightUp: 'spotlightUp',
 		onSpotlightDown: 'spotlightDown',
 		onDrawerAnimationEnd: 'drawerAnimationEnd'
 	},
@@ -273,30 +272,24 @@ module.exports = kind(
 	},
 
 	/**
-	* If header gets the focus, get it into the viewport area.
+	* If drawer is currently open, and event was sent via keypress (i.e., it has a direction),
+	* process header focus.
 	*
 	* @fires module:moonstone/Scroller~Scroller#onRequestScrollIntoView
 	* @private
 	*/
 	headerFocus: function (inSender, inEvent) {
+		var direction = inEvent && inEvent.dir;
+
+		if (this.getOpen() && this.getAutoCollapse() && direction === 'UP') {
+			this.setActive(false);
+		}
+
 		if (inEvent.originator === this.$.header) {
 			this.bubble('onRequestScrollIntoView');
 		}
 	},
 	
-	/**
-	* Check for the first item in the client area, and close the list
-	* if the focus moves out of the drawer and `autoCollapse` is true
-	*
-	* @private
-	*/
-	spotlightUp: function(inSender, inEvent) {
-		var children = Spotlight.getChildren(this.$.client);
-		if (this.getAutoCollapse() && this.getOpen() && children.length && inEvent.originator == children[0]) {
-			this.setActive(false);
-		}
-	},
-
 	/**
 	* Check for the last item in the client area, and prevent 5-way focus movement below it,
 	* per UX specs.
@@ -314,7 +307,21 @@ module.exports = kind(
 	* @fires module:moonstone/Scroller~Scroller#onRequestScrollIntoView
 	* @private
 	*/
-	drawerAnimationEnd: function () {
+	drawerAnimationEnd: function (inSender, inEvent) {
+		var current = Spotlight.getCurrent();
+		var bOpen = inEvent.originator.getOpen();
+
+		if (current && !current.isDescendantOf(this)) {
+			if (bOpen) {
+				if (this.getAutoCollapse() && !Spotlight.getPointerMode()) {
+					this.setActive(false);
+					return true;
+				}
+			} else {
+				return true;
+			}
+		}
+
 		this.bubble('onRequestScrollIntoView', {scrollInPointerMode: true});
 		return true;
 	}


### PR DESCRIPTION
### Issue

When drawer is automatically collapsed by 5-way key('UP') drawer's closing animation starts before finding nearest neighbor to give spot. At that time, spotlight finds incorrect neighbor so it gives spot to unexpected control.

### Fix

Due to regression, I reverted the previous change. And to fix the previous issue I added some conditions to close drawer when spot is located out of current expandable control.

Enyo-DCO-1.1-Signed-off-by: Hunkyo Jung <hunkyo.jung@lge.com>