### PR TITLE
ENYO-2159: Investigate/Remove .moon-icon-toggle from Icon.less

### DIFF
--- a/lib/Icon/Icon.less
+++ b/lib/Icon/Icon.less
@@ -1,6 +1,5 @@
 /* Icon.css */
-.moon-icon,
-.moon-icon-toggle {
+.moon-icon {
 	width: @moon-icon-size;
 	height: @moon-icon-size;
 	background-position: center -((@moon-icon-sprite-size - @moon-icon-size) / 2);


### PR DESCRIPTION
.moon-icon-toggle class was found only in moonstone/lib/Icon/Icon.less so it not used across components