### PR TITLE
ENYO-2448: Allow nav buttons to update disablement in creation time

### DIFF
--- a/src/SimplePicker/SimplePicker.js
+++ b/src/SimplePicker/SimplePicker.js
@@ -287,6 +287,9 @@ module.exports = kind(
 				// Force change handler, since the currently selected item actually changed
 				this.selectedIndexChanged();
 			}
+		}
+
+		if (this.$.buttonLeft && this.$.buttonRight) {
 			this.showHideNavButtons();
 		}
 	},

--- a/src/SimplePicker/SimplePicker.js
+++ b/src/SimplePicker/SimplePicker.js
@@ -189,6 +189,7 @@ module.exports = kind(
 	*/
 	create: function () {
 		Control.prototype.create.apply(this, arguments);
+		this._created = true;
 		this.animateChanged();
 		this.initializeActiveItem();
 		this.disabledChanged();
@@ -288,10 +289,7 @@ module.exports = kind(
 				this.selectedIndexChanged();
 			}
 		}
-
-		if (this.$.buttonLeft && this.$.buttonRight) {
-			this.showHideNavButtons();
-		}
+		if (this._created) this.showHideNavButtons();
 	},
 
 	/**


### PR DESCRIPTION
## Issue 
When child components are created in the creation time, nav buttons are shown as disabled.

## Cause
`this.generate` is always false in `create` function, which would skip executing `showHideNavButton` function to update the disablement status. 

## Fix
Change the condition for `showHideNavButton` in `addControl` function so that nav buttons' disablements are updated prior to being rendered.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>