### PR TITLE
ENYO-1907: Add Text to Speech Accessibility support to Drawer

### DIFF
--- a/src/Drawers/Drawers.js
+++ b/src/Drawers/Drawers.js
@@ -521,14 +521,11 @@ module.exports = kind(
 			// According to drawer is open or close or handleContainer state, drawers activator label is defined.
 			// In addition, if user add accessibilityLabel, label is determined with accessibilityLabel instead of default string.
 			// However, if user add only accessibilityHint, hint text is appended to default string.
-			var defaultLabel = (this._activated || this.$.handleContainer.getOpen()) ? $L('close drawer') : $L('open drawer'),
+			var defaultLabel = (this._activated || this.$.handleContainer.getOpen()) ? $L('Close drawer') : $L('Open drawer'),
 				prefix = this.accessibilityLabel || defaultLabel,
 				label = this.accessibilityHint && (prefix + ' ' + this.accessibilityHint) ||
 						prefix;
-			// Prevent reading activator label before drawer animation is completed 
-			setTimeout(this.bindSafely(function () {
-				this.$.activator.set('accessibilityLabel', label);
-			}), 16);
+			this.$.activator.set('accessibilityLabel', label);
 		}}
 	]
 });

--- a/src/Drawers/Drawers.js
+++ b/src/Drawers/Drawers.js
@@ -21,6 +21,7 @@ var
 	HistorySupport = require('../HistorySupport');
 
 var
+	$L = require('../i18n'),
 	MoonDrawer = require('./Drawer');
 
 /**
@@ -166,6 +167,15 @@ module.exports = kind(
 	clientTop: 0,
 
 	/**
+	* Value for Drawer open or close state
+	*
+	* @type {Boolean}
+	* @default false
+	* @private
+	*/
+	_activated: false,
+
+	/**
 	* @private
 	*/
 	handlers: {
@@ -208,7 +218,7 @@ module.exports = kind(
 		this.drawers = this.$.drawers.createComponents(this.drawers, {kind: MoonDrawer, owner: this.owner});
 		if (!options.accelerate) this.createComponent({name: 'animator', kind: Animator, onStep: 'animationStep'});
 		this.setupHandles();
-		this.updateActivator();
+		this._activatedChanged();
 	},
 
 	/**
@@ -268,9 +278,16 @@ module.exports = kind(
 	* @private
 	*/
 	updateActivator: function (open) {
+		this.set('_activated', !!open);
+	},
+
+	/**
+	* @private
+	*/
+	_activatedChanged: function () {
 		var icon, src;
 
-		if (open) {
+		if (this._activated) {
 			src = '';
 			icon = this.iconOpen;
 		} else {
@@ -278,7 +295,7 @@ module.exports = kind(
 			icon = (src && !this.icon) ? '' : (this.icon || this.iconClosed);
 		}
 
-		this.$.activator.addRemoveClass('open', open);
+		this.$.activator.addRemoveClass('open', this._activated);
 		this.$.activatorIcon.set('src', src);
 		this.$.activatorIcon.set('icon', icon);
 	},
@@ -495,7 +512,25 @@ module.exports = kind(
 	backKeyHandler: function () {
 		this.closeHandleContainer();
 		return true;
-	}
+	},
+
+	// Accessibility
+
+	ariaObservers: [
+		{path: ['accessibilityLabel', 'accessibilityHint', '_activated'], method: function() {
+			// According to drawer is open or close or handleContainer state, drawers activator label is defined.
+			// In addition, if user add accessibilityLabel, label is determined with accessibilityLabel instead of default string.
+			// However, if user add only accessibilityHint, hint text is appended to default string.
+			var defaultLabel = (this._activated || this.$.handleContainer.getOpen()) ? $L('close drawer') : $L('open drawer'),
+				prefix = this.accessibilityLabel || defaultLabel,
+				label = this.accessibilityHint && (prefix + ' ' + this.accessibilityHint) ||
+						prefix;
+			// Prevent reading activator label before drawer animation is completed 
+			setTimeout(this.bindSafely(function () {
+				this.$.activator.set('accessibilityLabel', label);
+			}), 16);
+		}}
+	]
 });
 
 module.exports.Drawer = MoonDrawer;


### PR DESCRIPTION
Initial add accessibility feature to Drawers.

## Requirement
Screen reader should read 'open drawer' or 'close drawer' when Drawer is focused.

## Implementation
Screen reader should read 'open drawer' or 'close drawer' when activator of drawers is focused according to drawer open or close state. 
Whenever drawer is opened or closed, updateActivator is called and Drawers could know whether or not drawer is open using isDrawerOpen function 
Thus, I added accessibility function to updateActivator function. 

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com