### PR TITLE
ENYO-2521: Make viewport a spotlight container without remembering last focus

### DIFF
--- a/src/ScrollStrategy/ScrollStrategy.js
+++ b/src/ScrollStrategy/ScrollStrategy.js
@@ -142,7 +142,7 @@ var MoonScrollStrategy = module.exports = kind(
 	*/
 	components: [
 		{name: 'clientContainer', kind: Control, classes: 'moon-scroller-client-wrapper', components: [
-			{name: 'viewport', kind: Control, classes:'moon-scroller-viewport', components: [
+			{name: 'viewport', kind: Control, spotlight: 'container', spotlightRememberFocus: false, classes:'moon-scroller-viewport', components: [
 				{name: 'client', kind: Control, classes: 'enyo-touch-scroller enyo-touch-scroller-client matrix-scroll-client matrix3dsurface'}
 			]}
 		]},

--- a/src/Scroller/Scroller.js
+++ b/src/Scroller/Scroller.js
@@ -226,6 +226,11 @@ if (platform.touch) {
 		/**
 		* @private
 		*/
+		spotlightRememberFocus: false,
+
+		/**
+		* @private
+		*/
 		handlePageUpDownKey: false,
 
 		/**


### PR DESCRIPTION
Issue:
When there is a disabled item between items on scroller, there is a
chance to return paging control as a best match even when there is
focusable item below. This is because paging control is having smaller
y distance than below item.

Fix:
It is risky to alter _getPrecedenceValue logic on spotlight.
But, we have new option that is not remembering last focus on container.
We set viewport of scroller as spotlight container and set option
spotlightRememberFocus as false. So, spotlight can consider items first
on 5way focus move.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>