### PR TITLE
ENYO-2561: Ensure small header sub-title has the correct size…

### DIFF
--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -48,6 +48,10 @@
 }
 .moon-sub-header-text {
 	.moon-text-base (@moon-sub-header-font-size);
+
+	.moon-small-header & {
+		font-size: @moon-small-header-sub-header-font-size;
+	}
 }
 .moon-header-sub-title-below {
 	font-family: @moon-sub-header-below-font-family;
@@ -161,7 +165,8 @@
 	.moon-popup-header-text {
 		font-size: @moon-non-latin-popup-header-font-size;
 	}
-	.moon-sub-header-text {
+	.moon-sub-header-text,
+	.moon-small-header .moon-sub-header-text {
 		font-size: @moon-non-latin-sub-header-font-size;
 	}
 	.moon-super-header-text {

--- a/src/Header/Header.less
+++ b/src/Header/Header.less
@@ -110,10 +110,6 @@
 				line-height: @moon-non-latin-small-header-line-height;
 			}
 		}
-
-		.moon-header-sub-title {
-			font-size: @moon-small-header-sub-header-font-size;
-		}
 	}
 
 	.moon-header-client {


### PR DESCRIPTION
…in non-latin locales.

Due to a precedence issue, the non-latin sub-header font size was being overridden by the latin font-size. This change removes the custom sizing from the control and relocates it back to moonstone-text, where the rest of the font rules are applied.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>