### PR TITLE
ENYO-2626: Hint is wrong in IntegerPicker

### DIFF
--- a/src/IntegerPicker/IntegerPicker.js
+++ b/src/IntegerPicker/IntegerPicker.js
@@ -727,7 +727,13 @@ module.exports = kind(
 		{path: 'spotted',  method: function () {
 			// When spotlight is focused, it reads value with hint
 			if (this.spotted) {
-				this.set('accessibilityHint', $L('change a value with up down button'));
+				if (!this.wrap && this.value == this.min) {
+					this.set('accessibilityHint', $L('change a value with up button'));
+				} else if (!this.wrap && this.value == this.max) {
+					this.set('accessibilityHint', $L('change a value with down button'));
+				} else {
+					this.set('accessibilityHint', $L('change a value with up down button'));
+				}
 				this.ariaValue();
 			}
 		}}

--- a/src/SimpleIntegerPicker/SimpleIntegerPicker.js
+++ b/src/SimpleIntegerPicker/SimpleIntegerPicker.js
@@ -201,25 +201,44 @@ module.exports = kind(
 	// Accessibility
 
 	/**
-	* @default $L('change a value with left/right button')
+	* @default 'spinbutton'
 	* @type {String}
-	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityHint
+	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityRole
 	* @public
 	*/
-	accessibilityHint: $L('change a value with left/right button'),
+	accessibilityRole: 'spinbutton',
 
 	/**
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['value', 'unit'], method: function () {
-			var text = this.unit ? this.value + ' ' + this.unit : this.value;
-
-			// It reads changed value only the case spotlight focus is on IntegerPicker
-			if (Spotlight.getCurrent() === this) {
-				this.$.repeater.setAriaAttribute('aria-valuetext', text);
+		{path: ['value', 'unit'],  method: function () {
+			// When value is changed, it reads only value
+			if (this.spotted) {
+				this.set('accessibilityHint', null);
+				this.ariaValue();
 			}
-			this.set('accessibilityLabel', text);
+		}},
+		{path: 'spotted',  method: function () {
+			// When spotlight is focused, it reads value with hint
+			if (this.spotted) {
+				if (!this.wrap && this.value == this.min) {
+					this.set('accessibilityHint', $L('change a value with right button'));
+				} else if (!this.wrap && this.value == this.max) {
+					this.set('accessibilityHint', $L('change a value with left button'));
+				} else {
+					this.set('accessibilityHint', $L('change a value with left right button'));
+				}
+				this.ariaValue();
+			}
 		}}
-	]
+	],
+
+	/**
+	* @private
+	*/
+	ariaValue: function () {
+		var text = this.unit ? this.value + ' ' + this.unit : this.value;
+		this.setAriaAttribute('aria-valuetext', text);
+	}
 });

--- a/src/SimpleIntegerPicker/SimpleIntegerPicker.js
+++ b/src/SimpleIntegerPicker/SimpleIntegerPicker.js
@@ -13,7 +13,6 @@ var
 	IntegerPicker = require('../IntegerPicker');
 
 var
-	Spotlight = require('spotlight'),
 	$L = require('../i18n');
 
 /**


### PR DESCRIPTION
Issue
When spotlight is focused on IntegerPicker with min value,
it reads 'value' + 'change a value with up down button',
but in this case we can not use 'down' button because the value is minimum
and down icon is disabled.
It should be read 'value' + 'change a value with up button'

Cause
added same hint without considering wrap property

Fix
add each proper hint when wrap is false.
- when value is the same as min, use only 'up'
- when value is the same as max, use only 'down'
- else, use both 'up' and 'down'
change similarly on SimpleIntegerPicker

https://jira2.lgsvl.com/browse/ENYO-2626
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>