### PR TITLE
ENYO-2463: Correct semantics of marqueeOnRender for header.

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -103,7 +103,7 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{kind: Header, name: 'header', type: 'medium', marqueeOnRender: false, marqueeOnRenderDelay: 1000},
+		{kind: Header, name: 'header', type: 'medium', marqueeOnRenderDelay: 1000},
 		{name: 'client', classes: 'client'},
 		{name: 'spotlightPlaceholder', spotlight: false, style: 'width:0;height:0;'}
 	],


### PR DESCRIPTION
### Issue
We had originally set `marqueeOnRender:false` for `LightPanels` in order to prevent any unnecessary marqueeing i.e. the time between the panel rendering and `preTransition` being called. This would really only be an issue if we set a very small `marqueeOnRenderDelay` value. But semantically, this is not quite accurate and by extension not compatible with https://github.com/enyojs/moonstone/pull/2507, because we *do* want the header's title to marquee upon "render", just that our definition of "render" would be after the transition is complete, and so we control this programmatically via the panel lifecycle methods.

### Fix
We have removed the `marqueeOnRender:false` setting of the header in `LightPanels` - our value for `marqueeOnRenderDelay` is sufficiently large enough that this should not be a problem, by default. We may need to do some more thinking about supporting the case where this value is very small, or zero, but it seems to be a rare use case. As always, thoughts on this are welcome.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>