### PR TITLE
Enyo-2003 Marquee is not starting for "Revoke all pairing authorizations" pop-up.

### DIFF
--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -49,7 +49,7 @@
 .moon-super-header-text {
 	font-family: @moon-super-header-font-family;
 	font-size: @moon-super-header-font-size;
-	-webkit-font-kerning: normal;
+	.font-kerning;
 }
 .moon-sub-header-text {
 	.moon-text-base (@moon-sub-header-font-size);
@@ -88,12 +88,12 @@
 .moon-large-button-text {
 	font-family: @moon-button-font-family;
 	font-size: @moon-button-large-font-size;
-	-webkit-font-kerning:normal;
+	.font-kerning;
 }
 .moon-small-button-text {
 	font-family: @moon-button-font-family;
 	font-size: @moon-button-small-font-size;
-	-webkit-font-kerning:normal;
+	.font-kerning;
 }
 .moon-icon-text {
 	font-family: @moon-icon-font-family;
@@ -104,7 +104,7 @@
 .moon-dialog-title {
 	font-family: @moon-popup-header-font-family;
 	font-size: @moon-popup-header-font-size;
-	-webkit-font-kerning: normal;
+	.font-kerning;
 }
 .moon-dialog-sub-title {
 	font-size: @moon-popup-sub-header-font-size;


### PR DESCRIPTION
Issue:

webOS Webkit, is misreading font widths without font-kerning applied to them.

Fix:

Add the font-kerning mixin

Enyo-DCO-1.1-Signed-off-by: Derek Anderson derek.anderson@lge.com