### PR TITLE
ENYO-2274: Contextual Popup position bug

### DIFF
--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -451,6 +451,7 @@ module.exports = kind(
 			this.$.closeButton.spotlight = false;
 			this.removeClass('reserve-close');
 		}
+		this.reflow();
 	},
 
 	/**


### PR DESCRIPTION
### Issue:
In the RTL case, Contextual Popup is shown in an abnormal position for the first time only.
### Fix:
The bug occurred when the reserve-close class was added without a reflow/resize. So, add a reflow to the end of ContextualPopup::configCloseButton()

Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan <krishna.rangarajan@lge.com>