### PR TITLE
Fixes ENYO-2516

### DIFF
--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -285,6 +285,7 @@ var SimpleMonthPicker = kind(
 });
 
 /**
+* THIS KIND IS DEPRECATED.
 * {@link module:moonstone/Calendar~Calendar} is a control that displays a monthly calendar, with the
 * month name at the top and a grid of days, grouped into rows by week, below.
 *
@@ -298,6 +299,7 @@ var SimpleMonthPicker = kind(
 * {kind: Calendar, content: 'Calendar Title'}
 * ```
 *
+* @deprecated
 * @class Calendar
 * @ui
 * @public

--- a/src/Clock/Clock.js
+++ b/src/Clock/Clock.js
@@ -12,6 +12,7 @@ var
 
 var
 	LocaleInfo = require('enyo-ilib/LocaleInfo'),
+	Locale = require('enyo-ilib/Locale'),
 	DateFmt = require('enyo-ilib/DateFmt'),
 	dateFactory = require('enyo-ilib/DateFactory');
 
@@ -89,15 +90,19 @@ module.exports = kind(
 		date: undefined,
 
 		/**
-		* Current locale used for formatting. May be set after the control is
-		* created, in which case the control will be updated to reflect the
-		* new value.  Only valid if [iLib]{@glossary ilib} is loaded.
+		* This property will be __private__ in the future and is deprecated as a __public__
+		* property. It is used internally and _should not be used otherwise_.
 		*
-		* @type {String}
-		* @default ''
+		* This is an [iLib]{@glossary ilib} Locale instance. Setting this directly may have
+		* unexpected results. This class will automatically respond to application locale
+		* changes that use the {@link module:enyo/i18n~updateLocale} method.
+		*
+		* @deprecated
+		* @type {Locale}
+		* @default null
 		* @public
 		*/
