### PR TITLE
Enyo-2314 Change disabled Icon color and opacity to make differences

### DIFF
--- a/css/moonstone-mixins.less
+++ b/css/moonstone-mixins.less
@@ -85,3 +85,9 @@
 	&:-o-full-screen { @rule(); }
 	&:fullscreen { @rule(); }
 }
+
+.vendor-opacity(@opacity) {
+	@opacity-ie: (@opacity * 100);	// Less doesn't like math inside `alpha`
+	opacity: @opacity;
+	filter: alpha(opacity=@opacity-ie);
+}

--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -95,7 +95,9 @@
 @moon-input-header-placeholder-color: darken(@moon-header-text-color, 45%);
 @moon-input-decorator-bg-color: @moon-white;
 
-@moon-icon-font-color: #A6A6A6;
+@moon-icon-font-color: #eeeeee;
+@moon-icon-font-disabled-color: rgba(187, 187, 187, 0.6);
+@moon-icon-bg-disabled-color: rgba(77, 77, 77, 0.2);
 @moon-icon-button-font-color: #ccc;
 @moon-icon-button-font-disabled-color: #4d4d4d;
 @moon-icon-button-bg-color: @moon-button-background-color;

--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -20,6 +20,7 @@
 @moon-spotlight-background-color:     @moon-accent;
 @moon-spotlight-border-color:         @moon-accent;
 @moon-spotlight-color:                @moon-accent;
+@moon-button-text-color:              #ccc;
 @moon-button-background-color:        #4d4d4d;
 @moon-divider-border-color:           #595959;
 @moon-active-border-color:            #a6a6a6;
@@ -66,7 +67,6 @@
 @moon-underline-overlay-color: #a2a2a2;
 @moon-searchheader-above-border-color: @moon-font-color-light;
 @moon-scrim-translucent-bg-color: #000;
-@moon-button-bar-bg-color: #a2a2a2;
 @moon-radio-item-text-color: @moon-sub-header-text-color;
 
 @moon-progress-button-bg-color: @moon-accent;
@@ -95,11 +95,8 @@
 @moon-input-header-placeholder-color: darken(@moon-header-text-color, 45%);
 @moon-input-decorator-bg-color: @moon-white;
 
-@moon-icon-font-color: #eeeeee;
-@moon-icon-font-disabled-color: rgba(187, 187, 187, 0.6);
-@moon-icon-bg-disabled-color: rgba(77, 77, 77, 0.2);
-@moon-icon-button-font-color: #ccc;
-@moon-icon-button-font-disabled-color: #4d4d4d;
+@moon-icon-text-color: @moon-button-text-color;
+@moon-icon-button-text-color: @moon-button-text-color;
 @moon-icon-button-bg-color: @moon-button-background-color;
 @moon-icon-button-active-border-color: @moon-spotlight-color;
 @moon-icon-button-active-bg-color: @moon-button-background-color;
@@ -131,11 +128,9 @@
 @moon-calendar-picker-date-color: @moon-white;
 @moon-calendar-picker-date-shadow-color: #A2A2A2;
 
-@moon-button-text-color: #ccc;
 @moon-breadcrumb-text-color: @moon-sup-header-text-color;
 
 @moon-thumb-bg-color: #a6a6a6;
-@moon-button-dark-gray-text-color: @moon-light-text-color;
 @moon-input-placeholder-color: #868686;
 @moon-breadcrumb-wrapper-bg-color: rgba(0,0,0,0.7);
 @moon-breadcrumb-wrapper-text-color: #fff;
@@ -186,6 +181,7 @@
 // Disabled Opacity
 // ---------------------------------------
 @moon-disabled-opacity: 0.6;
+@moon-disabled-translucent-opacity: (@moon-disabled-opacity - 0.2);
 
 @moon-carat-button-icon: url(../images/DarkTheme_Icons/CaratButton_Icon.png);
 @moon-carat-drawer-icon: url(../images/DarkTheme_Icons/CaratDrawer_Icon.png);

--- a/css/moonstone-variables-light.less
+++ b/css/moonstone-variables-light.less
@@ -20,6 +20,7 @@
 @moon-spotlight-background-color: @moon-accent;
 @moon-spotlight-border-color: @moon-accent;
 @moon-spotlight-color: @moon-accent;
+@moon-button-text-color: @moon-light-text-color;
 @moon-button-background-color: @moon-white;
 @moon-divider-border-color: @moon-dark-gray;
 @moon-active-border-color: #a6a6a6;
