### PR TITLE
ENYO-2347: spotlightPlaceholder isn't disabled when a panel add component after creation time.

### DIFF
--- a/lib/LightPanels/LightPanel.js
+++ b/lib/LightPanels/LightPanel.js
@@ -95,6 +95,13 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	handlers: {
+		onSpotlightFocus: 'disableSpotlightPlaceholder'
+	},
+
+	/**
+	* @private
+	*/
 	components: [
 		{kind: Header, name: 'header', type: 'medium', marqueeOnRenderDelay: 1000},
 		{name: 'client', classes: 'client'},
@@ -188,6 +195,15 @@ module.exports = kind(
 			spotlightPlaceholder.spotlight = false;
 			if (!Spotlight.isSpottable(this)) spotlightPlaceholder.spotlight = true;
 			if (!current || current === spotlightPlaceholder) Spotlight.spot(this);
+		}
+	},
+
+	/**
+	* @private
+	*/
+	disableSpotlightPlaceholder: function (sender, event) {
+		if (this.$.spotlightPlaceholder.spotlight && event.originator !== this && event.originator !== this.$.spotlightPlaceholder) {
+			this.$.spotlightPlaceholder.spotlight = false;
 		}
 	},
 


### PR DESCRIPTION
Applying same fix with ENYO-2130 on LightPanel.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>