### PR TITLE
ENYO-2172: Add Text to Speech Accessibility support to PagingControl

### DIFF
--- a/src/PagingControl/PagingControl.js
+++ b/src/PagingControl/PagingControl.js
@@ -8,13 +8,15 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	utils = require('enyo/utils'),
-	animation = require('enyo/animation');
+	animation = require('enyo/animation'),
+	options = require('enyo/options');
 
 var
 	Spotlight = require('spotlight');
 
 var
-	IconButton = require('../IconButton');
+	IconButton = require('../IconButton'),
+	PagingControlAccessibilitySupport = require('./PagingControlAccessibilitySupport');
 
 /**
 * Fires when page boundary is reached.
@@ -56,6 +58,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: IconButton,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [PagingControlAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/src/PagingControl/PagingControlAccessibilitySupport.js
+++ b/src/PagingControl/PagingControlAccessibilitySupport.js
@@ -1,0 +1,79 @@
+var
+	kind = require('enyo/kind');
+
+var
+	VoiceReadout = require('enyo-webos/VoiceReadout'),
+	Spotlight = require('spotlight');	
+
+var
+	$L = require('../i18n');
+
+
+/**
+* @name PagingControlAccessibilitySupport
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* In 5-way mode, screen reader should read scroll direction string. Screen reader generally reads content or label when component is focused. 
+	* Use readAlert() api because screen reader should read string whenever already focused component is pressed.
+	* @private
+	*/
+	depress: kind.inherit(function (sup) {
+		return function (oSender, oEvent) {
+			sup.apply(this, arguments);
+			var side = oEvent.originator.side;
+			switch(side) {
+			case 'top':
+				VoiceReadout.readAlert($L('up'));
+				break;
+			case 'bottom':
+				VoiceReadout.readAlert($L('down'));
+				break;
+			case 'left':
+				VoiceReadout.readAlert($L('left'));
+				break;
+			case 'right':
+				VoiceReadout.readAlert($L('right'));
+				break;
+			}
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	noop: kind.inherit(function (sup) {
+		return function (oSender, oEvent) {
+			// noop returns true, so this can not receive webkit focus, then screen reader can not read anything. 
+			if (oEvent.type == 'onSpotlightFocused' && !Spotlight.getPointerMode()) {
+				this.focus();
+			}
+			sup.apply(this, arguments);
+		};
+	}),
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: 'side', method: function () {
+			var side = this.get('side');
+			switch(side) {
+			case 'top':
+				this.set('accessibilityLabel', $L('scroll up'));
+				break;
+			case 'bottom':
+				this.set('accessibilityLabel', $L('scroll down'));
+				break;
+			case 'left':
+				this.set('accessibilityLabel', $L('scroll left'));
+				break;
+			case 'right':
+				this.set('accessibilityLabel', $L('scroll right'));
+				break;
+			}
+		}}
+	]
+};


### PR DESCRIPTION
Initial add accessibility feature to PagingControls

## Requirement
1) Screen reader should read scroll IconButton string when IconButton is focused.
2) Screen reader should read scroll direction string whenever this scroll iconButton is pressed.

## Implementation
The IconButton of Scroller is PagingControls component. 
I added PagingControlsAccessibilitySupport to override noop and depress function.

The noop() is onSpotlightFocused event handler, and simply returns true. so, Even If pagingControls is spotlight focused, screen reader should not read anything because pagingControls does not get the webkit focus. To prevent this, we directly add webkit focus before noop() is called.

We observer side property and when side is defined or changed, add accessibilityLabel to pagingControls.

We override depress() for reading scroll direction (ex. 'up' or 'down' ) whenever pagingControls is pressed. In this function, we use readAlert() api in enyo-webos because pagingControl's focus is not moved and screen reader should read string whenever it is pressed

## Limitation
We used readAlert() of enyo-webOS library, so No.2 requirement works on only webOS TV. 

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com