### PR TITLE
ENYO-1994: Apply accessibility on LightPanel

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -229,7 +229,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	accessibilityRole: 'region',
+	accessibilityRole: 'alert',
 
 	/**
 	* @private

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -40,23 +40,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	defaultKind: LightPanel,
-
-	// Accessibility
-
-	ariaObservers: [
-		{path: 'index', method: function () {
-			var panels = this.getPanels(),
-				active = panels[this.index],
-				l = panels.length,
-				panel;
-
-			while (--l >= 0) {
-				panel = panels[l];
-				panel.set('accessibilityRole', panel === active ? 'alert' : 'region');
-			}
-		}}
-	]
+	defaultKind: LightPanel
 
 });
 


### PR DESCRIPTION
## Issue 
LightPanel's animate property is default true. When LightPanel is moved, if animate is true, LightPanel role is remained as region though it is active.

## Cause
If animate is true, animateTo() is called. index is directly assigned with parameter. Thus, changed function is not called, so LightPanels can not observe index.

## Fix
set default role to alert.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>