### PR TITLE
ENYO-1994 : Add Text to Speech Accessibility support to LightPanels

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -5,10 +5,12 @@
 
 var
 	kind = require('enyo/kind'),
-	LightPanels = require('enyo/LightPanels');
+	LightPanels = require('enyo/LightPanels'),
+	options = require('enyo/options');
 
 var
-	LightPanel = require('./LightPanel');
+	LightPanel = require('./LightPanel'),
+	LightPanelsAccessibilitySupport = require('./LightPanelsAccessibilitySupport');
 
 /**
 * A light-weight panels implementation that has basic support for side-to-side transitions
@@ -31,6 +33,11 @@ module.exports = kind(
 	* @private
 	*/
 	kind: LightPanels,
+
+	/**
+	* @private
+	*/
+	mixins: options.accessibility ? [LightPanelsAccessibilitySupport] : null,
 
 	/**
 	* @private

--- a/src/LightPanels/LightPanelsAccessibilitySupport.js
+++ b/src/LightPanels/LightPanelsAccessibilitySupport.js
@@ -1,0 +1,27 @@
+var
+	kind = require('enyo/kind');
+
+var
+	VoiceReadout = require('enyo-webos/VoiceReadout');
+
+/**
+* @name LightPanelsAccessibilityMixin
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	setupTransitions: kind.inherit(function (sup) {
+		return function () {
+			var panels = this.getPanels(),
+				nextpanel = panels[this.index];
+			if (nextpanel) {
+				VoiceReadout.readAlert(nextpanel.getAttribute('aria-label') || nextpanel.get('title'));
+			}
+			sup.apply(this, arguments);
+		};
+	})
+	
+};


### PR DESCRIPTION
Initial add accessibility feature to LightPanels.

## Requirement
WebOS TV should read panel title or panels accessibilityLabel when LightPanel is opened or moved according to UX requirements.

## Implementation
We added LightPanelsAccessibilitySupport to support reading panel title.
LightPanel is spotlight container, so first child component or last spotlight component is focused when panel is opened.
Then, Screen reader first reads this focused component content. However, UX requirements request that Screen reader first should read panel title when panel is opened or moved. 
TV should read panel title as quickly as possible before reading focused component, so we added readAlert function to setupTransitions(). The setupTransitions is called when panel is opened or moved.

## Limitation
We used readAlert() of enyo-webOS library and overrided setupTransitions to read panel title as quickly as possible, but If panel is opened without animation, panel title sound will cut for reading focused child component of panel. In this case, user can replace title to short title using accessibilityLabel. Then, TV first reads accessiblityLabel string.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com