### PR TITLE
ENYO-2564: it can not set slider custom value if no popup

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -918,6 +918,15 @@ module.exports = kind(
 	accessibilityRole: 'slider',
 
 	/**
+	* Custom value for accessibility (ignored if `null`).
+	*
+	* @type {String|null}
+	* @default null
+	* @public
+	*/
+	accessibilityValueText: null,
+
+	/**
 	* @private
 	*/
 	ariaObservers: [
@@ -947,6 +956,15 @@ module.exports = kind(
 				this.resetAccessibilityProperties();
 			}
 		}},
+		{path: ['accessibilityValueText'], method: function () {
+			this.resetAccessibilityProperties();
+			this.setAriaAttribute('aria-valuetext', this.accessibilityValueText);
+			if (this.enableJumpIncrement) {
+				this.$.slider.setAriaAttribute('aria-valuetext', this.accessibilityValueText);
+				this.$.buttonLeft.set('accessibilityLabel', this.accessibilityValueText);
+				this.$.buttonRight.set('accessibilityLabel', this.accessibilityValueText);
+			}
+		}},
 		{path: ['value', 'popupContent', 'dragging'], method: 'ariaValue'}
 	],
 
@@ -969,7 +987,7 @@ module.exports = kind(
 		var attr = this.popup ? 'aria-valuetext' : 'aria-valuenow',
 			text = (this.popup && this.$.popupLabel)? this.$.popupLabel.getContent() : this.value;
 			
-		if (!this.dragging) {
+		if (!this.dragging && !this.accessibilityValueText) {
 			this.resetAccessibilityProperties();
 			this.setAriaAttribute(attr, text);
 			if (this.enableJumpIncrement) {


### PR DESCRIPTION
Issue
It can not set slider custom value if no popup
For TV Settings app, there are many cases it needs to set
custom value without popup.

Cause
If popup is false in Slider, app developer can not set custom value
at the slider.
In case popup is true, app developer can set custom value
through popupContent.

Fix
Add accessibilityValueText property to set custom value for slider

https://jira2.lgsvl.com/browse/ENYO-2564
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>