### PR TITLE
ENYO-2539: LabeledTextItem: Text direction is not updated for right-to-left text

### DIFF
--- a/src/LabeledTextItem/LabeledTextItem.js
+++ b/src/LabeledTextItem/LabeledTextItem.js
@@ -69,13 +69,13 @@ module.exports = kind(
 		*/
 		text: ''
 	},
-	
+
 	/**
 	* @private
 	*/
 	bindings: [
 		{from: 'label', to: '$.header.content'},
-		{from: 'text', to: '$.text.content'}
+		{from: 'text', to: '$.text.content', transform: 'setTextWithDirection'}
 	],
 
 	/**
@@ -85,6 +85,14 @@ module.exports = kind(
 		{name: 'header', kind: Marquee.Text, classes: 'moon-labeledtextitem-header'},
 		{name: 'text', classes: 'moon-labeledtextitem-text'}
 	],
+
+	/**
+	/* @private
+	*/
+	setTextWithDirection: function(val) {
+		this.$.text.detectTextDirectionality(val);
+		return val;
+	},
 
 	// Accessibility
 


### PR DESCRIPTION
### Issue
When text in LabeledTextItem is updated with LTR, RTL or a mix of both, base direction is not properly updated.

### Fix
If binding for the text is triggered, we check the directionality of the given text.