### PR TITLE
ENYO-2021: Add Text to Speech Accessibility support to ExpandableText

### DIFF
--- a/src/ExpandableText/ExpandableText.js
+++ b/src/ExpandableText/ExpandableText.js
@@ -341,7 +341,18 @@ var ExpandableText = module.exports = kind(
 	*/
 	canCollapseChanged: function (was, is) {
 		this.$.button.setShowing(is);
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: 'generated', method: function () {
+			this.$.button.setAriaAttribute('aria-labelledby', this.$.client.id);
+		}}
+	]
 });
 
 /**


### PR DESCRIPTION
Initial add accessibility feature to ExpandableText

## Requirement

WebOS TV should read all content of ExpandableText when more or less button is focused though content is collapsed.

## Implementation

ExpandableText has client and button component. The client component has content and button is more or less button. Screen reader should not read more or less button content when this button is focused. Instead, it should read all content of client component, To implement this requirement, we add aria-labelledby attribute, which has client component id to more or less button. 

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com