### PR TITLE
ENYO-2466: Accessibility: When the unit of SimpleIntegerPicker is nul…

### DIFF
--- a/src/SimpleIntegerPicker/SimpleIntegerPicker.js
+++ b/src/SimpleIntegerPicker/SimpleIntegerPicker.js
@@ -213,7 +213,7 @@ module.exports = kind(
 	*/
 	ariaObservers: [
 		{path: ['value', 'unit'], method: function () {
-			var text = this.value + ' ' + this.unit;
+			var text = this.unit ? this.value + ' ' + this.unit : this.value;
 
 			// It reads changed value only the case spotlight focus is on IntegerPicker
 			if (Spotlight.getCurrent() === this) {


### PR DESCRIPTION
…l, screen reader reads value with 'null' string.

Issue
When the unit set to null, it read 'value' + 'null'

Cause
Label string is set with this.value + ' ' +  this.unit

Fix
Add null checking for this.unit

https://jira2.lgsvl.com/browse/ENYO-2466
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>