### PR TITLE
Enyo 2337 Display positive value for slowRewind

### DIFF
--- a/lib/VideoFeedback/VideoFeedback.js
+++ b/lib/VideoFeedback/VideoFeedback.js
@@ -225,7 +225,7 @@ module.exports = kind(
 			break;
 
 		case 'Slowrewind':
-			msg = Math.abs(params.playbackRate) + 'x';
+			msg = params.playbackRate.split('-')[1] + 'x';
 			leftSrc = this.retriveImgOrIconPath(this._pauseBackImg);
 			break;
 

--- a/lib/VideoFeedback/VideoFeedback.js
+++ b/lib/VideoFeedback/VideoFeedback.js
@@ -225,12 +225,12 @@ module.exports = kind(
 			break;
 
 		case 'Slowrewind':
-			msg = params.playbackRate + 'x';
+			msg = Math.abs(params.playbackRate) + 'x';
 			leftSrc = this.retriveImgOrIconPath(this._pauseBackImg);
 			break;
 
 		case 'Fastforward':
-			msg = Math.abs(params.playbackRate) + 'x';
+			msg = params.playbackRate + 'x';
 			rightSrc = this.retriveImgOrIconPath(this._fastForwardImg);
 			break;
 


### PR DESCRIPTION
Issue
------
slowRewind shows '-' value

Cause
-------
feedback() does not make absolute value

Fix
----
Remove '-' from msg string

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com