### PR TITLE
ENYO-2363 allowHtml with Expandable header

### DIFF
--- a/lib/ExpandableListItem/ExpandableListItem.js
+++ b/lib/ExpandableListItem/ExpandableListItem.js
@@ -16,9 +16,7 @@ var
 	Spotlight = require('spotlight');
 
 var
-	Item = require('../Item'),
-	Marquee = require('../Marquee'),
-	MarqueeText = Marquee.Text;
+	Item = require('../Item');
 
 var
 	ExpandableListItemHeader = require('./ExpandableListItemHeader'),
@@ -298,7 +296,6 @@ module.exports = kind(
 	* @private
 	*/
 	expandContract: function () {
-		var spot;
 		if (this.open) {
 			this.closeDrawerAndHighlightHeader();
 		} else {
@@ -321,8 +318,7 @@ module.exports = kind(
 	* @private
 	*/
 	closeDrawerAndHighlightHeader: function () {
-		var mode = Spotlight.getPointerMode(),
-			current = Spotlight.getCurrent();
+		var current = Spotlight.getCurrent();
 
 		// If the spotlight is elsewhere, we don't want to hijack it (e.g. after the delay in
 		// ExpandablePicker)

--- a/lib/ExpandableListItem/ExpandableListItemHeader.js
+++ b/lib/ExpandableListItem/ExpandableListItemHeader.js
@@ -39,7 +39,8 @@ module.exports = kind(
 	* @private
 	*/
 	bindings: [
-		{from: 'textShowing', to: '$.text.showing'}
+		{from: 'textShowing', to: '$.text.showing'},
+		{from: 'allowHtml', to: '$.text.allowHtml'}
 	],
 
 	/**


### PR DESCRIPTION
## Issue
Current value of expandable picker does not get the allowHtml property passed to it, so values with HTML do not display properly. Test ExpandablePickerSample and select the 'Symbols' line.

## Solution
In ExpandableListItemHeader, pass `allowHtml` to the text item.

Also cleaned up jshint warnings.

Enyo-DCO-1.1-Signed-off-by: Roy Sutton <roy.sutton@lge.com>