### PR TITLE
ENYO-2336: Accessibility: Do not read folded date picker and time pic…

### DIFF
--- a/lib/DateTimePickerBase/DateTimePickerBase.js
+++ b/lib/DateTimePickerBase/DateTimePickerBase.js
@@ -168,9 +168,9 @@ module.exports = kind(
 		{name: 'headerWrapper', kind: Item, classes: 'moon-date-picker-header-wrapper', onSpotlightFocus: 'headerFocus', ontap: 'expandContract', components: [
 			// headerContainer required to avoid bad scrollWidth returned in RTL for certain text widths (webkit bug)
 			{name: 'headerContainer', kind: Control, classes: 'moon-expandable-list-item-header moon-expandable-datetime-header', components: [
-				{name: 'header', kind: MarqueeText, accessibilityDisabled: true}
+				{name: 'header', kind: MarqueeText}
 			]},
-			{name: 'currentValue', kind: MarqueeText, accessibilityDisabled: true, classes: 'moon-expandable-list-item-current-value'}
+			{name: 'currentValue', kind: MarqueeText, classes: 'moon-expandable-list-item-current-value'}
 		]},
 		{name: 'drawer', kind: ExpandableListDrawer, resizeContainer:false, classes:'moon-expandable-list-item-client indented', components: [
 			{name: 'client', kind: Control, classes: 'enyo-tool-decorator moon-date-picker-client', onSpotlightLeft:'closePicker', onSpotlightSelect: 'closePicker'}


### PR DESCRIPTION
…ker.

It had been merged including accessibilityDisabled true at child node
on ENYO-1904.
Remove them on child node to prevent blink ignore child content.

https://jira2.lgsvl.com/browse/ENYO-2336?filter=25890
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>