### PR TITLE
ENYO-2499: Accessibility: Screen reader reads popup contents repeated…

### DIFF
--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -81,7 +81,9 @@ module.exports = kind(
 
 			while (--l >= 0) {
 				panel = panels[l];
-				panel.set('accessibilityRole', panel === active ? 'alert' : 'region');
+				if (panel.title) {
+					panel.set('accessibilityRole', panel === active ? 'alert' : 'region');
+				}
 			}
 		}}
 	]

--- a/src/LightPanels/LightPanels.js
+++ b/src/LightPanels/LightPanels.js
@@ -81,7 +81,7 @@ module.exports = kind(
 
 			while (--l >= 0) {
 				panel = panels[l];
-				if (panel.title) {
+				if (panel instanceof LightPanel && panel.title) {
 					panel.set('accessibilityRole', panel === active ? 'alert' : 'region');
 				}
 			}

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1349,7 +1349,9 @@ module.exports = kind(
 
 			while (--l >= 0) {
 				panel = panels[l];
-				panel.set('accessibilityRole', panel === active ? 'alert' : 'region');
+				if (panel.title) {
+					panel.set('accessibilityRole', panel === active ? 'alert' : 'region');
+				}
 			}
 		}}
 	]

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1349,7 +1349,7 @@ module.exports = kind(
 
 			while (--l >= 0) {
 				panel = panels[l];
-				if (panel.title) {
+				if (panel instanceof Panel && panel.title) {
 					panel.set('accessibilityRole', panel === active ? 'alert' : 'region');
 				}
 			}


### PR DESCRIPTION
…ly when an event occurs in the popup.

Issue
Screen reader try read the popup contents repeatedly.

Cause
We set the alert role in Panels and LightPanels to read title automatically
and set aria-live 'off' in Panel and LightPanel, but we can use any control
in Panels not Panel in this case this issue occurs.

Fix
The alert role is needed in case there is title in panel, so check whether
title is exist or not.

https://jira2.lgsvl.com/browse/ENYO-2499
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>