### PR TITLE
Fix for: ENYO-1859

### DIFF
--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -285,6 +285,7 @@ var SimpleMonthPicker = kind(
 });
 
 /**
+* THIS KIND IS DEPRECATED.
 * {@link module:moonstone/Calendar~Calendar} is a control that displays a monthly calendar, with the
 * month name at the top and a grid of days, grouped into rows by week, below.
 *
@@ -298,6 +299,7 @@ var SimpleMonthPicker = kind(
 * {kind: Calendar, content: 'Calendar Title'}
 * ```
 *
+* @deprecated
 * @class Calendar
 * @ui
 * @public

--- a/src/Clock/Clock.js
+++ b/src/Clock/Clock.js
@@ -12,6 +12,7 @@ var
 
 var
 	LocaleInfo = require('enyo-ilib/LocaleInfo'),
+	Locale = require('enyo-ilib/Locale'),
 	DateFmt = require('enyo-ilib/DateFmt'),
 	dateFactory = require('enyo-ilib/DateFactory');
 
@@ -89,15 +90,19 @@ module.exports = kind(
 		date: undefined,
 
 		/**
-		* Current locale used for formatting. May be set after the control is
-		* created, in which case the control will be updated to reflect the
-		* new value.  Only valid if [iLib]{@glossary ilib} is loaded.
+		* This property will be __private__ in the future and is deprecated as a __public__
+		* property. It is used internally and _should not be used otherwise_.
 		*
-		* @type {String}
-		* @default ''
+		* This is an [iLib]{@glossary ilib} Locale instance. Setting this directly may have
+		* unexpected results. This class will automatically respond to application locale
+		* changes that use the {@link module:enyo/i18n~updateLocale} method.
+		*
+		* @deprecated
+		* @type {Locale}
+		* @default null
 		* @public
 		*/
-		locale: ''
+		locale: null
 	},
 
 	/**
@@ -151,7 +156,8 @@ module.exports = kind(
 	* @private
 	*/
 	initILib: function () {
-		this.ilibLocaleInfo = new LocaleInfo(this.locale || undefined);
+		this.locale = new Locale();
+		this.ilibLocaleInfo = new LocaleInfo(this.locale);
 		var clockPref = this.ilibLocaleInfo.getClock();
 		var clock = clockPref !== 'locale' ? clockPref : undefined;
 
@@ -198,14 +204,6 @@ module.exports = kind(
 		if (this.mode === 'normal') {
 			this.startJob('refresh', this.bindSafely('refreshJob'), this.getRefresh());
 		}
-	},
-
-	/**
-	* @private
-	*/
-	localeChanged: function () {
-		this._refresh();
-		this.updateDate();
 	},
 
 	/**

--- a/src/DateTimePickerBase/DateTimePickerBase.js
+++ b/src/DateTimePickerBase/DateTimePickerBase.js
@@ -13,7 +13,8 @@ var
 var
 	ilib = require('enyo-ilib'),
 	dateFactory = require('enyo-ilib/DateFactory'),
-	DateFmt = require('enyo-ilib/DateFmt');
+	DateFmt = require('enyo-ilib/DateFmt'),
+	Locale = require('enyo-ilib/Locale');
 
 var
 	ExpandableListItem = require('../ExpandableListItem');
@@ -30,9 +31,9 @@ var
 */
 
 /**
-* {@link module:moonstone/DateTimePickerBase~DateTimePickerBase} is a base kind implementing fuctionality shared by
-* {@link module:moonstone/DatePicker~DatePicker} and {@link module:moonstone/TimePicker~TimePicker}. It is not intended to be used
-* directly.
+* {@link module:moonstone/DateTimePickerBase~DateTimePickerBase} is a base kind implementing
+* fuctionality shared by {@link module:moonstone/DatePicker~DatePicker} and
+* {@link module:moonstone/TimePicker~TimePicker}. It is not intended to be used directly.
 *
 * @class DateTimePickerBase
 * @extends module:moonstone/ExpandableListItem~ExpandableListItem
@@ -90,23 +91,15 @@ module.exports = kind(
 		noneText: '',
 
 		/**
-		* The locale (in IETF format) used for picker formatting.
+		* This property will be __private__ in the future and is deprecated as a __public__
+		* property. It is used internally and _should not be used otherwise_.
 		*
-		* This setting only applies when the [iLib]{@glossary ilib} library is loaded.
+		* This is an [iLib]{@glossary ilib} Locale instance. Setting this directly may have
+		* unexpected results. This class will automatically respond to application locale
+		* changes that use the {@link module:enyo/i18n~updateLocale} method.
 		*
-		* When `iLib` is not present, U.S. English `(en-US)` formatting is applied.
-		*
-		* When `iLib` is present and `locale` is set to the default value `(null)`,
-		* the picker uses `iLib`'s current locale (which `iLib` tries to determine
-		* from the system).
-		*
-		* When `iLib` is present and an explicit `locale` is provided, that locale
-		* will be used (regardless of `iLib`'s current locale).
-		*
-		* The `locale` value may be changed after the picker is created; if this happens,
-		* the picker will be reformatted to reflect the new setting.
-		*
-		* @type {Object}
+		* @deprecated
+		* @type {Locale}
 		* @default null
 		* @public
 		*/
@@ -172,6 +165,7 @@ module.exports = kind(
 	* @private
 	*/
 	initILib: function () {
+		this.locale = new Locale();
 		var fmtParams = {
 			type: this.iLibFormatType,
 			useNative: false,
@@ -289,16 +283,6 @@ module.exports = kind(
 			this.expandContract();
 			return true;
 		}
-	},
-
-	/**
-	* @private
-	*/
-	localeChanged: function () {
-		// Our own locale property has changed, so we need to rebuild our child pickers
-		ilib.setLocale(this.locale);
-		this.iLibLocale = ilib.getLocale();
-		this.refresh();
 	},
 
 	/**


### PR DESCRIPTION
## Issue

Inconsistent and incorrect application of internal locale api's caused bad results when attempting to update to current locale.

## Fix

Update documentation, correctly use internal api's, and deprecate the Calendar widget that needs to be re-written to correctly make use of the locales.

Tied to these other PR's:

https://github.com/enyojs/enyo-strawman/pull/137 
https://github.com/enyojs/enyo-ilib/pull/146

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)