### PR TITLE
ENYO-2315: JumpIncrement button status in slider is not updated

### DIFF
--- a/lib/Slider/Slider.js
+++ b/lib/Slider/Slider.js
@@ -410,8 +410,7 @@ module.exports = kind(
 	*/
 	disabledChanged: function () {
 		if (this.enableJumpIncrement) {
-			this.$.buttonLeft.set('disabled', this.disabled);
-			this.$.buttonRight.set('disabled', this.disabled);
+			this.updateButtonStatus();
 			this.$.slider.set('disabled', this.disabled);
 		}
 		this.addRemoveClass('disabled', this.disabled);
@@ -535,10 +534,7 @@ module.exports = kind(
 
 		this.value = v;
 		this.updatePopup(v);
-
-		if (this.enableJumpIncrement) {
-			this.updateButtonStatus(this.value);
-		}
+		this.updateButtonStatus();
 
 		if (this.lockBar) {
 			this.setProgress(this.value);
@@ -557,9 +553,11 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	updateButtonStatus: function (val) {
-		this.$.buttonLeft.set('disabled', this.disabled || val == this.min);
-		this.$.buttonRight.set('disabled', this.disabled || val == this.max);
+	updateButtonStatus: function () {
+		if (this.enableJumpIncrement) {
+			this.$.buttonLeft.set('disabled', this.disabled || this.value == this.min);
+			this.$.buttonRight.set('disabled', this.disabled || this.value == this.max);
+		}
 	},
 
 	/**
@@ -657,10 +655,7 @@ module.exports = kind(
 		Spotlight.unfreeze();
 		this.set('value',v);
 
-		if (this.enableJumpIncrement) {
-			this.updateButtonStatus(v);
-		}
-
+		this.updateButtonStatus();
 		this.sendChangeEvent({value: this.getValue()});
 		e.preventTap();
 		this.$.knob.removeClass('active');

--- a/lib/Slider/Slider.js
+++ b/lib/Slider/Slider.js
@@ -537,8 +537,7 @@ module.exports = kind(
 		this.updatePopup(v);
 
 		if (this.enableJumpIncrement) {
-			this.$.buttonLeft.set('disabled', this.disabled || v == this.min);
-			this.$.buttonRight.set('disabled', this.disabled || v == this.max);
+			this.updateButtonStatus(this.value);
 		}
 
 		if (this.lockBar) {
@@ -553,6 +552,14 @@ module.exports = kind(
 	*/
 	getValue: function () {
 		return (this.animatingTo !== null) ? this.animatingTo : this.value;
+	},
+
+	/**
+	* @private
+	*/
+	updateButtonStatus: function (val) {
+		this.$.buttonLeft.set('disabled', this.disabled || val == this.min);
+		this.$.buttonRight.set('disabled', this.disabled || val == this.max);
 	},
 
 	/**
@@ -649,6 +656,11 @@ module.exports = kind(
 		this.dragging = false;
 		Spotlight.unfreeze();
 		this.set('value',v);
+
+		if (this.enableJumpIncrement) {
+			this.updateButtonStatus(v);
+		}
+
 		this.sendChangeEvent({value: this.getValue()});
 		e.preventTap();
 		this.$.knob.removeClass('active');


### PR DESCRIPTION
### Issue

When enableJumpIncrement is set to true, slider has left and right buttons to move towards left or right based on jumpIncrementAmount. However if we use MRCU, the status of the two buttons are not updated.

### Fix

While dragging the knob, we check the status of jumpIncrement buttons based on the current value.

Enyo-DCO-1.1-Signed-Off-By: Hunkyo Jung (hunkyo.jung@lge.com)