### PR TITLE
ENYO-2446: Adding max-width 100% on header client

### DIFF
--- a/src/Header/Header.less
+++ b/src/Header/Header.less
@@ -119,6 +119,7 @@
 	.moon-header-client {
 		position: absolute;
 		bottom: 12px;
+		max-width: 100%;
 		left: 0;
 		right: 0;
 		text-align: right;	/* fallback in case text-align:end isn't supported */


### PR DESCRIPTION
Issue:
- When marquee text is used with 100% width inside of headerComponents,
  it is not have ellipsis when text is large enough.
- Marquee Text is having two times larger width than panel.

Fix:
- Add 100% max-width on moon-header-client. So that inner controls can
  not have larger width than panel.

Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>