### PR TITLE
ENYO-1994 : Add Text to Speech Accessibility support to LightPanels

### DIFF
--- a/lib/LightPanels/LightPanels.js
+++ b/lib/LightPanels/LightPanels.js
@@ -5,10 +5,12 @@
 
 var
 	kind = require('enyo/kind'),
-	LightPanels = require('enyo/LightPanels');
+	LightPanels = require('enyo/LightPanels'),
+	options = require('enyo/options');
 
 var
-	LightPanel = require('./LightPanel');
+	LightPanel = require('./LightPanel'),
+	LightPanelsAccessibilitySupport = require('./LightPanelsAccessibilitySupport');
 
 /**
 * A light-weight panels implementation that has basic support for side-to-side transitions
@@ -31,6 +33,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: LightPanels,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [LightPanelsAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/LightPanels/LightPanelsAccessibilitySupport.js
+++ b/lib/LightPanels/LightPanelsAccessibilitySupport.js
@@ -1,0 +1,27 @@
+var
+	kind = require('enyo/kind');
+
+var
+	$L = require('../i18n'),
+	VoiceReadout = require('enyo-webos/VoiceReadout');
+
+/**
+* @name LightPanelsAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	applyTransitions: kind.inherit(function (sup) {
+		return function (nextpanel) {
+			sup.apply(this, arguments);
+			// applyTransitions(nextpanel) is called in setupTransitions() when panel is moved,
+			// so we applied readAlert for reading 'new page' after panel transition is completed.
+			if (nextpanel) {
+				VoiceReadout.readAlert($L('new page'));
+			}
+		};
+	})
+};


### PR DESCRIPTION
Initial add accessibility feature to LightPanels.

## Requirement
WebOS TV should read 'new page' string when LightPanel is opened or moved according to UX requirements.

## Implementation
We added LightPanelsAccessibilitySupport to support reading 'new page' string.
LightPanel is spotlight container, so first child component or last spotlight component is focused when panel is opened.
Then, Screen reader first reads this focused component content. However, UX requirements request that Screen reader first should read 'new page' string when panel is opened or moved. 
TV should read 'new page' string as quickly as possible before reading focused component, so we added readAlert function to applyTransitions(). The applyTransitions is called when panel is opened or moved.

## Limitation
We used readAlert() of enyo-webOS library and overrided applyTransitions to read 'new page' string as quickly as possible, but If panel is opened without animation, 'new page' sound will cut for reading focused child component of panel 

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com