### PR TITLE
ENYO-2234: Tooltip Does Not Display on Input

### DIFF
--- a/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
+++ b/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
@@ -25,11 +25,11 @@ module.exports = {
 			}
 			this.set('accessibilityLabel', text);
 
+			// add an accesibilityHandled flag to the event so that if the event bubbles accessibility
+			// code in spotlight doesn't force a focus() thereby activating the internal <input>
+			oEvent.accessibilityHandled = true;
+			
 			sup.apply(this, arguments);
-
-			// return true to stop the event bubble so the accessibility code in spotlight doesn't
-			// force a focus() thereby activating the internal <input>
-			return true;
 		};
 	}),
 

--- a/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
+++ b/lib/InputDecorator/InputDecoratorAccessibilitySupport.js
@@ -28,7 +28,7 @@ module.exports = {
 			// add an accesibilityHandled flag to the event so that if the event bubbles accessibility
 			// code in spotlight doesn't force a focus() thereby activating the internal <input>
 			oEvent.accessibilityHandled = true;
-			
+
 			sup.apply(this, arguments);
 		};
 	}),


### PR DESCRIPTION
### Issue:
Tooltip Does Not Display on Input
### Fix:
Removed code in InputDecoratorAccessibilitySupport::spotlightFocusedHandler that stopped bubbling of the onSpotlightFocused event. That code was added to prevent spotlight accessibility code from incorrectly focusing the input when inputDecorator was spotted. Replaced the stop-bubbling code by adding an accesibilityHandled flag to the event, and having spotlight check for this flag before it calls focus()

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan krishna.rangarajan@lge.com