### PR TITLE
ENYO-2449: ListAction: skip to destroy controls at creation time

### DIFF
--- a/src/ListActions/ListActions.js
+++ b/src/ListActions/ListActions.js
@@ -484,7 +484,9 @@ var ListActions = module.exports = kind(
 		var listAction, i;
 
 		this.listActionComponents = [];
-		this.$.listActions.destroyClientControls();
+		if (this.generated) {
+			this.$.listActions.destroyClientControls();
+		}
 
 		for (i = 0; (listAction = this.listActions[i]); i++) {
 			this.listActionComponents.push(this.createListActionComponent(listAction, owner));


### PR DESCRIPTION
### Issue
This is an additional work for ENYO-2218. As you see code change, client controls were destroyed no matter what they exist or not but it's not necessary at creation time

### Fix
Add guard code to skip destroying client controls at creation time

Enyo-DCO-1.1-Signed-off-by: Hunkyo Jung <hunkyo.jung@lge.com>