### PR TITLE
ENYO-2277: Scroll to top/bottom/left/right when focus leave from scroller.

### DIFF
--- a/src/Scroller/Scroller.js
+++ b/src/Scroller/Scroller.js
@@ -361,7 +361,9 @@ if (platform.touch) {
 		containerLeaveHandler: function () {
 			var strategy = this.getStrategy(),
 				b = strategy.getScrollBounds(),
-				o5WayEvent = Spotlight.getLast5WayEvent();
+				o5WayEvent = Spotlight.getLast5WayEvent(),
+				s5WayEventType = null,
+				s5WayEventDir = null;
 
 			// We scroll to end on focus leave to show disabled controls at the top or bottom of scroller in 5way.
 			if (o5WayEvent) {

--- a/src/Scroller/Scroller.js
+++ b/src/Scroller/Scroller.js
@@ -190,7 +190,7 @@ if (platform.touch) {
 			onSpotlightScrollUp:'spotlightWheel',
 			onSpotlightScrollDown:'spotlightWheel',
 			onSpotlightContainerEnter:'enablePageUpDownKey',
-			onSpotlightContainerLeave:'disablePageUpDownKey',
+			onSpotlightContainerLeave:'containerLeaveHandler',
 			onenter:'enablePageUpDownKey',
 			onleave:'disablePageUpDownKey',
 			onmove:'move'
@@ -356,6 +356,34 @@ if (platform.touch) {
 		*/
 		disablePageUpDownKey: function () {
 			this.handlePageUpDownKey = false;
+		},
+
+		containerLeaveHandler: function () {
+			var strategy = this.getStrategy(),
+				b = strategy.getScrollBounds(),
+				o5WayEvent = Spotlight.getLast5WayEvent();
+
+			// We scroll to end on focus leave to show disabled controls at the top or bottom of scroller in 5way.
+			if (o5WayEvent) {
+				s5WayEventType = o5WayEvent.type;
+				s5WayEventDir = s5WayEventType.replace('onSpotlight', '').toUpperCase();
+				switch (s5WayEventDir) {
+					case 'UP': 
+						if (strategy.getScrollTop() > 0) strategy.setScrollTop(0);
+						break;
+					case 'DOWN':
+						if (strategy.getScrollTop() < b.maxTop) strategy.setScrollTop(b.maxTop);
+						break;
+					case 'LEFT':
+						if (strategy.getScrollLeft() > 0) strategy.setScrollLeft(0);
+						break;
+					case 'RIGHT':
+						if (strategy.getScrollLeft() < b.maxLeft) strategy.setScrollLeft(b.maxLeft);
+						break;
+				}
+			}
+
+			this.disablePageUpDownKey();
 		},
 
 		/**

--- a/src/Scroller/Scroller.js
+++ b/src/Scroller/Scroller.js
@@ -358,28 +358,25 @@ if (platform.touch) {
 			this.handlePageUpDownKey = false;
 		},
 
-		containerLeaveHandler: function () {
+		containerLeaveHandler: function (sender, event) {
+			if (event.originator != this) return;
 			var strategy = this.getStrategy(),
 				b = strategy.getScrollBounds(),
-				o5WayEvent = Spotlight.getLast5WayEvent(),
-				s5WayEventType = null,
-				s5WayEventDir = null;
+				o5WayEvent = Spotlight.getLast5WayEvent();
 
 			// We scroll to end on focus leave to show disabled controls at the top or bottom of scroller in 5way.
 			if (o5WayEvent) {
-				s5WayEventType = o5WayEvent.type;
-				s5WayEventDir = s5WayEventType.replace('onSpotlight', '').toUpperCase();
-				switch (s5WayEventDir) {
-					case 'UP': 
+				switch (o5WayEvent.type) {
+					case 'onSpotlightUp': 
 						if (strategy.getScrollTop() > 0) strategy.setScrollTop(0);
 						break;
-					case 'DOWN':
+					case 'onSpotlightDown':
 						if (strategy.getScrollTop() < b.maxTop) strategy.setScrollTop(b.maxTop);
 						break;
-					case 'LEFT':
+					case 'onSpotlightLeft':
 						if (strategy.getScrollLeft() > 0) strategy.setScrollLeft(0);
 						break;
-					case 'RIGHT':
+					case 'onSpotlightRight':
 						if (strategy.getScrollLeft() < b.maxLeft) strategy.setScrollLeft(b.maxLeft);
 						break;
 				}


### PR DESCRIPTION
Issue:
If controls at the top or bottom (left or right also) are disabled inside of scroller, there
is no way to show them by 5way key.

Fix:
We force scroll to top or bottom (left or right also) on focus leave based on last 5way event.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi <kunmyon.choi@lge.com>