### PR TITLE
ContextualPopup: Direction does not work after pre.17

### DIFF
--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -262,8 +262,8 @@ module.exports = kind(
 		if (n) {
 			this.activatorOffset = this.getPageOffset(n);
 		}
-		this.show();
 		this.configCloseButton();
+		this.show();
 		if (Spotlight.isSpottable(this)) {
 			Spotlight.spot(this);
 		}
@@ -451,7 +451,6 @@ module.exports = kind(
 			this.$.closeButton.spotlight = false;
 			this.removeClass('reserve-close');
 		}
-		this.reflow();
 	},
 
 	/**


### PR DESCRIPTION
### Issue:
a reflow() call added at the end of ContextualPopup::configCloseButton() caused ContextualPopup direction not to work
### Fix:
The ContextualPopup::requestShow() method called show(), then configCloseButton(). The call to show() triggered a call to showingChanged(), which called alterDirection(), which positioned the contextualPopup according to the "direction" property. When configCloseButton() called reflow() after this moon.ContextualPopup positioning code had been called, it resulted in a call to enyo.Popup::reflow(), which called enyo.Popup::updatePosition(), which repositioned the popup without reference to the moon.ContextualPopup "direction" property.

There seem to be a few possible fixes for this. One would be to have moon.ContextualPopup() override the enyo.Popup::updatePosition() method, and implement it respecting the direction property. Another possible fix would be to have moon.ContextualPopup override enyo.Popup::reflow(), adding a call to alterDirection().

But the simplest fix seemed to be to remove the reflow() call from configCloseButton(), and switch the order of method calls in requestShow() to call configCloseButton() first, and then show(). This seems to fix the original ENYO-2274 issue, as well as the ENYO-2627 regression, and there doesn't seem to be any code in configCloseButton() which is dependent on show() being called first.


Enyo-DCO-1.1-Signed-off-by: Krishna Rangarajan <krishna.rangarajan@lge.com>