### PR TITLE
ENYO-1905: Add Text to Speech Accessibility support to Spinner

### DIFF
--- a/src/Spinner/Spinner.js
+++ b/src/Spinner/Spinner.js
@@ -11,6 +11,7 @@ var
 	Control = require('enyo/Control');
 
 var
+	$L = require('../i18n'),
 	Marquee = require('../Marquee'),
 	MarqueeText = Marquee.Text,
 	MarqueeSupport = Marquee.Support;
@@ -225,5 +226,20 @@ module.exports = kind(
 	*/
 	transparentChanged: function() {
 		this.addRemoveClass('moon-spinner-transparent-background', !!this.get('transparent'));
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['showing'], method: function () {
+			if (!this.accessibilityLabel && !this.accessibilityHint && !this.hasContent()) {
+				this.set('accessibilityLabel', this.get('showing') ? $L('loading') : null);
+			}
+			this.set('accessibilityAlert', this.get('showing') ? true : null);
+			this.setAriaAttribute('aria-live', this.get('showing') ? 'off' : null);
+		}}
+	]
 });


### PR DESCRIPTION
Initial add accessibility feature to Spinner

## Requirement
Screen reader should read Spinner Loading text when Spinner is loading according to UX requirements.

## Implementation
We added SpinnerAccessibilitySupport to support reading a spinner's content.
Spinner has animating control and client content, so sreen reader should read content string when spinner is shown. However, Spinner is not spotlight component, so we should use accessibilityAlert API for reading it. If aceessibilityAlert is true, screen reader reads contents whenever it is changed.
Because Spinner' client control is marqeeeText, The scrren reader reads content whenever marquee animataion is started. To prevent this, we added aria-live: off attribute to spinner.

## Limitation
In ChromeVox, this commit doesn't work. it works only WebOS TV.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com