### PR TITLE
ENYO-2569: Relocate focus-at-end code from ExpandableInput to Input…

### DIFF
--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -120,7 +120,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	drawerComponents: [		
+	drawerComponents: [
 		{name: 'inputDecorator', kind: InputDecorator, onSpotlightBlur: 'inputSpotBlurred', onSpotlightFocus: 'inputFocus', onSpotlightDown: 'inputSpotDown', onkeyup: 'inputKeyUp', defaultSpotlightUp: 'drawer', components: [
 			{name: 'clientInput', kind: Input, onchange: 'doChange', dismissOnEnter: true}
 		]}
@@ -243,11 +243,6 @@ module.exports = kind(
 	*/
 	focusInput: function () {
 		this.$.clientInput.focus();
-		// Force cursor to end of text. We were sometimes seeing the
-		// cursor positioned at the start of the text, which caused
-		// problems in 5-way mode (where there's no way to move the
-		// cursor).
-		this.$.clientInput.hasNode().selectionStart = this.value.length;
 	},
 
 	/**

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -102,7 +102,10 @@ module.exports = kind(
 		// Force cursor to end of text during a generic focus event. Creating the input by compiling
 		// a string of text with value="this.value" produces different initial caret position than
 		// using node.setAttribute('value', this.value), which is what would happen any time after
-		// the initial creation.
+		// the initial creation. The initial end-position of the caret is required to support
+		// Virtual keyboards because without arrow-keys because normal left/right arrow navigation
+		// in inputs is impossible, so the caret must be positioned at the end to allow for deletion
+		// of the previous input.
 		this.hasNode().selectionStart = this.value.length;
 	},
 

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -78,7 +78,7 @@ module.exports = kind(
 	* @private
 	*/
 	handlers: {
-		onkeyup : 'onKeyUp',
+		onkeyup    : 'onKeyUp',
 		onblur     : 'onBlur',
 		onfocus    : 'onFocus'
 	},
@@ -99,6 +99,11 @@ module.exports = kind(
 			var oThis = this;
 			util.asyncMethod(this, function () {oThis._bFocused = true;});
 		}
+		// Force cursor to end of text during a generic focus event. Creating the input by compiling
+		// a string of text with value="this.value" produces different initial caret position than
+		// using node.setAttribute('value', this.value), which is what would happen any time after
+		// the initial creation.
+		this.hasNode().selectionStart = this.value.length;
 	},
 
 	/**

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -95,6 +95,8 @@ module.exports = kind(
 	* @private
 	*/
 	onFocus: function () {
+		var node = this.hasNode();
+
 		if (this.dismissOnEnter) {
 			var oThis = this;
 			util.asyncMethod(this, function () {oThis._bFocused = true;});
@@ -105,8 +107,10 @@ module.exports = kind(
 		// the initial creation. The initial end-position of the caret is required to support
 		// Virtual keyboards because without arrow-keys because normal left/right arrow navigation
 		// in inputs is impossible, so the caret must be positioned at the end to allow for deletion
-		// of the previous input.
-		this.hasNode().selectionStart = this.value.length;
+		// of the previous input. We are intentionally setting the value to force the cursor to the
+		// end of the text. `selectionStart` is the obvious choice, but it is not supported in
+		// certain types of fields (i.e. number, email).
+		if (node) node.value = this.get('value');
 	},
 
 	/**


### PR DESCRIPTION
…so everyone gets consistent behavior.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>