### PR TITLE
ENYO-2346: Accessibility: When ExpandableInput is focused, screen rea…

### DIFF
--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -12,6 +12,7 @@ var
 	Spotlight = require('spotlight');
 
 var
+	$L = require('../i18n'),
 	ExpandableListItem = require('../ExpandableListItem'),
 	Input = require('../Input'),
 	InputDecorator = require('../InputDecorator');
@@ -263,5 +264,15 @@ module.exports = kind(
 			this.expandContract();
 		}
 		return true;
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @default $L('edit box')
+	* @type {String}
+	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityHint
+	* @public
+	*/
+	accessibilityHint: $L('edit box')
 });


### PR DESCRIPTION
…der does not read 'edit box' hint.

Issue
There is no 'edit box' hint on ExpandableInput

Cause
The hint removed after refactoring expandable controls

Fix
Add accessibilityHint 'edit box' in ExpandableInput

https://jira2.lgsvl.com/browse/ENYO-2346
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>