### PR TITLE
ENYO-2494: Contextual Popup Buttons once again have their chevron arrows

### DIFF
--- a/css/moonstone-mixins.less
+++ b/css/moonstone-mixins.less
@@ -52,6 +52,12 @@
 	}
 }
 
+// Asign font-kerning rules in a non-proprietary way. Default value being "normal", to enable kerning.
+.font-kerning(@val: normal) {
+	-webkit-font-kerning: @val;
+	font-kerning: @val;
+}
+
 // THIS IS AN EXACT COPY OF THE MIXINS IN ENYO - THIS IS TEMPORARY SINCE LIBRARIES CURRENTLY
 // DO NOT SUPPORT DEPENDENCIES WHEN BUILDING STANDALONE AT THE MOMENT
 

--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -1,8 +1,3 @@
-.font-kerning {
-	-webkit-font-kerning: normal;
-	font-kerning: normal;
-}
-
 // mixin classes for create the moontone text classes
 .moon-text-base (@font-size) {
 	font-family: @moon-font-family;

--- a/src/ContextualPopupButton/ContextualPopupButton.less
+++ b/src/ContextualPopupButton/ContextualPopupButton.less
@@ -14,6 +14,7 @@
 		font-size: @moon-contextual-arrow-font-size;
 		line-height: @moon-button-height - 2 * @moon-button-border-width;
 		color: @moon-accent;
+		.font-kerning(none);
 	}
 	&.small:after {
 		line-height: @moon-button-small-height - 2 * @moon-button-border-width;


### PR DESCRIPTION
The Moonstone Icon font (as of the current version) has no kerning information, which means if kerning rules are enabled, none of its glyphs render. We must reset anything that uses the font to *not* use kerning "normal".

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>