### PR TITLE
ENYO-2468: Accessibility: Screen reader does not read the unit of Dat…

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -346,7 +346,7 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['dayText', 'monthText', 'yearText', 'locale'], method: function () {
+		{path: ['dayText', 'monthText', 'yearText'], method: function () {
 			this.$.day.set('accessibilityLabel', this.dayText);
 			this.$.month.set('accessibilityLabel', this.monthText);
 			this.$.year.set('accessibilityLabel', this.yearText);

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -346,7 +346,7 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['dayText', 'monthText', 'yearText'], method: function () {
+		{path: ['dayText', 'monthText', 'yearText', 'locale'], method: function () {
 			this.$.day.set('accessibilityLabel', this.dayText);
 			this.$.month.set('accessibilityLabel', this.monthText);
 			this.$.year.set('accessibilityLabel', this.yearText);

--- a/src/IntegerPicker/IntegerPicker.js
+++ b/src/IntegerPicker/IntegerPicker.js
@@ -212,7 +212,7 @@ module.exports = kind(
 		// FIXME: TranslateScrollStrategy doesn't work with the current design of this component so
 		// we're forcing TouchScrollStrategy
 		{kind: Scroller, strategyKind: TouchScrollStrategy, thumb: false, touch: true, useMouseWheel: false, classes: 'moon-scroll-picker', components:[
-			{name: 'repeater', kind: FlyweightRepeater, classes: 'moon-scroll-picker-repeater', ondragstart: 'dragstart', onSetupItem: 'setupItem', noSelect: true, accessibilityRole: 'spinbutton', components: [
+			{name: 'repeater', kind: FlyweightRepeater, classes: 'moon-scroll-picker-repeater', ondragstart: 'dragstart', onSetupItem: 'setupItem', noSelect: true, components: [
 				{name: 'item', kind: Control, classes: 'moon-scroll-picker-item'}
 			]},
 			{name: 'buffer', kind: Control, accessibilityDisabled: true, classes: 'moon-scroll-picker-buffer'}
@@ -624,6 +624,7 @@ module.exports = kind(
 	* @private
 	*/
 	spotlightFocused: function () {
+		this.set('spotted', true);
 		this.bubble('onRequestScrollIntoView');
 	},
 
@@ -631,6 +632,7 @@ module.exports = kind(
 	* @private
 	*/
 	spotlightBlur: function () {
+		this.set('spotted', false);
 		this.hideTopOverlay();
 		this.hideBottomOverlay();
 	},
@@ -696,29 +698,32 @@ module.exports = kind(
 	// Accessibility
 
 	/**
-	* @default $L('change a value with up/down button')
+	* @default 'spinbutton'
 	* @type {String}
-	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityHint
+	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityRole
 	* @public
 	*/
-	accessibilityHint: $L('change a value with up/down button'),
+	accessibilityRole: 'spinbutton',
 
 	/**
 	* @private
 	*/
 	ariaObservers: [
-		{from: 'min', method: function () {
-			this.$.repeater.setAriaAttribute('aria-valuemin', this.min);
-		}},
-		{from: 'max', method: function () {
-			this.$.repeater.setAriaAttribute('aria-valuemax', this.max);
-		}},
-		{from: 'value', method: function () {
-			// It reads changed value only the case spotlight focus is on IntegerPicker
-			if (Spotlight.getCurrent() === this) {
-				this.$.repeater.setAriaAttribute('aria-valuenow', this.value);
+		{from: 'min', to: 'aria-valuemin'},
+		{from: 'max', to: 'aria-valuemax'},
+		{path: 'value',  method: function () {
+			// When value is changed, it reads only value
+			if (this.spotted) {
+				this.set('accessibilityHint', null);
+				this.setAriaAttribute('aria-valuenow', this.value);
 			}
-			this.set('accessibilityLabel', this.value);
+		}},
+		{path: 'spotted',  method: function () {
+			// When spotlight is focused, it reads value with hint
+			if (this.spotted) {
+				this.set('accessibilityHint', $L('change a value with up/down button'));
+				this.setAriaAttribute('aria-valuenow', this.value);
+			}
 		}}
 	]
 });

--- a/src/IntegerPicker/IntegerPicker.js
+++ b/src/IntegerPicker/IntegerPicker.js
@@ -715,15 +715,22 @@ module.exports = kind(
 			// When value is changed, it reads only value
 			if (this.spotted) {
 				this.set('accessibilityHint', null);
-				this.setAriaAttribute('aria-valuenow', this.value);
+				this.ariaValue();
 			}
 		}},
 		{path: 'spotted',  method: function () {
 			// When spotlight is focused, it reads value with hint
 			if (this.spotted) {
 				this.set('accessibilityHint', $L('change a value with up down button'));
-				this.setAriaAttribute('aria-valuenow', this.value);
+				this.ariaValue();
 			}
 		}}
-	]
+	],
+
+	/**
+	* @private
+	*/
+	ariaValue: function () {
+		this.setAriaAttribute('aria-valuenow', this.value);
+	}
 });

--- a/src/IntegerPicker/IntegerPicker.js
+++ b/src/IntegerPicker/IntegerPicker.js
@@ -19,8 +19,8 @@ var
 	TouchScrollStrategy = ScrollStrategy.Touch;
 
 var
-	Spotlight = require('spotlight'),
 	$L = require('../i18n');
+
 /**
 * Fires when the currently selected value changes.
 *

--- a/src/IntegerPicker/IntegerPicker.js
+++ b/src/IntegerPicker/IntegerPicker.js
@@ -721,7 +721,7 @@ module.exports = kind(
 		{path: 'spotted',  method: function () {
 			// When spotlight is focused, it reads value with hint
 			if (this.spotted) {
-				this.set('accessibilityHint', $L('change a value with up/down button'));
+				this.set('accessibilityHint', $L('change a value with up down button'));
 				this.setAriaAttribute('aria-valuenow', this.value);
 			}
 		}}

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -171,7 +171,7 @@ var MeridiemPicker = kind(
 		{path: 'spotted',  method: function () {
 			// When spotlight is focused, it reads value with hint
 			if (this.spotted) {
-				this.set('accessibilityHint', $L('change a value with up/down button'));
+				this.set('accessibilityHint', $L('change a value with up down button'));
 				this.setAriaAttribute('aria-valuetext', this.meridiems[this.value].name);
 			}
 		}}

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -162,7 +162,18 @@ var MeridiemPicker = kind(
 	
 	ariaObservers: [
 		{path: 'value', method: function () {
-			this.setAriaAttribute('aria-valuetext', this.meridiems[this.value]);
+			// When value is changed, it reads only value
+			if (this.spotted) {
+				this.set('accessibilityHint', null);
+				this.setAriaAttribute('aria-valuetext', this.meridiems[this.value].name);
+			}
+		}},
+		{path: 'spotted',  method: function () {
+			// When spotlight is focused, it reads value with hint
+			if (this.spotted) {
+				this.set('accessibilityHint', $L('change a value with up/down button'));
+				this.setAriaAttribute('aria-valuetext', this.meridiems[this.value].name);
+			}
 		}}
 	]
 });
@@ -225,7 +236,7 @@ var HourMinutePickerBase = kind(
 
 	ariaObservers: [
 		{path: 'value', method: function () {
-			if (this.date && this.range) {
+			if (this.spotted && this.date && this.range) {
 				var value = this.format(this.value % this.range);
 				this.setAriaAttribute('aria-valuenow', value);
 			}
@@ -766,7 +777,7 @@ var TimePicker = module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['dayText', 'monthText', 'yearText'], method: function () {
+		{path: ['dayText', 'monthText', 'yearText', 'locale'], method: function () {
 			this.$.hour.set('accessibilityLabel', this.hourText);
 			this.$.minute.set('accessibilityLabel', this.minuteText);
 			if (this.$.meridiem) this.$.meridiem.set('accessibilityLabel', this.meridiemText);

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -160,22 +160,9 @@ var MeridiemPicker = kind(
 
 	// Accessibility
 	
-	ariaObservers: [
-		{path: 'value', method: function () {
-			// When value is changed, it reads only value
-			if (this.spotted) {
-				this.set('accessibilityHint', null);
-				this.setAriaAttribute('aria-valuetext', this.meridiems[this.value].name);
-			}
-		}},
-		{path: 'spotted',  method: function () {
-			// When spotlight is focused, it reads value with hint
-			if (this.spotted) {
-				this.set('accessibilityHint', $L('change a value with up down button'));
-				this.setAriaAttribute('aria-valuetext', this.meridiems[this.value].name);
-			}
-		}}
-	]
+	ariaValue: function () {
+		this.setAriaAttribute('aria-valuetext', this.meridiems[this.value].name);
+	}
 });
 
 /**
@@ -234,14 +221,12 @@ var HourMinutePickerBase = kind(
 
 	// Accessibility
 
-	ariaObservers: [
-		{path: 'value', method: function () {
-			if (this.spotted && this.date && this.range) {
-				var value = this.format(this.value % this.range);
-				this.setAriaAttribute('aria-valuenow', value);
-			}
-		}}
-	]
+	ariaValue: function () {
+		if (this.date && this.range) {
+			var value = this.format(this.value % this.range);
+			this.setAriaAttribute('aria-valuenow', value);
+		}
+	}
 });
 
 /**
@@ -777,7 +762,7 @@ var TimePicker = module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['dayText', 'monthText', 'yearText', 'locale'], method: function () {
+		{path: ['hourText', 'minuteText', 'meridiemText'], method: function () {
 			this.$.hour.set('accessibilityLabel', this.hourText);
 			this.$.minute.set('accessibilityLabel', this.minuteText);
 			if (this.$.meridiem) this.$.meridiem.set('accessibilityLabel', this.meridiemText);


### PR DESCRIPTION
…aPicker and TimePicker.

Issue
It doesn't read unit(day, month, hour etc) on DatePicker and TimePicker

Cause
aria-label is overrided in IntegerPicker after it is set by units
in TimePicker and DatePicker.

Fix
On IntergerPicker we just handle only accessibilityHint and aria-valuenow
to keep the accessibilityLabel which is set by TimePicker and DatePicker.
To do this we set the accessibilityRole of IntegerPicker to spinbutton and
only set the hint when spotlight is focused and then remove hint during
value changed.

https://jira2.lgsvl.com/browse/ENYO-2468
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>