### PR TITLE
ENYO-2421: Move transition scrim to panels container.

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -103,7 +103,7 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{kind: Header, name: 'header', type: 'medium', marqueeOnRenderDelay: 1000},
+		{kind: Header, name: 'header', type: 'medium', marqueeOnRender: false, marqueeOnRenderDelay: 1000},
 		{name: 'client', classes: 'client'},
 		{name: 'spotlightPlaceholder', spotlight: false, style: 'width:0;height:0;'}
 	],
@@ -145,6 +145,8 @@ module.exports = kind(
 			currentSpottable = current && Spotlight.isSpottable(current),
 			isChild = current && current.isDescendantOf(this);
 
+		this.$.header.stopMarquee();
+
 		this.spotlightDisabled = true; // we do not want to allow 5-way spotting during transition
 
 		// This is highly related to the order in which "preTransition" is fired for the outgoing
@@ -181,7 +183,10 @@ module.exports = kind(
 			this.didClientRender();
 		}
 
-		if (this.state == States.ACTIVE) this.checkSpottability();
+		if (this.state == States.ACTIVE) {
+			this.checkSpottability();
+			this.$.header.startMarquee();
+		}
 	},
 
 	/**

--- a/src/LightPanels/LightPanel.less
+++ b/src/LightPanels/LightPanel.less
@@ -4,28 +4,8 @@
 		padding-top: 12px;
 
 		&.populated {
+			.moon-composite();
 			opacity: 1;
-		}
-	}
-
-	// Base set of styling for scrim to prevent receiving user input while transitioning
-	&:after {
-		position: absolute;
-		top: 0;
-		left: 0;
-		bottom: 0;
-		right: 0;
-	}
-
-	// Adding the content property here, instead of above, means that this element will only appear in
-	// the DOM during ".transitioning". This was altered to improve marquee animation performance.
-	// Pseudo-elements without a content property cannot receive styling.
-	.moon-light-panels.transitioning & {
-		-webkit-transform: translateZ(0);
-		transform: translateZ(0);
-
-		&:after {
-			content: '';
 		}
 	}
 }

--- a/src/LightPanels/LightPanels.less
+++ b/src/LightPanels/LightPanels.less
@@ -1,0 +1,24 @@
+.moon-light-panels {
+	// Base set of styling for scrim to prevent receiving user input while transitioning
+	&:after {
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+	}
+
+	&.transitioning {
+		// Adding the content property here, instead of above, means that this element will only appear in
+		// the DOM during ".transitioning". This was altered to improve marquee animation performance.
+		// Pseudo-elements without a content property cannot receive styling.
+		&:after {
+			content: '';
+		}
+
+		.panels-container > * {
+			// Added to prevent graphical glitches
+			.moon-composite();
+		}
+	}
+}

--- a/src/LightPanels/package.json
+++ b/src/LightPanels/package.json
@@ -1,6 +1,7 @@
 {
 	"main": "LightPanels.js",
 	"styles": [
+		"LightPanels.less",
 		"LightPanel.less"
 	]
 }


### PR DESCRIPTION
### Issue
With the fix for ENYO-2384 to transition a single panel container instead of individual panels, the transition scrim applied to each panel could also be moved to the panel container. Also, I noticed the header marquee was running during transition.

### Fix
The transition scrim is now being applied to the panel container. We also utilize the composite class for the client element when populated. And lastly, the marqueeing of the header is now explicitly controlled via the transition lifecycle methods. This is not a perfect solution as auto-marqueeing kinds in the view could potentially still marquee during transition, but these seemed much more rare, and this was a decent compromise for a known auto-marqueeing kind, rather than waterfall an event to all of the panel elements.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>