### PR TITLE
ENYO-2547: ProgressBar can now generate/destroy its popup as needed.

### DIFF
--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -524,6 +524,7 @@ module.exports = kind(
 			flip = percent > 50;
 
 		this.updatePopupPosition(percent);
+
 		if (this.$.popup) {
 			if (this.get('orientation') == 'horizontal') {
 				this.$.popup.addRemoveClass('moon-progress-bar-popup-flip-h', flip);
@@ -540,7 +541,9 @@ module.exports = kind(
 	* @private
 	*/
 	updatePopupPosition: function (percent) {
-		this.$.popup.applyStyle(this.get('orientation') == 'vertical' ? 'bottom' : 'left', percent + '%');
+		if (this.$.popup) {
+			this.$.popup.applyStyle(this.get('orientation') == 'vertical' ? 'bottom' : 'left', percent + '%');
+		}
 	},
 
 	/**

--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -363,7 +363,7 @@ module.exports = kind(
 
 	rendered: function () {
 		Control.prototype.rendered.apply(this, arguments);
-		if(this.$.popup){
+		if (this.$.popup) {
 			this.drawToCanvas(this.popupColor);
 		}
 	},
@@ -504,6 +504,19 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	popupChanged: function () {
+		if (this.popup && !this.$.popup) {
+			this.createPopup();
+			this.initPopupStyles();
+			this.render();
+		} else if (!this.popup && this.$.popup) {
+			this.$.popup.destroy();
+		}
+	},
+
+	/**
+	* @private
+	*/
 	updatePopup: function (val) {
 		var usePercentage = this.showPercentage && this.popupContent === null,
 			percent = this.calcPercent(val),
@@ -511,12 +524,14 @@ module.exports = kind(
 			flip = percent > 50;
 
 		this.updatePopupPosition(percent);
-		if (this.get('orientation') == 'horizontal') {
-			this.$.popup.addRemoveClass('moon-progress-bar-popup-flip-h', flip);
-			this.$.popupLabel.addRemoveClass('moon-progress-bar-popup-flip-h', flip);
-		}
+		if (this.$.popup) {
+			if (this.get('orientation') == 'horizontal') {
+				this.$.popup.addRemoveClass('moon-progress-bar-popup-flip-h', flip);
+				this.$.popupLabel.addRemoveClass('moon-progress-bar-popup-flip-h', flip);
+			}
 
-		this.updatePopupLabel(popupLabel);
+			this.updatePopupLabel(popupLabel);
+		}
 	},
 
 	/**
@@ -525,7 +540,7 @@ module.exports = kind(
 	* @private
 	*/
 	updatePopupPosition: function (percent) {
-		this.$.popup.applyStyle(this.get('orientation') == 'vertical' ? 'bottom' :'left', percent + '%');
+		this.$.popup.applyStyle(this.get('orientation') == 'vertical' ? 'bottom' : 'left', percent + '%');
 	},
 
 	/**
@@ -665,7 +680,7 @@ module.exports = kind(
 		return val;
 	},
 
-		/**
+	/**
 	* @private
 	*/
 	drawToCanvas: function (bgColor) {
@@ -723,7 +738,7 @@ module.exports = kind(
 	},
 
 	// Accessibility
-	
+
 	/**
 	* @default progressbar
 	* @type {String}

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -947,7 +947,7 @@ module.exports = kind(
 			if (this.selected) {
 				// avoid using readAlert api, temporary set accessibilityRole to alert
 				// this will be reset on resetAccessibilityProperties
-				var hint = (this.get('orientation') == 'horizontal') ? 
+				var hint = (this.get('orientation') == 'horizontal') ?
 								$L('change a value with left right button') : $L('change a value with up down button');
 				this.set('accessibilityRole', 'alert');
 				this.set('accessibilityLive', 'off');
@@ -968,7 +968,7 @@ module.exports = kind(
 		{path: ['value', 'popupContent', 'dragging'], method: 'ariaValue'}
 	],
 
-	/** 
+	/**
 	* @private
 	*/
 	resetAccessibilityProperties : function() {
@@ -986,7 +986,7 @@ module.exports = kind(
 	ariaValue: function () {
 		var attr = this.popup ? 'aria-valuetext' : 'aria-valuenow',
 			text = (this.popup && this.$.popupLabel)? this.$.popupLabel.getContent() : this.value;
-			
+
 		if (!this.dragging && !this.accessibilityValueText) {
 			this.resetAccessibilityProperties();
 			this.setAriaAttribute(attr, text);


### PR DESCRIPTION
ProgressBar was expecting `popup` to always be true by directly referencing components that are only generated at create-time when `popup` is true. ProgressBar now automatically creates and destroys the `popupComponents` as needed based on the current setting of `popup`. Guard code has been added to updatePopup that safely isolates the methods which require `this.$.popup` to be present. Also some incidental cleanup on Slider.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>