-		locale: ''
+		locale: null
 	},
 
 	/**
@@ -151,7 +156,8 @@ module.exports = kind(
 	* @private
 	*/
 	initILib: function () {
-		this.ilibLocaleInfo = new LocaleInfo(this.locale || undefined);
+		this.locale = new Locale();
+		this.ilibLocaleInfo = new LocaleInfo(this.locale);
 		var clockPref = this.ilibLocaleInfo.getClock();
 		var clock = clockPref !== 'locale' ? clockPref : undefined;
 
@@ -198,14 +204,6 @@ module.exports = kind(
 		if (this.mode === 'normal') {
 			this.startJob('refresh', this.bindSafely('refreshJob'), this.getRefresh());
 		}
-	},
-
-	/**
-	* @private
-	*/
-	localeChanged: function () {
-		this._refresh();
-		this.updateDate();
 	},
 
 	/**

--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -211,7 +211,7 @@ module.exports = kind(
 	*/
 	tools: [
 		{name: 'client', kind: Control, classes: 'moon-neutral moon-contextual-popup-client'},
-		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', backgroundOpacity: 'transparent', accessibilityLabel: $L('Close'), spotlight: false}
+		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', backgroundOpacity: 'transparent', accessibilityLabel: $L('Close'), tabIndex: -1, spotlight: false}
 	],
 
 	/**

--- a/src/DateTimePickerBase/DateTimePickerBase.js
+++ b/src/DateTimePickerBase/DateTimePickerBase.js
@@ -300,6 +300,7 @@ module.exports = kind(
 			// changed, so we'll just update the child pickers
 			this.setChildPickers();
 		}
+		this.notify('currentValueText');
 	},
 
 	/**

--- a/src/DateTimePickerBase/DateTimePickerBase.js
+++ b/src/DateTimePickerBase/DateTimePickerBase.js
@@ -13,7 +13,8 @@ var
 var
 	ilib = require('enyo-ilib'),
 	dateFactory = require('enyo-ilib/DateFactory'),
-	DateFmt = require('enyo-ilib/DateFmt');
+	DateFmt = require('enyo-ilib/DateFmt'),
+	Locale = require('enyo-ilib/Locale');
 
 var
 	ExpandableListItem = require('../ExpandableListItem');
@@ -30,9 +31,9 @@ var
 */
 
 /**
-* {@link module:moonstone/DateTimePickerBase~DateTimePickerBase} is a base kind implementing fuctionality shared by
-* {@link module:moonstone/DatePicker~DatePicker} and {@link module:moonstone/TimePicker~TimePicker}. It is not intended to be used
-* directly.
+* {@link module:moonstone/DateTimePickerBase~DateTimePickerBase} is a base kind implementing
+* fuctionality shared by {@link module:moonstone/DatePicker~DatePicker} and
+* {@link module:moonstone/TimePicker~TimePicker}. It is not intended to be used directly.
 *
 * @class DateTimePickerBase
 * @extends module:moonstone/ExpandableListItem~ExpandableListItem
@@ -90,23 +91,15 @@ module.exports = kind(
 		noneText: '',
 
 		/**
-		* The locale (in IETF format) used for picker formatting.
+		* This property will be __private__ in the future and is deprecated as a __public__
+		* property. It is used internally and _should not be used otherwise_.
 		*
-		* This setting only applies when the [iLib]{@glossary ilib} library is loaded.
+		* This is an [iLib]{@glossary ilib} Locale instance. Setting this directly may have
+		* unexpected results. This class will automatically respond to application locale
+		* changes that use the {@link module:enyo/i18n~updateLocale} method.
 		*
-		* When `iLib` is not present, U.S. English `(en-US)` formatting is applied.
-		*
-		* When `iLib` is present and `locale` is set to the default value `(null)`,
-		* the picker uses `iLib`'s current locale (which `iLib` tries to determine
-		* from the system).
-		*
-		* When `iLib` is present and an explicit `locale` is provided, that locale
-		* will be used (regardless of `iLib`'s current locale).
-		*
-		* The `locale` value may be changed after the picker is created; if this happens,
-		* the picker will be reformatted to reflect the new setting.
-		*
-		* @type {Object}
+		* @deprecated
+		* @type {Locale}
 		* @default null
 		* @public
 		*/
@@ -172,6 +165,7 @@ module.exports = kind(
 	* @private
 	*/
 	initILib: function () {
+		this.locale = new Locale();
 		var fmtParams = {
 			type: this.iLibFormatType,
 			useNative: false,
@@ -289,16 +283,6 @@ module.exports = kind(
 			this.expandContract();
 			return true;
 		}
-	},
-
-	/**
-	* @private
-	*/
-	localeChanged: function () {
-		// Our own locale property has changed, so we need to rebuild our child pickers
-		ilib.setLocale(this.locale);
-		this.iLibLocale = ilib.getLocale();
-		this.refresh();
 	},
 
 	/**

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -12,6 +12,7 @@ var
 	Control = require('enyo/Control');
 
 var
+	$L = require('../i18n'),
 	Popup = require('../Popup'),
 	IconButton = require('../IconButton'),
 	BodyText = require('../BodyText'),
@@ -142,7 +143,7 @@ module.exports = kind(
 	* @private
 	*/
 	tools: [
-		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', backgroundOpacity: 'transparent', showing: false},
+		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', accessibilityLabel: $L('close'), backgroundOpacity: 'transparent', showing: false},
 		{kind: Control, classes: 'moon-dialog-client-wrapper', components: [
 			{name: 'client', kind: Control, classes: 'moon-dialog-client'},
 			{components: [

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -367,5 +367,26 @@ module.exports = kind(
 			this.bubble('onRequestSetupBounds');
 		}
 		return true;
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['content', 'currentValueText', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+			var content = this.get('content') + ' ' + this.get('currentValueText') ,
+				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
+				prefix = this.accessibilityLabel || content || null,
+				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						null;
+
+				// header gets spotlight focus, it also can get dom focus
+				this.$.header.setAriaAttribute('tabindex', focusable ? 0 : null);
+				this.$.header.setAriaAttribute('aria-label', label);
+		}}
+	]
 });

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -194,7 +194,12 @@ module.exports = kind(
 		{from: 'disabled', to: '$.header.disabled'},
 		{from: 'content', to: '$.header.label'},
 		{from: 'currentValueShowing', to: '$.header.textShowing'},
-		{from: 'currentValueText', to: '$.header.text'}
+		{from: 'currentValueText', to: '$.header.text'},
+
+		// Accessibility
+		{from: 'accessibilityHint', to: '$.header.accessibilityHint'},
+		{from: 'accessibilityLabel', to: '$.header.accessibilityLabel'},
+		{from: 'accessibilityDisabled', to: '$.header.accessibilityDisabled'}
 	],
 
 	/**
@@ -367,26 +372,5 @@ module.exports = kind(
 			this.bubble('onRequestSetupBounds');
 		}
 		return true;
-	},
-
-	// Accessibility
-
-	/**
-	* @private
-	*/
-	ariaObservers: [
-		{path: ['content', 'currentValueText', 'accessibilityHint', 'accessibilityLabel'], method: function () {
-			var content = this.get('content') + ' ' + this.get('currentValueText') ,
-				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
-				prefix = this.accessibilityLabel || content || null,
-				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
-						this.accessibilityHint ||
-						this.accessibilityLabel ||
-						null;
-
-				// header gets spotlight focus, it also can get dom focus
-				this.$.header.setAriaAttribute('tabindex', focusable ? 0 : null);
-				this.$.header.setAriaAttribute('aria-label', label);
-		}}
-	]
+	}
 });

--- a/src/GridListImageItem/GridListImageItem.js
+++ b/src/GridListImageItem/GridListImageItem.js
@@ -122,15 +122,12 @@ module.exports = kind(
 	ariaObservers: [
 		{path: ['caption', 'subCaption', 'accessibilityHint', 'accessibilityLabel'], method: function () {
 			var content = this.caption + ' ' + this.subCaption,
-				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
 				prefix = this.accessibilityLabel || content || null,
 				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityHint ||
 						this.accessibilityLabel ||
 						null;
 
-				// GridListImageItem gets spotlight focus, it also can get dom focus
-				this.setAriaAttribute('tabindex', focusable ? 0 : null);
 				this.setAriaAttribute('aria-label', label);
 		}}
 	]

--- a/src/GridListImageItem/GridListImageItem.js
+++ b/src/GridListImageItem/GridListImageItem.js
@@ -112,5 +112,26 @@ module.exports = kind(
 		if (inEvent.originator === this) {
 			this.bubble('onRequestScrollIntoView');
 		}
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['caption', 'subCaption', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+			var content = this.caption + ' ' + this.subCaption,
+				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
+				prefix = this.accessibilityLabel || content || null,
+				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						null;
+
+				// GridListImageItem gets spotlight focus, it also can get dom focus
+				this.setAriaAttribute('tabindex', focusable ? 0 : null);
+				this.setAriaAttribute('aria-label', label);
+		}}
+	]
 });

