### PR TITLE
ENYO-2171: Add tabindex for Item to avoid accessibility timing issue

### DIFF
--- a/src/Item/Item.js
+++ b/src/Item/Item.js
@@ -109,5 +109,14 @@ module.exports = kind(
 	*/
 	tap: function () {
 		return this.disabled;
-	}
+	},
+
+	// Accessibility
+	
+	ariaObservers: [
+		// Item may have components as child. However, Sometimes screen reader does not read
+		// child component's content because time to receive tabindex is late than child.
+		// To prevent timing issue, add tabindex.
+		{to: 'tabindex', value: 0}
+	]
 });


### PR DESCRIPTION
## Issue 
 screen reader sometimes does not read child component's content when Item is focused.

## Cause
Item may have components as child. However, Sometimes screen reader does not read child component's content because time to receive tabindex is late than child.
To prevent this timing issue, I add tabindex to Item.

## Fix
Add tabindex in ariaObservers. 

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