@@ -65,7 +66,6 @@
 @moon-underline-overlay-color: #A2A2A2;
 @moon-searchheader-above-border-color: @moon-font-color-light;
 @moon-scrim-translucent-bg-color: #000000;
-@moon-button-bar-bg-color: #A2A2A2;
 @moon-radio-item-text-color: @moon-font-color-light;
 
 @moon-progress-button-bg-color: @moon-accent;
@@ -94,11 +94,8 @@
 @moon-input-header-placeholder-color: lighten(@moon-header-text-color, 40%);
 @moon-input-decorator-bg-color: white;
 
-@moon-icon-font-color: @moon-dark-gray;
-@moon-icon-font-disabled-color: rgba(187, 187, 187, 0.6);
-@moon-icon-bg-disabled-color: rgba(77, 77, 77, 0.2);
-@moon-icon-button-font-color: #999;
-@moon-icon-button-font-disabled-color: #d9d9d9;
+@moon-icon-text-color: @moon-dark-gray;
+@moon-icon-button-text-color: #999;
 @moon-icon-button-bg-color: #fff;
 @moon-icon-button-active-border-color: @moon-spotlight-color;
 @moon-icon-button-active-bg-color: #ffffff;
@@ -129,11 +126,9 @@
 @moon-calendar-picker-date-color: @moon-white;
 @moon-calendar-picker-date-shadow-color: #A2A2A2;
 
-@moon-button-text-color: @moon-light-text-color;
 @moon-breadcrumb-text-color: @moon-font-color-light;
 
 @moon-thumb-bg-color: rgba(50, 50, 50, 0.8);
-@moon-button-dark-gray-text-color: @moon-light-text-color;
 @moon-input-placeholder-color: #868686;
 @moon-breadcrumb-wrapper-bg-color: rgba(0,0,0,0.7);
 @moon-breadcrumb-wrapper-text-color: #fff;
@@ -185,6 +180,7 @@
 // Disabled Opacity
 // ---------------------------------------
 @moon-disabled-opacity: 0.35;
+@moon-disabled-translucent-opacity: (@moon-disabled-opacity - 0.1);
 
 @moon-carat-button-icon: url(../images/LightTheme_Icons/CaratButton_Icon.png);
 @moon-carat-drawer-icon: url(../images/LightTheme_Icons/CaratDrawer_Icon.png);

--- a/css/moonstone-variables-light.less
+++ b/css/moonstone-variables-light.less
@@ -95,6 +95,8 @@
 @moon-input-decorator-bg-color: white;
 
 @moon-icon-font-color: @moon-dark-gray;
+@moon-icon-font-disabled-color: rgba(187, 187, 187, 0.6);
+@moon-icon-bg-disabled-color: rgba(77, 77, 77, 0.2);
 @moon-icon-button-font-color: #999;
 @moon-icon-button-font-disabled-color: #d9d9d9;
 @moon-icon-button-bg-color: #fff;

--- a/lib/Button/Button.less
+++ b/lib/Button/Button.less
@@ -91,8 +91,16 @@
 		.moon-taparea(@moon-button-small-height);
 	}
 
+	&.translucent {
+		background-color: fade(@moon-button-background-color, @moon-button-translucent-opacity);
+	}
+
+	&.transparent {
+		background-color: transparent;
+	}
+
 	// Button-non-disabled rules
-	&:not(.disabled) {
+	&:not([disabled]) {
 		&.pressed,
 		&.spotlight:active {
 			-webkit-animation-name: moonButtonExpand;
@@ -106,15 +114,6 @@
 			}
 		}
 
-		&.translucent {
-			background-color: fade(@moon-button-background-color, @moon-button-translucent-opacity);
-		}
-
-		&.transparent {
-			background-color: transparent;
-		}
-
-		// This is below the translucent and transparent so it takes priority
 		&.spotlight {
 			background-color: @moon-spotlight-border-color;
 			color: @moon-spotlight-text-color;
@@ -136,15 +135,7 @@
 	// Button-disabled rules
 	&[disabled] {
 		cursor: default;
-		color: @moon-button-disabled-text-color;
-		background-color: @moon-button-disabled-bg-color;
-
-		&.translucent {
-			background-color: fade(@moon-button-background-color, @moon-button-translucent-opacity);
-		}
-		&.transparent {
-			background-color: transparent;
-		}
+		.vendor-opacity(@moon-disabled-translucent-opacity);
 	}
 }
 

--- a/lib/Icon/Icon.less
+++ b/lib/Icon/Icon.less
@@ -14,7 +14,7 @@
 	line-height: @moon-icon-size;
 	text-align: center;
 	position: relative;
-	color: @moon-icon-font-color;
+	color: @moon-icon-text-color;
 
 	.moon-taparea(@moon-icon-size);
 
@@ -41,20 +41,19 @@
 	.moon-neutral & {
 		color: inherit;
 	}
-}
 
