### PR TITLE
ENYO-2406: ExpandablePicker: getSelected() returns undefined, not null

### DIFF
--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -318,7 +318,7 @@ module.exports = kind(
 				controls[i].setChecked(checked);
 			}
 		} else {
-			this.set('selected', controls[index]);
+			this.set('selected', index >= 0 ? controls[index] : null);
 		}
 	},
 


### PR DESCRIPTION
### Issue

When ExpandablePicker is created, selectedIndexChanged() is called for initialization. If nothing is selected, getSelectedIndex() returns -1 which is default value. And then if the picker doesn't support multipleSelection it calls setSelected with selected control. However index is set to -1 which is out of bounds and undefined is returned.

### Fix

If index is set to invalid value like -1, `selected` would be set to `null`.

Enyo-DCO-1.1-Signed-off-by: Hunkyo Jung (hunkyo.jung@lge.com)