### PR TITLE
Fixes ENYO-2362

### DIFF
--- a/lib/ExpandableInput/ExpandableInput.js
+++ b/lib/ExpandableInput/ExpandableInput.js
@@ -145,7 +145,7 @@ module.exports = kind(
 	* @private
 	*/
 	computed: {
-		'currentValueShowing': ['open', 'value', 'noneText'],
+		'currentValueShowing': ['open', 'currentValueText', 'type'],
 		'currentValueText': ['value', 'noneText']
 	},
 

--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -210,7 +210,7 @@ module.exports = kind(
 	* @private
 	*/
 	computed: {
-		'currentValueShowing': ['open', 'value'],
+		'currentValueShowing': ['open', 'currentValueText'],
 		'currentValueText': ['value']
 	},
 


### PR DESCRIPTION
## Issue
The logic in `currentValueShowing` used `currentValueText` but only declared `value` in its computed list. Since ExpandablePicker overrides the computed path for `currentValueText` to use `selected` and `selectedIndex`, the value of `currentValueShowing` wasn't updated correctly.

## Fix
Update the computed path to use `currentValueText` instead of `value`

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)