-.spotlight .moon-icon {
-	color: @moon-spotlight-text-color;
-	background-position: center -(@moon-icon-sprite-size + ((@moon-icon-sprite-size - @moon-icon-size) / 2));
-
-	&.small {
-		background-position: center -(@moon-icon-sprite-small-size + ((@moon-icon-sprite-small-size - @moon-icon-small-size) / 2));
+	&.disabled,
+	.disabled & {
+		.vendor-opacity(@moon-disabled-opacity);
 	}
-}
 
-.disabled .moon-icon,
-.moon-icon.disabled {
-	color: @moon-icon-font-disabled-color;
-	background-color: @moon-icon-bg-disabled-color;
+	.spotlight & {
+		color: @moon-spotlight-text-color;
+		background-position: center -(@moon-icon-sprite-size + ((@moon-icon-sprite-size - @moon-icon-size) / 2));
+
+		&.small {
+			background-position: center -(@moon-icon-sprite-small-size + ((@moon-icon-sprite-small-size - @moon-icon-small-size) / 2));
+		}
+	}
 }
 

--- a/lib/Icon/Icon.less
+++ b/lib/Icon/Icon.less
@@ -54,7 +54,7 @@
 
 .disabled .moon-icon,
 .moon-icon.disabled {
-	opacity: @moon-disabled-opacity;
-	filter: alpha(opacity=@moon-disabled-opacity-ie);
+	color: @moon-icon-font-disabled-color;
+	background-color: @moon-icon-bg-disabled-color;
 }
 

--- a/lib/IconButton/IconButton.less
+++ b/lib/IconButton/IconButton.less
@@ -1,7 +1,7 @@
 /* IconButton.css */
 .moon-icon-button {
 	.border-box;
-	color: @moon-icon-button-font-color;
+	color: @moon-icon-button-text-color;
 	width: @moon-icon-button-size;
 	height: @moon-icon-button-size;
 	border-radius: @moon-icon-button-size / 2;
@@ -24,11 +24,11 @@
 		}
 	}
 
-	&.translucent:not(.disabled) {
+	&.translucent {
 		background-color: fade(@moon-icon-button-bg-color, @moon-button-translucent-opacity);
 	}
 
-	&.transparent:not(.disabled) {
+	&.transparent {
 		background-color: transparent;
 	}
 
@@ -49,7 +49,7 @@
 	&:active.spotlight,
 	&.pressed,
 	&.hover:hover:not(.disabled):active {
-		color: @moon-icon-button-font-color;
+		color: @moon-icon-button-active-text-color;
 		background-color: @moon-icon-button-active-bg-color;
 		background-position: center 0;
 		border-color: @moon-icon-button-active-border-color;
@@ -65,14 +65,13 @@
 		}
 	}
 
-	&.disabled {
+	&.disabled,
+	.disabled & {
 		border-color: transparent;
 
-		&.translucent {
-			background-color: fade(@moon-icon-button-bg-color, @moon-button-translucent-opacity);
-		}
+		&.translucent,
 		&.transparent {
-			background-color: transparent;
+			.vendor-opacity(@moon-disabled-translucent-opacity);
 		}
 	}
 


### PR DESCRIPTION
Issue
------
It is not easy to distinguish disabled and enabled Icon button with translucent status

Cause
--------
Background color and opacity are same in both

Fix
----
Button and IconButton are now more translucent to allow for easier differentiation, as well as colors between them being synced-up.

This change includes:
* Several LESS variable name changes to be more consistent with other names
* Several deletions of abandoned deprecated LESS variables
* A correction to button's disabled attribute reference (it doesn't rely on a class)
* Addition and implementation of new `.vendor-opacity` mixin
* Simplification of the translucent/transparent CSS rules for Button, IconButton

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com
Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>