--- a/src/ImageItem/ImageItem.js
+++ b/src/ImageItem/ImageItem.js
@@ -141,15 +141,12 @@ module.exports = kind(
 	ariaObservers: [
 		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
 			var content = this.label + ' ' + this.text ,
-				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
 				prefix = this.accessibilityLabel || content || null,
 				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityHint ||
 						this.accessibilityLabel ||
 						null;
 
-				// ImageItem gets spotlight focus, it also can get dom focus
-				this.setAriaAttribute('tabindex', focusable ? 0 : null);
 				this.setAriaAttribute('aria-label', label);
 		}}
 	]

--- a/src/ImageItem/ImageItem.js
+++ b/src/ImageItem/ImageItem.js
@@ -131,5 +131,26 @@ module.exports = kind(
 	*/
 	imageAlignRightChanged: function () {
 		this.addRemoveClass('align-right', this.imageAlignRight);
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+			var content = this.label + ' ' + this.text ,
+				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
+				prefix = this.accessibilityLabel || content || null,
+				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						null;
+
+				// ImageItem gets spotlight focus, it also can get dom focus
+				this.setAriaAttribute('tabindex', focusable ? 0 : null);
+				this.setAriaAttribute('aria-label', label);
+		}}
+	]
 });

--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -329,7 +329,7 @@ module.exports = kind(
 			var text = '',
 				oInput = this.getInputControl();
 
-			this.set('accessibilityLive', this.focused ? null : 'polite');
+			this.set('accessibilityLive', this.focused || !this.spotted ? null : 'polite');
 			if (oInput) {
 				if (oInput instanceof RichText && oInput.hasNode()) {
 					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('edit box');

--- a/src/LabeledTextItem/LabeledTextItem.js
+++ b/src/LabeledTextItem/LabeledTextItem.js
@@ -94,15 +94,12 @@ module.exports = kind(
 	ariaObservers: [
 		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
 			var content = this.label + ' ' + this.text ,
-				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
 				prefix = this.accessibilityLabel || content || null,
 				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityHint ||
 						this.accessibilityLabel ||
 						null;
 
-				// LabeledTextItem gets spotlight focus, it also can get dom focus
-				this.setAriaAttribute('tabindex', focusable ? 0 : null);
 				this.setAriaAttribute('aria-label', label);
 		}}
 	]

--- a/src/LabeledTextItem/LabeledTextItem.js
+++ b/src/LabeledTextItem/LabeledTextItem.js
@@ -84,5 +84,26 @@ module.exports = kind(
 	components:[
 		{name: 'header', kind: Marquee.Text, classes: 'moon-labeledtextitem-header'},
 		{name: 'text', classes: 'moon-labeledtextitem-text'}
+	],
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+			var content = this.label + ' ' + this.text ,
+				focusable = this.accessibilityLabel || content || this.accessibilityHint || null,
+				prefix = this.accessibilityLabel || content || null,
+				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint ||
+						this.accessibilityLabel ||
+						null;
+
+				// LabeledTextItem gets spotlight focus, it also can get dom focus
+				this.setAriaAttribute('tabindex', focusable ? 0 : null);
+				this.setAriaAttribute('aria-label', label);
+		}}
 	]
 });

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -281,7 +281,7 @@ module.exports = kind(
 			]},
 			{name: 'client', kind: Control, tag: null}
 		]},
