### PR TITLE
ENYO-2273: Remeasure when setting up bounds...

### DIFF
--- a/lib/ScrollStrategy/ScrollStrategy.js
+++ b/lib/ScrollStrategy/ScrollStrategy.js
@@ -244,6 +244,7 @@ var MoonScrollStrategy = module.exports = kind(
 		this.calcBoundaries();
 		this.syncScrollMath();
 		this.enableDisableScrollColumns();
+		this.remeasure();
 		this.setThumbSizeRatio();
 		this.clampScrollPosition();
 	},


### PR DESCRIPTION
...to handle the case where just-enabled scroll controls have
caused naturally sized contents to reflow, altering scroll metrics.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)