### PR TITLE
ENYO-2348: Accessibility: Do not read ExpandbalePicker and LabeledTex…

### DIFF
--- a/lib/LabeledTextItem/LabeledTextItem.js
+++ b/lib/LabeledTextItem/LabeledTextItem.js
@@ -80,7 +80,7 @@ module.exports = kind(
 	* @private
 	*/
 	components:[
-		{name: 'header', kind: Marquee.Text, classes: 'moon-labeledtextitem-header', accessibilityDisabled: true},
-		{name: 'text', classes: 'moon-labeledtextitem-text', accessibilityDisabled: true}
+		{name: 'header', kind: Marquee.Text, classes: 'moon-labeledtextitem-header'},
+		{name: 'text', classes: 'moon-labeledtextitem-text'}
 	]
 });


### PR DESCRIPTION
…tItem

Blink is changed to ignore the child node if it has aria-hidden even though
parent has aria-labelledby.
In expandable controls we need to remove accessibilityDisabled in
child node if it is dispensable.

https://jira2.lgsvl.com/browse/ENYO-2348
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>