### PR TITLE
ENYO-2304: Accessibility: A tooltip for an input does not float.

### DIFF
--- a/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
+++ b/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
@@ -27,6 +27,9 @@ module.exports = {
 
 			sup.apply(this, arguments);
 
+			// bubble 'onInputSpotFocused' event instead of onSpotlightFocused to handle if it is needed.
+			this.bubble('onInputSpotFocused');
+
 			// return true to stop the event bubble so the accessibility code in spotlight doesn't
 			// force a focus() thereby activating the internal <input>
 			return true;

--- a/lib/TooltipDecorator/TooltipDecorator.js
+++ b/lib/TooltipDecorator/TooltipDecorator.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	options = require('enyo/options'),
 	Control = require('enyo/Control');
 
 var
@@ -14,6 +15,9 @@ var
 
 var
 	Button = require('../Button');
+
+var
+	TooltipDecoratorAccessibilitySupport = require('./TooltipDecoratorAccessibilitySupport');
 
 /**
 * Bubble this event from a contained [control]{@link module:enyo/Control~Control} to mute tooltips. No data
@@ -93,6 +97,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Control,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [TooltipDecoratorAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/lib/TooltipDecorator/TooltipDecoratorAccessibilitySupport.js
+++ b/lib/TooltipDecorator/TooltipDecoratorAccessibilitySupport.js
@@ -1,0 +1,28 @@
+var
+	kind = require('enyo/kind');
+
+var
+	Spotlight = require('spotlight');
+
+/**
+* @name TooltipDecoratorAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	handlers: {
+		onInputSpotFocused: 'showTooltip'
+	},
+
+	/**
+	* @private
+	*/
+	showTooltip: function (inSender, inEvent) {
+		if (this.autoShow && !Spotlight.isFrozen()) {
+				this.waterfallDown('onRequestShowTooltip', {originator: inSender}, this);
+		}
+	}
+};


### PR DESCRIPTION
Issue

When the TooltipDecorator which has InputDecorator and Tooltip
is focused, tootip isn't shown.

Cause

TooltipDecorator needs onSpotlightFocused event to handle Tooltip,
but it stops that event bubble in InputDecorator to prevent activating
internal <input>

Fix

Bubble onInputSpotFocused event instead of onSpotlightFocused to handle
Tooltip in TooltipDecorator

https://jira2.lgsvl.com/browse/ENYO-2304?filter=-1
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>