### PR TITLE
ENYO-1908: Add accessibilityLabel for close iconButton of ListAction

### DIFF
--- a/src/ListActions/ListActions.js
+++ b/src/ListActions/ListActions.js
@@ -21,6 +21,7 @@ var
 	Spotlight = require('spotlight');
 
 var
+	$L = require('../i18n'),
 	Scroller = require('../Scroller'),
 	IconButton = require('../IconButton'),
 	HistorySupport = require('../HistorySupport');
@@ -398,7 +399,7 @@ var ListActions = module.exports = kind(
 	*/
 	drawerComponents: [
 		{name: 'drawer', spotlightDisabled: true, kind: ListActionsDrawer, classes: 'list-actions-drawer', onComplete: 'drawerAnimationEnd', open: false, spotlight: 'container', spotlightModal:true, components: [
-			{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close moon-list-actions-close moon-neutral', ontap: 'expandContract', backgroundOpacity: 'transparent', defaultSpotlightDown:'listActions'},
+			{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close moon-list-actions-close moon-neutral', ontap: 'expandContract', accessibilityLabel: $L('Close'), backgroundOpacity: 'transparent', defaultSpotlightDown:'listActions'},
 			{name: 'listActionsClientContainer', kind: Control, classes: 'enyo-fit moon-list-actions-client-container moon-neutral', components: [
 				{name: 'listActions', kind: Scroller, classes: 'enyo-fit moon-list-actions-scroller', horizontal:'hidden', vertical:'hidden', onActivate: 'optionSelected', defaultSpotlightUp:'closeButton'}
 			]}


### PR DESCRIPTION
Initial add accessibility feature to ListActions

## Requirement
1) Screen reader should read ListAction IconButton's tooltip text when it is focused.
2) Screen reader should read ListAction Item content and state when ListAction's item is focused.
3) Screen reader should read close string when ListActions close button is focused.

## Implementation
Only No.3 requirement is applied because the others are already applied in each component.
To read 'close' when close button is focused, we add accessibilityLabel to IconButton. 

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com