### PR TITLE
ENYO-2022: Add Text to Speech Accessibility support to VideoFullscree…

### DIFF
--- a/src/VideoFullscreenToggleButton/VideoFullscreenToggleButton.js
+++ b/src/VideoFullscreenToggleButton/VideoFullscreenToggleButton.js
@@ -9,6 +9,7 @@ var
 	kind = require('enyo/kind');
 
 var
+	$L = require('../i18n'),
 	IconButton = require('../IconButton');
 
 /**
@@ -67,5 +68,20 @@ module.exports = kind(
 		* @fires module:moonstone/VideoPlayer~VideoPlayer#onRequestToggleFullscreen
 		*/
 		ontap: 'doRequestToggleFullscreen'
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: 'icon', method: function () {
+			if (this.icon === 'exitfullscreen') {
+				this.set('accessibilityLabel', $L('original screen'));
+			} else {
+				this.set('accessibilityLabel', $L('full screen'));
+			}
+		}}
+	] 
 });

--- a/src/VideoPlayer/VideoPlayer.js
+++ b/src/VideoPlayer/VideoPlayer.js
@@ -665,7 +665,7 @@ module.exports = kind(
 					{name: 'controlsContainer', kind: Panels, arrangerKind: CarouselArranger, fit: true, draggable: false, classes: 'moon-video-player-controls-container', components: [
 						{name: 'trickPlay', kind: Control, ontap:'playbackControlsTapped', components: [
 							{name: 'playbackControls', kind: Control, classes: 'moon-video-player-control-buttons', components: [
-								{name: 'jumpBack',		kind: IconButton, small: false, onholdpulse: 'onHoldPulseBackHandler', ontap: 'onjumpBackward', onrelease: 'onReleaseHandler'},
+								{name: 'jumpBack',		kind: IconButton, small: false, onholdpulse: 'onHoldPulseBackHandler', ontap: 'onjumpBackward', onrelease: 'onReleaseHandler', accessibilityLabel: $L('Previous')},
 								{name: 'rewind',		kind: IconButton, small: false, ontap: 'rewind', accessibilityLabel: $L('Rewind')},
 								{name: 'fsPlayPause',	kind: IconButton, small: false, ontap: 'playPause'},
 								{name: 'fastForward',	kind: IconButton, small: false, ontap: 'fastForward', accessibilityLabel: $L('Fast Forward')},


### PR DESCRIPTION
Initial add accessibility feature to VideoFullscreenToggleButton.

## Requirement
WebOS TV should read 'original screen' or 'full screen' when VideoFullscreenToggleButton is focused.

## Implementation
VideoFullscreenToggleButton is iconButton, which default has 'exitfullscreen' as icon value, so screen reader should default read 'original screen'. In the other hands, if user click VideoFullscreenToggleButton, its icon value is changed to 'fullscreen', so screen reader should read 'full sreen'.
Thus, I add accessibilityLabel according to icon.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com