### PR TITLE
ENYO-1984: Add Text to Speech Accessibility support to Panels

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -13,7 +13,8 @@ var
 	Control = require('enyo/Control'),
 	EnyoHistory = require('enyo/History'),
 	Img = require('enyo/Image'),
-	Signals = require('enyo/Signals');
+	Signals = require('enyo/Signals'),
+	options = require('enyo/options');
 
 var
 	Panels = require('layout/Panels');
@@ -26,7 +27,8 @@ var
 	BreadcrumbArranger = require('../BreadcrumbArranger'),
 	Panel = require('../Panel'),
 	StyleAnimator = require('../StyleAnimator'),
-	HistorySupport = require('../HistorySupport');
+	HistorySupport = require('../HistorySupport'),
+	PanelsAccessibilitySupport = require('./PanelsAccessibilitySupport');
 
 /**
 * `moon.PanelsHandle` is a helper kind for {@link module:moonstone/Panels~Panels} which implements a spottable
@@ -132,7 +134,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	mixins : [HistorySupport],
+	mixins : options.accessibility ? [PanelsAccessibilitySupport, HistorySupport] : [HistorySupport],
 
 	/**
 	* @private

--- a/src/Panels/PanelsAccessibilitySupport.js
+++ b/src/Panels/PanelsAccessibilitySupport.js
@@ -1,0 +1,27 @@
+var
+	kind = require('enyo/kind');
+
+var
+	VoiceReadout = require('enyo-webos/VoiceReadout');
+
+/**
+* @name PanelsAccessibilitySupport
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	indexChanged: kind.inherit(function (sup) {
+		return function () {
+			var panels = this.getPanels(),
+				nextpanel = panels[this.index];
+			if (nextpanel) {
+				VoiceReadout.readAlert(nextpanel.getAttribute('aria-label') || nextpanel.get('title'));
+			}
+			sup.apply(this, arguments);
+		};
+	})
+
+};


### PR DESCRIPTION
Initial add accessibility feature to Panels.

## Requirement
WebOS TV should read panel title or panels accessibilityLabel when Panel is opened or moved according to UX requirements.

## Implementation
We added PanelsAccessibilitySupport to support reading panel title.
Panel is spotlight container, so first child component or last spotlight component is focused when panel is opened.
Then, Screen reader first reads this focused component content. However, UX requirements request that Screen reader first should read panel title when panel is opened or moved. 
TV should read panel title as quickly as possible before reading focused component, so we added readAlert function to indexChanged(). The indexChanged is called when panel is opened or moved.

## Limitation
We used readAlert() of enyo-webOS library and overrided indexChanged to read panel title as quickly as possible, but If panel is opened without animation, panel title sound will cut for reading focused child component of panel. In this case, user can replace title to short title using accessibilityLabel. Then, TV first reads accessiblityLabel string.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com