### PR TITLE
Fixes ENYO-2430

### DIFF
--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -211,7 +211,7 @@ module.exports = kind(
 	*/
 	tools: [
 		{name: 'client', kind: Control, classes: 'moon-neutral moon-contextual-popup-client'},
-		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', backgroundOpacity: 'transparent', accessibilityLabel: $L('Close'), spotlight: false}
+		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', backgroundOpacity: 'transparent', accessibilityLabel: $L('Close'), tabIndex: -1, spotlight: false}
 	],
 
 	/**

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -281,7 +281,7 @@ module.exports = kind(
 			]},
 			{name: 'client', kind: Control, tag: null}
 		]},
-		{name: 'showHideHandle', kind: PanelsHandle, classes: 'hidden', canGenerate: false, ontap: 'handleTap', onSpotlightLeft: 'handleSpotLeft', onSpotlightRight: 'handleSpotRight', onSpotlightFocused: 'handleFocused', onSpotlightBlur: 'handleBlur'},
+		{name: 'showHideHandle', kind: PanelsHandle, classes: 'hidden', canGenerate: false, ontap: 'handleTap', onSpotlightLeft: 'handleSpotLeft', onSpotlightRight: 'handleSpotRight', onSpotlightFocused: 'handleFocused', onSpotlightBlur: 'handleBlur', tabIndex: -1},
 		{name: 'showHideAnimator', kind: StyleAnimator, onComplete: 'showHideAnimationComplete'}
 	],
 


### PR DESCRIPTION
There are a couple controls that are not initially declared as
spottable but may become so at runtime. Setting tabIndex on them so
they are focusable for accessibility.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)