### PR TITLE
ENYO-2328 moon-marquee was overriding .moon-simple-picker-client>*

### DIFF
--- a/lib/SimplePicker/SimplePicker.less
+++ b/lib/SimplePicker/SimplePicker.less
@@ -11,20 +11,21 @@
 	&.block {
 		display: block;
 	}
-}
+	
+	.moon-simple-picker-button {
+		position: absolute;
+		top: 0;
+		margin: 0;
 
-.moon-simple-picker-button {
-	position: absolute;
-	top: 0;
-	margin: 0;
+		&.left {
+			left: 0;
+		}
 
-	&.left {
-		left: 0;
+		&.right {
+			right: 0;
+		}
 	}
-
-	&.right {
-		right: 0;
-	}
+	
 }
 
 .moon-simple-picker-client-wrapper {

--- a/lib/SimplePicker/SimplePicker.less
+++ b/lib/SimplePicker/SimplePicker.less
@@ -11,21 +11,20 @@
 	&.block {
 		display: block;
 	}
-	
-	.moon-simple-picker-button {
-		position: absolute;
-		top: 0;
-		margin: 0;
+}
 
-		&.left {
-			left: 0;
-		}
+.moon-simple-picker-button {
+	position: absolute;
+	top: 0;
+	margin: 0;
 
-		&.right {
-			right: 0;
-		}
+	&.left {
+		left: 0;
 	}
-	
+
+	&.right {
+		right: 0;
+	}
 }
 
 .moon-simple-picker-client-wrapper {
@@ -46,11 +45,15 @@
 		-moz-transition: -moz-transform ease-out 0.3s;
 		transition: transform ease-out 0.3s;
 	}
+	
+	> *,
+	.moon-marquee {
+		width: 100%;
+	}
 
 	> * {
 		display: inline-block;
 		box-sizing: border-box;
-		width: 100%;
 		line-height: @moon-picker-button-width;
 	}
 


### PR DESCRIPTION
Issue.

Cause: Appears that .moon-marquee was overriding .moon-simple-picker-client>*, changing from 100% to auto

Fixes the following reported issues from ENYO-2309:
TV Guide SimplePicker: Date is displayed without space
Settings SimplePicker: 2 items displayed at the same time

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com