### PR TITLE
ENYO-2559: Explicitly set Icon (and IconButton) to not allow kerning.

### DIFF
--- a/src/Icon/Icon.less
+++ b/src/Icon/Icon.less
@@ -16,6 +16,7 @@
 	position: relative;
 	color: @moon-icon-text-color;
 
+	.font-kerning(none);
 	.moon-taparea(@moon-icon-size);
 
 	&.small {


### PR DESCRIPTION
This resolves an issue where the Moonstone Icons font is rendered invisible due to the font itself not having built-in (or correct) kerning information. (And is therefore unable to render anything visibly to the screen.)

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>