### PR TITLE
toggle role on Panel when activated

### DIFF
--- a/src/Panel/Panel.js
+++ b/src/Panel/Panel.js
@@ -797,5 +797,34 @@ module.exports = kind(
 				return true;	// We stop header animation event bubble up here.
 			}
 		}
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	accessibilityRole: 'region',
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['title', 'accessibilityLabel', 'accessibilityHint'], method: function () {
+			var content = this.title,
+				prefix = this.accessibilityLabel || content || null,
+				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						prefix ||
+						null;
+
+			this.setAriaAttribute('aria-label', label);
+		}}
+	],
+
+	/**
+	* @private
+	*/
+	accessibilityLive: 'off'
 });


### PR DESCRIPTION
Give Panel a default role of region and toggle it to alert when
activated so it is read immediately. May need to revist if/when browser
will read region consistently when a contained control is focused.

Issue: ENYO-1994
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)