### PR TITLE
ENYO-2152: screen reader does not read accessibilityHint of component that has aria-labelledby

### DIFF
--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -367,5 +367,26 @@ module.exports = kind(
 			this.bubble('onRequestSetupBounds');
 		}
 		return true;
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['content', 'currentValueText', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+			var content = this.get('content') + ' ' + this.get('currentValueText') ,
+				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
+				prefix = this.accessibilityLabel || content || null,
+				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						null;
+
+				// header gets spotlight focus, it also can get dom focus
+				this.$.header.setAriaAttribute('tabindex', focusable ? 0 : null);
+				this.$.header.setAriaAttribute('aria-label', label);
+		}}
+	]
 });

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -194,7 +194,12 @@ module.exports = kind(
 		{from: 'disabled', to: '$.header.disabled'},
 		{from: 'content', to: '$.header.label'},
 		{from: 'currentValueShowing', to: '$.header.textShowing'},
-		{from: 'currentValueText', to: '$.header.text'}
+		{from: 'currentValueText', to: '$.header.text'},
+
+		// Accessibility
+		{from: 'accessibilityHint', to: '$.header.accessibilityHint'},
+		{from: 'accessibilityLabel', to: '$.header.accessibilityLabel'},
+		{from: 'accessibilityDisabled', to: '$.header.accessibilityDisabled'}
 	],
 
 	/**
@@ -367,26 +372,5 @@ module.exports = kind(
 			this.bubble('onRequestSetupBounds');
 		}
 		return true;
-	},
-
-	// Accessibility
-
-	/**
-	* @private
-	*/
-	ariaObservers: [
-		{path: ['content', 'currentValueText', 'accessibilityHint', 'accessibilityLabel'], method: function () {
-			var content = this.get('content') + ' ' + this.get('currentValueText') ,
-				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
-				prefix = this.accessibilityLabel || content || null,
-				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
-						this.accessibilityHint ||
-						this.accessibilityLabel ||
-						null;
-
-				// header gets spotlight focus, it also can get dom focus
-				this.$.header.setAriaAttribute('tabindex', focusable ? 0 : null);
-				this.$.header.setAriaAttribute('aria-label', label);
-		}}
-	]
+	}
 });

--- a/src/GridListImageItem/GridListImageItem.js
+++ b/src/GridListImageItem/GridListImageItem.js
@@ -107,5 +107,26 @@ module.exports = kind(
 		if (inEvent.originator === this) {
 			this.bubble('onRequestScrollIntoView');
 		}
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['caption', 'subCaption', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+			var content = this.caption + ' ' + this.subCaption,
+				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
+				prefix = this.accessibilityLabel || content || null,
+				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						null;
+
+				// GridListImageItem gets spotlight focus, it also can get dom focus
+				this.setAriaAttribute('tabindex', focusable ? 0 : null);
+				this.setAriaAttribute('aria-label', label);
+		}}
+	]
 });

--- a/src/GridListImageItem/GridListImageItem.js
+++ b/src/GridListImageItem/GridListImageItem.js
@@ -117,15 +117,12 @@ module.exports = kind(
 	ariaObservers: [
 		{path: ['caption', 'subCaption', 'accessibilityHint', 'accessibilityLabel'], method: function () {
 			var content = this.caption + ' ' + this.subCaption,
-				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
 				prefix = this.accessibilityLabel || content || null,
 				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityHint ||
 						this.accessibilityLabel ||
 						null;
 
-				// GridListImageItem gets spotlight focus, it also can get dom focus
-				this.setAriaAttribute('tabindex', focusable ? 0 : null);
 				this.setAriaAttribute('aria-label', label);
 		}}
 	]

--- a/src/ImageItem/ImageItem.js
+++ b/src/ImageItem/ImageItem.js
@@ -141,15 +141,12 @@ module.exports = kind(
 	ariaObservers: [
 		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
 			var content = this.label + ' ' + this.text ,
-				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
 				prefix = this.accessibilityLabel || content || null,
 				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityHint ||
 						this.accessibilityLabel ||
 						null;
 
-				// ImageItem gets spotlight focus, it also can get dom focus
-				this.setAriaAttribute('tabindex', focusable ? 0 : null);
 				this.setAriaAttribute('aria-label', label);
 		}}
 	]

--- a/src/ImageItem/ImageItem.js
+++ b/src/ImageItem/ImageItem.js
@@ -131,5 +131,26 @@ module.exports = kind(
 	*/
 	imageAlignRightChanged: function () {
 		this.addRemoveClass('align-right', this.imageAlignRight);
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+			var content = this.label + ' ' + this.text ,
+				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
+				prefix = this.accessibilityLabel || content || null,
+				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						null;
+
+				// ImageItem gets spotlight focus, it also can get dom focus
+				this.setAriaAttribute('tabindex', focusable ? 0 : null);
+				this.setAriaAttribute('aria-label', label);
+		}}
+	]
 });

--- a/src/LabeledTextItem/LabeledTextItem.js
+++ b/src/LabeledTextItem/LabeledTextItem.js
@@ -94,15 +94,12 @@ module.exports = kind(
 	ariaObservers: [
 		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
 			var content = this.label + ' ' + this.text ,
-				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
 				prefix = this.accessibilityLabel || content || null,
 				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityHint ||
 						this.accessibilityLabel ||
 						null;
 
-				// LabeledTextItem gets spotlight focus, it also can get dom focus
-				this.setAriaAttribute('tabindex', focusable ? 0 : null);
 				this.setAriaAttribute('aria-label', label);
 		}}
 	]

--- a/src/LabeledTextItem/LabeledTextItem.js
+++ b/src/LabeledTextItem/LabeledTextItem.js
@@ -84,5 +84,26 @@ module.exports = kind(
 	components:[
 		{name: 'header', kind: Marquee.Text, classes: 'moon-labeledtextitem-header'},
 		{name: 'text', classes: 'moon-labeledtextitem-text'}
+	],
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+			var content = this.label + ' ' + this.text ,
+				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
+				prefix = this.accessibilityLabel || content || null,
+				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						null;
+
+				// LabeledTextItem gets spotlight focus, it also can get dom focus
+				this.setAriaAttribute('tabindex', focusable ? 0 : null);
+				this.setAriaAttribute('aria-label', label);
+		}}
 	]
 });


### PR DESCRIPTION
On expandable control the header control can get spotlight focus,
we set the aria-label on the header if it is needed.
The cases we should consider are
 - accessibilityLabel set
    : read only <accessibilityLabel>
 - accessibilityHint set
    : read <content> + <current value> + <accessibilityHint>
 - accessibilityLabel and accessibilityHint set
    : <accessibilityLabel> + <accessibilityHint>

apply similarly on ImageItem and LabeledTextItem.

https://jira2.lgsvl.com/browse/ENYO-2152
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>