### PR TITLE
ENYO-2243: Fix reading input value twice on ExpandableInput

### DIFF
--- a/lib/ExpandableInput/ExpandableInputAccessibilitySupport.js
+++ b/lib/ExpandableInput/ExpandableInputAccessibilitySupport.js
@@ -27,5 +27,15 @@ module.exports = {
 			this.$.headerWrapper.set('accessibilityDisabled', this.accessibilityDisabled);
 			this.$.inputDecorator.set('accessibilityDisabled', this.accessibilityDisabled);
 		};
+	}),
+
+	/**
+	* @private
+	*/
+	toggleActive: kind.inherit(function (sup) {
+		return function (inSender, inEvent) {
+			sup.apply(this, arguments);
+			this.$.inputDecorator.set('accessibilityLabel', null);
+		};
 	})
 };


### PR DESCRIPTION
## Issue 
When ExpandableInput is expanded, screen reader reads the value in the input twice

## Cause
When ExpandableInput is expanded, input is focused(webkit focus) and this focus() event is bubble up.
Because InputDecorator has onfocus handler, which calls Spotlight.spot, InputDecorator is spotlight focused after input is focused.
In spotLightFocusedHandler of inputDecorator, it is implemented that reading placeholder and 'editBox' string, so this issue is happend.

## Fix
Set accessibilityLabel to null for preventing reading a placeholder and 'editBox' string.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
