### PR TITLE
ENYO-2334: Popup close button misaligned and with background color - reverted

### DIFF
--- a/lib/Popup/Popup.less
+++ b/lib/Popup/Popup.less
@@ -30,14 +30,11 @@
 	position: absolute;
 	right: @moon-spotlight-outset;
 	top: @moon-spotlight-outset;
-
-	&.moon-icon-button {
-		margin: 0;
-		background-color: transparent;
-		background-repeat: no-repeat;
-		background-position: 0 0;
-		color: @moon-popup-close-text-color;
-	}
+	margin: 0;
+	background-color: transparent;
+	background-repeat: no-repeat;
+	background-position: 0 0;
+	color: @moon-popup-close-text-color;
 
 	&.pressed,
 	&:active {


### PR DESCRIPTION
With merged PR, popup close button does not get spotlight's background color. So, I made reverted PR.

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung2.lee@lge.com