### PR TITLE
ENYO-2312: Prevent calling resize, while already resizing.

### DIFF
--- a/lib/ScrollStrategy/ScrollStrategy.js
+++ b/lib/ScrollStrategy/ScrollStrategy.js
@@ -796,10 +796,9 @@ var MoonScrollStrategy = module.exports = kind(
 			hWas = this.horizontalScrollEnabled;
 		this.enableDisableVerticalScrollControls(this.showVertical());
 		this.enableDisableHorizontalScrollControls(this.showHorizontal());
-		if ((vWas !== this.verticalScrollEnabled)
-			|| (hWas !== this.horizontalScrollEnabled)) {
-				this.resize();
-			}
+		if ((vWas !== this.verticalScrollEnabled || hWas !== this.horizontalScrollEnabled) && !this.resizing) {
+			this.resize();
+		}
 	},
 
 	/**


### PR DESCRIPTION
### Issue
When one set of scrollbars is visible (usually the vertical), there are certain circumstances where the `setupBounds` method of `moonstone/ScrollStrategy` can be executed when the scroller is not visible. This results in an infinite loop by the way of the `resize` method.

More specifically, during the first loop, the vertical scrollbars are disabled, which results in the `v-scroll-enabled` class being removed from both the vertical and horizontal scroll columns (this is always done in lock-step). After this occurs, we compute whether or not the horizontal scrollbars should be visible. We had previously computed our scroll bounds with the `v-scroll-enabled` class already enabled, and thus there is a horizontal offset that results in determining that we need horizontal scrollbars, which adds the `h-scroll-enabled` class to the vertical and horizontal scroll columns. Because there was a change in needing either vertical or horizontal scrollbars, a call to `resize` is triggered. The next time through the loop, it will be determined that vertical scrollbars need to be displayed, due to the `h-scroll-enabled` class having been previously added, while it be determined we do not need horizontal scrollbars. This repeats indefinitely, bouncing back and forth between attempting to display the vertical scrollbar and the horizontal scrollbar.

### Fix
We prevent this by guarding the call to `resize` with a check of `this.resizing`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>