### PR TITLE
Enyo 2391 Prevent to close popup with back key when spotlightModal is true.

### DIFF
--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -596,9 +596,8 @@ module.exports = kind(
 	* @private
 	*/
 	backKeyHandler: function() {
-		if (this.showing) {
-			this.hide();
-		}
+		if (this.spotlightModal) this.pushBackHistory();
+		else if (this.showing) this.hide();
 
 		if (this.spotlight && !this.spotlightDisabled) {
 			this.doRequestSpot();

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -592,5 +592,21 @@ module.exports = kind(
 	destroy: function() {
 		this.showHideScrim(false);
 		Popup.prototype.destroy.apply(this, arguments);
-	}
+	},
+
+	/**
+	* If [spotlightModel]{@link module:moonstone/Popup~Popup#spotlightModal} property is true
+	* back key could not close popup.
+	* Because every event out-boundary of popup should be ignored when it is true.
+	*
+	* @method
+	* @public
+	*/
+	backKeyHandler: kind.inherit(function (sup) {
+		return function () {
+			if (this.spotlightModal) this.pushBackHistory();
+			else if (this.showing) this.hide();
+			return true;
+		};
+	})
 });


### PR DESCRIPTION
Requirement from HE UX

Issue
-------
When spotlightModal is true, we should block to close popup although back key is pressed.

Cause
--------
Currently popup will be closed when back key is pressed

Fix
----
Add guard code to prevent closing popup

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com