### PR TITLE
ENYO-2501: Lost focus when set initialFocusIndex on disabled item in DataList

### DIFF
--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -68,7 +68,10 @@ var DataListSpotlightSupport = {
 				child = this.childForIndex(inIndex);
 			}
 			subChild = inSubChild ? Spotlight.getChildren(child)[inSubChild] : child;
-			Spotlight.spot(subChild);
+			if (Spotlight.isSpottable(subChild)) 
+				Spotlight.spot(subChild);
+			else
+				Spotlight.spot(this); 
 		} else {
 			this._indexToFocus = inIndex;
 			this._subChildToFocus = inSubChild;

--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -68,10 +68,7 @@ var DataListSpotlightSupport = {
 				child = this.childForIndex(inIndex);
 			}
 			subChild = inSubChild ? Spotlight.getChildren(child)[inSubChild] : child;
-			if (Spotlight.isSpottable(subChild)) 
-				Spotlight.spot(subChild);
-			else
-				Spotlight.spot(this); 
+			Spotlight.spot(subChild) || Spotlight.spot(this); 
 		} else {
 			this._indexToFocus = inIndex;
 			this._subChildToFocus = inSubChild;


### PR DESCRIPTION
Issue:
DataList is give focus on specific item when initialFocusIndex is set.
But, when that item is disabled, Spotlight fails give focus.

Fix:
Check spottability on item before give focus, then give focus on list
instead when that item is not focusable. This workaround will give focus
to the first focusable item on list.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>