### PR TITLE
ENYO-2492: Prevent spotting of inactive panels.

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -42,6 +42,34 @@ module.exports = kind(
 	*/
 	defaultKind: LightPanel,
 
+	/**
+	* @private
+	*/
+	addChild: function (control) {
+		LightPanels.prototype.addChild.apply(this, arguments);
+		if (control.parent === this.$.client) control.spotlightDisabled = true;
+	},
+
+	/**
+	* @private
+	*/
+	setupTransitions: function (was) {
+		this.updateSpottability(was, this.index);
+		LightPanels.prototype.setupTransitions.apply(this, arguments);
+	},
+
+	/**
+	* @private
+	*/
+	updateSpottability: function (from, to) {
+		var panels = this.getPanels(),
+			panelPrev = panels[from],
+			panelNext = panels[to];
+
+		if (panelPrev) panelPrev.spotlightDisabled = true;
+		if (panelNext) panelNext.spotlightDisabled = false;
+	},
+
 	// Accessibility
 
 	ariaObservers: [


### PR DESCRIPTION
### Issue
In the case where we have a static components block with spottable components, inactive panels are still spottable and cause Spotlight focus to effectively be lost.

### Fix
We now explicitly set the `spotlightDisabled` value accordingly. Technically, Spotlight checks the `showing` property to cover this case, but we had specifically wanted to avoid setting this property and waterfalling the `showingChanged` event, each time. I am open to revisiting this and weighing the pros and cons between the two approaches.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>