### PR TITLE
PLAT-1948: Reduced the header font size to allow for deeper glyphs (like j, y, g)

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -60,7 +60,7 @@
 @moon-superscript-text-size:        24px;
 @moon-large-text-size:              48px;
 @moon-pre-text-size:                24px;
-@moon-header-font-size:             126px;
+@moon-header-font-size:             120px;
 @moon-super-header-font-size:       33px;
 @moon-sub-header-font-size:         30px;
 @moon-sub-header-below-font-size:   27px;

--- a/lib/Header/Header.less
+++ b/lib/Header/Header.less
@@ -27,7 +27,7 @@
 	}
 
 	.moon-header-title-below {
-		margin-top: -9px;  // Tuck this element up under the title
+		margin-top: -3px;  // Tuck this element up under the title
 
 		.enyo-locale-non-latin & {
 			margin-top: -21px;  // Tuck this element up under the title
@@ -156,7 +156,7 @@
 				padding-right: 1px;
 				display: inline-block;
 				box-sizing: border-box;
-				line-height: 1em;
+				line-height: 1.25em;
 				color: inherit;
 				width: 100%;
 				text-overflow: ellipsis;


### PR DESCRIPTION

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>