### PR TITLE
ENYO-2502: Lost focus when create DataList dynamically on LightPanel

### DIFF
--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -117,8 +117,9 @@ var DataListSpotlightSupport = {
 			this._indexToFocus = -1;
 		} else {
 			// Otherwise, check if the list was focused and if so, transfer focus to the first
-			// spottable child inside
-			if (Spotlight.getCurrent() == this) {
+			// spottable child inside. And we transfer focus when dummy is focused.
+			var current = Spotlight.getCurrent();
+			if (current == this || (current && current.name == 'spotlightPlaceholder') || (current && current.name == 'spotlightDummy')) {
 				Spotlight.spot(this);
 			}
 		}

--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -119,7 +119,7 @@ var DataListSpotlightSupport = {
 			// Otherwise, check if the list was focused and if so, transfer focus to the first
 			// spottable child inside. And we transfer focus when dummy is focused.
 			var current = Spotlight.getCurrent();
-			if (current == this || (current && current.name == 'spotlightPlaceholder') || (current && current.name == 'spotlightDummy')) {
+			if (current && (current === this || current.name == 'spotlightPlaceholder' || current.name == 'spotlightDummy')) {
 				Spotlight.spot(this);
 			}
 		}


### PR DESCRIPTION
Issue:
When datalist is created dynamically and there is no focusable item,
lightPanels is give focus to spotlightPlaceholder.
But, datalist is fails to give focus when didRender is called because
current focus is not datalist and datalist is not trying to transfer
focus to inner item.

Fix:
Add condition to see the current focus is on spotlightPlaceholder or
spotlightDummy.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>