-		{name: 'showHideHandle', kind: PanelsHandle, classes: 'hidden', canGenerate: false, ontap: 'handleTap', onSpotlightLeft: 'handleSpotLeft', onSpotlightRight: 'handleSpotRight', onSpotlightFocused: 'handleFocused', onSpotlightBlur: 'handleBlur'},
+		{name: 'showHideHandle', kind: PanelsHandle, classes: 'hidden', canGenerate: false, ontap: 'handleTap', onSpotlightLeft: 'handleSpotLeft', onSpotlightRight: 'handleSpotRight', onSpotlightFocused: 'handleFocused', onSpotlightBlur: 'handleBlur', tabIndex: -1},
 		{name: 'showHideAnimator', kind: StyleAnimator, onComplete: 'showHideAnimationComplete'}
 	],
 

--- a/src/ScrollStrategy/ScrollStrategy.js
+++ b/src/ScrollStrategy/ScrollStrategy.js
@@ -429,6 +429,10 @@ var MoonScrollStrategy = module.exports = kind(
 			}
 
 			this.scrollTo(x, y);
+			if (!isScrolling && this.thumb) {
+				this.showThumbs();
+				this.delayHideThumbs(100);
+			}
 			event.preventDefault();
 			this.scrollBounds = null;
 			return true;

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -17,6 +17,9 @@ var
 	ProgressBar = require('../ProgressBar'),
 	IconButton = require('../IconButton');
 
+var
+	$L = require('../i18n');
+
 /**
 * Fires when bar position is set.
 *
@@ -731,7 +734,7 @@ module.exports = kind(
 	* @private
 	*/
 	spotSelect: function () {
-		this.selected = !this.selected;
+		this.set('selected', !this.selected);
 		if (this.popup) {
 			this.$.popup.setShowing(this.selected);
 			if (this.selected) {
@@ -754,7 +757,7 @@ module.exports = kind(
 			if (this.$.popup) {
 				this.$.popup.hide();
 			}
-			this.selected = false;
+			this.set('selected', false);
 		}
 	},
 
@@ -923,12 +926,38 @@ module.exports = kind(
 			this.setAriaAttribute('aria-disabled', this.disabled || null);
 		}},
 		{path: 'enableJumpIncrement', method: function () {
+			// if enableJumpIncrement is true we set the spinbutton role to this.$.slider to be able to
+			// read accessibilityHint of buttons.
 			if (this.enableJumpIncrement) {
-				this.$.slider.setAriaAttribute('aria-labelledby', this.id);
+				this.$.slider.set('accessibilityRole', 'slider');
+				this.$.buttonLeft.set('accessibilityHint', $L('press ok button to decrease the value'));
+				this.$.buttonRight.set('accessibilityHint', $L('press ok button to increase the value'));
+			}
+		}},
+		{path: 'selected', method: function () {
+			if (this.selected) {
+				// avoid using readAlert api, temporary set accessibilityRole to alert
+				// this will be reset on resetAccessibilityProperties
+				var hint = (this.get('orientation') == 'horizontal') ? 
+								$L('change a value with left right button') : $L('change a value with up down button');
+				this.set('accessibilityRole', 'alert');
+				this.set('accessibilityLive', 'off');
+				this.set('accessibilityHint', hint);
+			} else {
+				this.resetAccessibilityProperties();
 			}
 		}},
 		{path: ['value', 'popupContent', 'dragging'], method: 'ariaValue'}
 	],
+
+	/** 
+	* @private
+	*/
+	resetAccessibilityProperties : function() {
+		this.set('accessibilityRole', !this.enableJumpIncrement ? 'spinbutton' : null);
+		this.set('accessibilityLive', null);
+		this.set('accessibilityHint', null);
+	},
 
 	/**
 	* Overriding {@link module:moonstone/ProgressBar~ProgressBar#ariaValue} to guard updating value
@@ -937,9 +966,18 @@ module.exports = kind(
 	* @private
 	*/
 	ariaValue: function () {
-		var attr = this.popupContent ? 'aria-valuetext' : 'aria-valuenow';
+		var attr = this.popup ? 'aria-valuetext' : 'aria-valuenow',
+			text = (this.popup && this.$.popupLabel)? this.$.popupLabel.getContent() : this.value;
+			
 		if (!this.dragging) {
-			this.setAriaAttribute(attr, this.popupContent || this.value);
+			this.resetAccessibilityProperties();
+			this.setAriaAttribute(attr, text);
+			if (this.enableJumpIncrement) {
+				this.$.slider.setAriaAttribute(attr, text);
+				this.$.buttonLeft.set('accessibilityLabel', String(text));
+				this.$.buttonRight.set('accessibilityLabel', String(text));
+			}
 		}
+
 	}
 });


### PR DESCRIPTION
For subkinds of DateTimePickerBase, the value of currentValueText is
formatted for the locale. The local locale member is deprecated by
ENYO-1859 so we must manually notify observers of currentValueText to
refetch its value when the locale changes.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)