### PR TITLE
ENYO-2437: Recompute when selected item content changes on ExpandablePicker

### DIFF
--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -205,8 +205,12 @@ module.exports = kind(
 		{name: 'helpText', kind: BodyText, canGenerate: false, classes: 'moon-expandable-picker-help-text'}
 	],
 
+	bindings: [
+		{from: 'selected.content', to: 'selectedText'}
+	],
+
 	computed: {
-		'currentValueText': ['selected', 'noneText']
+		'currentValueText': ['selected', 'noneText', 'selectedText']
 	},
 
 	/**


### PR DESCRIPTION
Issue:
CurrentValueText is not updated when user change content of selected item on ExpandablePicker.

Fix:
Add a binding from selected content to currentValueText to trigger
compute.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>