### PR TITLE
ENYO-1751: Accessibility: It read value with html tag in the RichText…

### DIFF
--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -333,7 +333,11 @@ module.exports = kind(
 				oInput = this.getInputControl();
 
 			if (oInput) {
-				text = (oInput.get('value') || oInput.get('placeholder')) + ' ' + $L('edit box');
+				if (oInput instanceof RichText && oInput.hasNode()) {
+					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('edit box');
+				} else {
+					text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('edit box');
+				}
 			}
 			this.set('accessibilityLabel', this.spotted ? text : null);
 		}}


### PR DESCRIPTION
… control

In case RichText, html tag can be included on it.
If we get the value using getValue() it will return the value including
html tag and screen reader will read it.
For RichText, set the label using innerText to remove html tag.

https://jira2.lgsvl.com/browse/ENYO-1751
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>