### PR TITLE
ENYO-2521: Add spotlightPrecedence option handler

### DIFF
--- a/src/Scroller/Scroller.js
+++ b/src/Scroller/Scroller.js
@@ -197,6 +197,16 @@ if (platform.touch) {
 		},
 
 		/**
+		* @private
+		*/
+		decorateEvent: function (nom, event, sender) {
+			this.inherited(arguments);
+			if (this.spotlightPrecedence && nom.indexOf('onSpotlight') > -1) {
+				event.spotlightPrecedence = this.spotlightPrecedence;
+			}
+		},
+
+		/**
 		* If `true`, scroll events are not allowed to propagate.
 		*
 		* @private


### PR DESCRIPTION
Issue:
Spotlight is having fixed calculation weight factor on
_getPrecedenceValue. But, there is some cases that angle is more
important than distance like this issue.

Fix:
We add an option to setup the weight. So, developer can set option on
each control.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>