### PR TITLE
ENYO-2240: Tooltip: Disabled Button Prevents Marquee to get 'Start' Event

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -8,6 +8,7 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	util = require('enyo/utils'),
+	Control = require('enyo/Control'),
 	Button = require('enyo/Button');
 
 var
@@ -163,6 +164,8 @@ module.exports = kind(
 	initComponents: function () {
 		if (!(this.components && this.components.length > 0)) {
 			this.createComponent({name: 'client', kind: MarqueeText, classes: 'button-client', isChrome: true});
+			//overlay to enable button to receive mouse events when disabled
+			this.createComponent({name: 'overlay', kind: Control, classes: 'button-overlay', isChrome: true});
 		}
 		if (this.small) this.smallChanged();
 		if (this.minWidth) this.minWidthChanged();

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -76,6 +76,15 @@
 		min-width: @moon-button-large-min-width;
 	}
 
+	> .button-overlay {
+		position: absolute;
+		border-radius: @moon-button-border-radius;
+		top: -(@moon-button-border-width);
+		bottom: -(@moon-button-border-width);
+		left: -(@moon-button-border-width);
+		right: -(@moon-button-border-width);
+	}
+
 	&.small {
 		height: @moon-button-small-height;
 		min-width: @moon-button-small-height;
@@ -86,6 +95,14 @@
 
 		&.min-width {
 			min-width: @moon-button-small-min-width;
+		}
+
+		> .button-overlay {
+			border-radius: 0;
+			top: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);
+			bottom: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);
+			left: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);
+			right: -(@moon-button-border-width + (@moon-button-small-tap-area-height - @moon-button-small-height) / 2);
 		}
 
 		.moon-taparea(@moon-button-small-height);


### PR DESCRIPTION
### Issue:
Disabled buttons intermittently do not marquee or tooltip
### Fix:
re-inserting the button overlay child node. The overlay had been replaced with a :before tag (via the moon-taparea less mixin) to save the overhead of an extra node. Pseudo-selectors do not get mouse events when the button is disabled, while the overlay child node does.

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan <krishna.rangarajan@lge.com>