### PR TITLE
Enyo 2292: Password input should read 'n-characters' instead of real …

### DIFF
--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -335,6 +335,9 @@ module.exports = kind(
 			if (oInput) {
 				if (oInput instanceof RichText && oInput.hasNode()) {
 					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('edit box');
+				} else if (oInput.type == 'password' && oInput.getValue()) {
+					var character = (oInput.getValue().length > 1) ? $L('characters') : $L('character');
+					text = oInput.getValue().length + ' ' + character + ' ' + $L('edit box');
 				} else {
 					text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('edit box');
 				}


### PR DESCRIPTION
…value.

In case password input we need to hide password.
According to ux guide it reads 'n characters edit box' when the password input
is focused.

https://jira2.lgsvl.com/browse/ENYO-2292
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang jaewon98.jang@lgepartner.com