### PR TITLE
Fixes ENYO-2431

### DIFF
--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -329,7 +329,7 @@ module.exports = kind(
 			var text = '',
 				oInput = this.getInputControl();
 
-			this.set('accessibilityLive', this.focused ? null : 'polite');
+			this.set('accessibilityLive', this.focused || !this.spotted ? null : 'polite');
 			if (oInput) {
 				if (oInput instanceof RichText && oInput.hasNode()) {
 					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('edit box');


### PR DESCRIPTION
Remove aria-live from InputDecorator when not spotted. This prevents the browser from reading the contents instead of the aria-label when spotting a different control.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)