### PR TITLE
ENYO-2238: Fix not reading when press enter dismissOnEnter input

### DIFF
--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -325,13 +325,11 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: 'focused', method: function () {
-			this.set('accessibilityLive', this.focused ? null : 'polite');
-		}},
-		{path: 'spotted', method: function () {
+		{path: ['spotted', 'focused'], method: function () {
 			var text = '',
 				oInput = this.getInputControl();
 
+			this.set('accessibilityLive', this.focused ? null : 'polite');
 			if (oInput) {
 				if (oInput instanceof RichText && oInput.hasNode()) {
 					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('edit box');
@@ -342,7 +340,7 @@ module.exports = kind(
 					text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('edit box');
 				}
 			}
-			this.set('accessibilityLabel', this.spotted ? text : null);
+			this.set('accessibilityLabel', this.spotted && !this.focused ? text : null);
 		}}
 	]
 });


### PR DESCRIPTION
## Issue 
If Input type is 'dismissOnEnter:true', it does not read the value after 'Enter' button is clicked.

## Cause
In input focus state, spotted is true, and If user press enter, TV does not read again own inputDecorator's label because spotted is not changed.

## Fix
set spotted to true when input is focused in spotlightSelectHander, and if input type is dismissOnEnter and press enter, set spotted to true in new added keyupHandler. 

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com