### PR TITLE
ENYO-1808: Converted all controls to use a standard font configuration.

### DIFF
--- a/css/moonstone-fonts.less
+++ b/css/moonstone-fonts.less
@@ -10,44 +10,44 @@
 @font-face {
 	font-family: "Moonstone Miso";
 	src: @font-system-name-non-latin;
-	font-weight: normal;
+	font-weight: 500;
 	font-style: normal;
 }
 @font-face {
 	font-family: "Moonstone Miso";
 	src: local("Moon Miso Medium"),
 		url("../fonts/Miso/Miso-Regular.ttf") format("truetype");
-	font-weight: normal;
+	font-weight: 500;
 	font-style: normal;
 	unicode-range: @font-unicode-range-miso;
 }
 
 @font-face {
-	font-family: "Moonstone Miso Bold";
+	font-family: "Moonstone Miso";
 	src: @font-system-name-non-latin-bold;
-	font-weight: normal;
+	font-weight: 700;
 	font-style: normal;
 }
 @font-face {
-	font-family: "Moonstone Miso Bold";
+	font-family: "Moonstone Miso";
 	src: local("Moon Miso Bold"),
 		url("../fonts/Miso/Miso-Bold.ttf") format("truetype");
-	font-weight: normal;
+	font-weight: 700;
 	font-style: normal;
 	unicode-range: @font-unicode-range-miso;
 }
 
 @font-face {
-	font-family: "Moonstone Miso Light";
+	font-family: "Moonstone Miso";
 	src: @font-system-name-non-latin-light;
-	font-weight: normal;
+	font-weight: 300;
 	font-style: normal;
 }
 @font-face {
-	font-family: "Moonstone Miso Light";
+	font-family: "Moonstone Miso";
 	src: local("Moon Miso Light"),
 		url("../fonts/Miso/Miso-Light.ttf") format("truetype");
-	font-weight: normal;
+	font-weight: 300;
 	font-style: normal;
 	unicode-range: @font-unicode-range-miso;
 }
@@ -58,136 +58,111 @@
 
 @font-face {
 	font-family: "MuseoSans";
+	src: @font-system-name-non-latin-light;
+	font-weight: 100;
+}
+@font-face {
+	font-family: "MuseoSans";
+	src: local("Moon Museo Sans Thin"),
+		url("../fonts/MuseoSans/MuseoSans-Light.ttf") format("truetype");
+	font-weight: 100;
+	unicode-range: @font-unicode-range-museosans;
+}
+
+@font-face {
+	font-family: "MuseoSans";
+	src: @font-system-name-non-latin-light;
+	font-weight: 300;
+}
+@font-face {
+	font-family: "MuseoSans";
+	src: local("Moon Museo Sans Light"),
+		url("../fonts/MuseoSans/MuseoSans-Normal.ttf") format("truetype");
+	font-weight: 300;
+	unicode-range: @font-unicode-range-museosans;
+}
+
+@font-face {
+	font-family: "MuseoSans";
 	src: @font-system-name-non-latin;
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 500;
 }
 @font-face {
 	font-family: "MuseoSans";
 	src: local("Moon Museo Sans Medium"),
 		url("../fonts/MuseoSans/MuseoSans-DemiBold.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 500;
 	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
-	font-family: "MuseoSans 100";
-	src: @font-system-name-non-latin-light;
-	font-weight: normal;
-	font-style: normal;
-}
-@font-face {
-	font-family: "MuseoSans 100";
-	src: local("Moon Museo Sans Thin"),
-		url("../fonts/MuseoSans/MuseoSans-Light.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
-	unicode-range: @font-unicode-range-museosans;
-}
-
-@font-face {
-	font-family: "MuseoSans 300";
-	src: @font-system-name-non-latin-light;
-	font-weight: normal;
-	font-style: normal;
-}
-@font-face {
-	font-family: "MuseoSans 300";
-	src: local("Moon Museo Sans Light"),
-		url("../fonts/MuseoSans/MuseoSans-Normal.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
-	unicode-range: @font-unicode-range-museosans;
-}
-
-@font-face {
-	font-family: "MuseoSans 500";
+	font-family: "MuseoSans";
 	src: @font-system-name-non-latin;
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 500;
+	font-style: italic;
 }
 @font-face {
-	font-family: "MuseoSans 500";
-	src: local("Moon Museo Sans Medium"),
-		url("../fonts/MuseoSans/MuseoSans-DemiBold.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
-	unicode-range: @font-unicode-range-museosans;
-}
-
-@font-face {
-	font-family: "MuseoSans 500 Italic";
-	src: @font-system-name-non-latin;
-	font-weight: normal;
-	font-style: normal;
-}
-@font-face {
-	font-family: "MuseoSans 500 Italic";
+	font-family: "MuseoSans";
 	src: local("Moon Museo Medium Italic"),
 		url("../fonts/MuseoSans/MuseoSans-DemiBoldItalic.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 500;
+	font-style: italic;
 	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
-	font-family: "MuseoSans 700";
+	font-family: "MuseoSans";
 	src: @font-system-name-non-latin-bold;
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 700;
 }
 @font-face {
-	font-family: "MuseoSans 700";
+	font-family: "MuseoSans";
 	src: local("Moon Museo Sans Bold"),
 		url("../fonts/MuseoSans/MuseoSans-Bold.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 700;
 	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
-	font-family: "MuseoSans 700 Italic";
+	font-family: "MuseoSans";
 	src: @font-system-name-non-latin-bold;
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 700;
+	font-style: italic;
 }
 @font-face {
-	font-family: "MuseoSans 700 Italic";
+	font-family: "MuseoSans";
 	src: local("Moon Museo Sans Bold Italic"),
 		url("../fonts/MuseoSans/MuseoSans-BoldItalic.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 700;
+	font-style: italic;
 	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
-	font-family: "MuseoSans 900";
+	font-family: "MuseoSans";
 	src: @font-system-name-non-latin-bold;
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 900;
 }
 @font-face {
-	font-family: "MuseoSans 900";
+	font-family: "MuseoSans";
 	src: local("Moon Museo Sans Black"),
 		url("../fonts/MuseoSans/MuseoSans-Black.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 900;
 	unicode-range: @font-unicode-range-museosans;
 }
 
 @font-face {
-	font-family: "MuseoSans 900 Italic";
+	font-family: "MuseoSans";
 	src: @font-system-name-non-latin-bold;
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 900;
+	font-style: italic;
 }
 @font-face {
-	font-family: "MuseoSans 900 Italic";
+	font-family: "MuseoSans";
 	src: local("Moon Museo Sans Black Italic"),
 		url("../fonts/MuseoSans/MuseoSans-BlackItalic.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 900;
+	font-style: italic;
 	unicode-range: @font-unicode-range-museosans;
 }
 
@@ -195,11 +170,8 @@
 
 @font-face {
 	font-family: "Moonstone Icons";
-	// The "space" after moonstone is intentional. That's the actual system font name.
 	src: local("Moonstone"),
 		url("../fonts/Moonstone.ttf") format("truetype");
-	font-weight: normal;
-	font-style: normal;
 }
 
 /* ----- LG Dingbats (Icons) ------ */
@@ -207,8 +179,6 @@
 @font-face {
 	font-family: "LG Icons";
 	src: local("LG Display_Dingbat");
-	font-weight: normal;
-	font-style: normal;
 }
 
 /* ----- LG Display ------ */
@@ -217,18 +187,14 @@
 	/* We want "LG Display" to map to the bold variant, since that was originally the only option */
 	font-family: "Moonstone LG Display";
 	src: @font-system-name-non-latin;
-	font-weight: normal;
-	font-style: normal;
 }
 @font-face {
-	font-family: "Moonstone LG Display Bold";
+	font-family: "Moonstone LG Display";
 	src: @font-system-name-non-latin-bold;
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 700;
 }
 @font-face {
-	font-family: "Moonstone LG Display Light";
+	font-family: "Moonstone LG Display";
 	src: @font-system-name-non-latin-light;
-	font-weight: normal;
-	font-style: normal;
+	font-weight: 300;
 }

--- a/css/moonstone-fonts.less
+++ b/css/moonstone-fonts.less
@@ -198,3 +198,28 @@
 	src: @font-system-name-non-latin-light;
 	font-weight: 300;
 }
+
+
+/*
+ * ----- Deprecated Font Names ------
+ *
+ * The following font names are provided here to help clearly identify old font
+ * names that must be updated. These old names have been deprecated and should
+ * be changed as soon as possible to avoid unwanted font substitutions. "Times"
+ * has been assigned directly to help quickly identify these cases.
+ */
+
+@font-face { font-family: "Moonstone Miso Bold"; src: local("Times"); }
+@font-face { font-family: "Moonstone Miso Light"; src: local("Times"); }
+
+@font-face { font-family: "MuseoSans 100"; src: local("Times"); }
+@font-face { font-family: "MuseoSans 300"; src: local("Times"); }
+@font-face { font-family: "MuseoSans 500"; src: local("Times"); }
+@font-face { font-family: "MuseoSans 700"; src: local("Times"); }
+@font-face { font-family: "MuseoSans 900"; src: local("Times"); }
+@font-face { font-family: "MuseoSans 500 Italic"; src: local("Times"); }
+@font-face { font-family: "MuseoSans 700 Italic"; src: local("Times"); }
+@font-face { font-family: "MuseoSans 900 Italic"; src: local("Times"); }
+
+@font-face { font-family: "Moonstone LG Display Bold"; src: local("Times"); }
+@font-face { font-family: "Moonstone LG Display Light"; src: local("Times"); }

--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -39,11 +39,15 @@
 .moon-header-text {
 	font-family: @moon-header-font-family;
 	font-size: @moon-header-font-size;
+	font-weight: @moon-header-font-weight;
+	font-style: @moon-header-font-style;
 	.font-kerning;
 }
 .moon-super-header-text {
 	font-family: @moon-super-header-font-family;
 	font-size: @moon-super-header-font-size;
+	font-weight: @moon-super-header-font-weight;
+	font-style: @moon-super-header-font-style;
 	.font-kerning;
 }
 .moon-sub-header-text {
@@ -59,6 +63,8 @@
 }
 .moon-body-text {
 	font-family: @moon-body-font-family;
+	font-weight: @moon-body-font-weight;
+	font-style: @moon-body-font-style;
 	font-size: @moon-body-font-size;
 	color: @moon-body-text-color;
 	line-height: @moon-body-line-height;
@@ -72,14 +78,7 @@
 	line-height: @moon-body-line-height + 9;
 }
 .moon-bold-text {
-	font-family: @moon-font-family-bold;
-	font-size: @moon-body-font-size;
-	color: @moon-body-text-color;
-	line-height: @moon-body-line-height;
-	a:link {color: @moon-spotlight-color; text-decoration:none;}
-	a:visited {color: @moon-spotlight-color; text-decoration:none;}
-	a:hover {color: @moon-spotlight-color; text-decoration:none;}
-	a:active {color: @moon-spotlight-color; text-decoration:none;}
+	font-weight: bold;
 }
 .moon-body-text-spacing {
 	margin: 0 @moon-spotlight-outset @moon-grid-row-height @moon-spotlight-outset;
@@ -87,11 +86,15 @@
 .moon-large-button-text {
 	font-family: @moon-button-font-family;
 	font-size: @moon-button-large-font-size;
+	font-weight: @moon-button-font-weight;
+	font-style: @moon-button-font-style;
 	.font-kerning;
 }
 .moon-small-button-text {
 	font-family: @moon-button-font-family;
 	font-size: @moon-button-small-font-size;
+	font-weight: @moon-button-font-weight;
+	font-style: @moon-button-font-style;
 	.font-kerning;
 }
 .moon-icon-text {
@@ -114,6 +117,8 @@
 .moon-divider-text {
 	font-family: @moon-divider-font-family;
 	font-size: @moon-divider-font-size;
+	font-weight: @moon-divider-font-weight;
+	font-style: @moon-divider-font-style;
 	color: @moon-divider-text-color;
 }
 

--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -51,10 +51,10 @@
 	.font-kerning;
 }
 .moon-sub-header-text {
-	.moon-text-base (@moon-sub-header-font-size);
 	font-family: @moon-sub-header-font-family;
 	font-weight: @moon-sub-header-font-weight;
 	font-style: @moon-sub-header-font-style;
+	font-size: @moon-sub-header-font-size;
 
 	.moon-small-header & {
 		font-size: @moon-small-header-sub-header-font-size;
@@ -63,6 +63,7 @@
 .moon-header-sub-title-below {
 	font-family: @moon-sub-header-below-font-family;
 	font-weight: @moon-sub-header-below-font-weight;
+	font-style: @moon-sub-header-below-font-style;
 	font-size: @moon-sub-header-below-font-size;
 }
 .moon-body-text {

--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -52,6 +52,9 @@
 }
 .moon-sub-header-text {
 	.moon-text-base (@moon-sub-header-font-size);
+	font-family: @moon-sub-header-font-family;
+	font-weight: @moon-sub-header-font-weight;
+	font-style: @moon-sub-header-font-style;
 
 	.moon-small-header & {
 		font-size: @moon-small-header-sub-header-font-size;
@@ -59,6 +62,7 @@
 }
 .moon-header-sub-title-below {
 	font-family: @moon-sub-header-below-font-family;
+	font-weight: @moon-sub-header-below-font-weight;
 	font-size: @moon-sub-header-below-font-size;
 }
 .moon-body-text {

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -131,6 +131,7 @@
 @moon-sub-header-line-height: 2em;
 @moon-sub-header-below-font-family: @moon-font-family-light;
 @moon-sub-header-below-font-weight: 300;
+@moon-sub-header-below-font-style: normal;
 
 @moon-super-header-font-family: @moon-alt-font-family;
 @moon-super-header-font-weight: normal;

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -126,8 +126,8 @@
 
 @moon-sub-header-font-family: @moon-font-family;
 @moon-sub-header-font-weight: bold;
-@moon-sub-header-letter-spacing: 0;
 @moon-sub-header-font-style: normal;
+@moon-sub-header-letter-spacing: 0;
 @moon-sub-header-line-height: 2em;
 @moon-sub-header-below-font-family: @moon-font-family-light;
 @moon-sub-header-below-font-weight: 300;

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -99,18 +99,18 @@
 
 // Other Font Properties
 // ---------------------------------------
-@moon-font-family: "MuseoSans 700";
-@moon-font-family-light: "MuseoSans 300";
-@moon-font-family-bold: "MuseoSans 900";
+@moon-font-family: "MuseoSans";         // 500
+@moon-font-family-light: "MuseoSans";   // 300
+@moon-font-family-bold: "MuseoSans";    // 700
 @moon-alt-font-family: "Moonstone Miso";
 @moon-non-latin-font-family: "Moonstone LG Display";
-@moon-non-latin-font-family-light: "Moonstone LG Display Light";
-@moon-non-latin-font-family-bold: "Moonstone LG Display Bold";
+@moon-non-latin-font-family-light: "Moonstone LG Display";
+@moon-non-latin-font-family-bold: "Moonstone LG Display";
 
 @moon-header-font-family: @moon-alt-font-family;
 @moon-header-font-weight: normal;
-@moon-header-letter-spacing: normal;
 @moon-header-font-style: normal;
+@moon-header-letter-spacing: normal;
 @moon-header-line-height: 1.3em;
 @moon-medium-header-line-height: 1.3em;
 @moon-small-header-line-height: 1.3em;
@@ -125,11 +125,12 @@
 @moon-popup-header-line-height: normal;
 
 @moon-sub-header-font-family: @moon-font-family;
-@moon-sub-header-font-weight: normal;
+@moon-sub-header-font-weight: bold;
 @moon-sub-header-letter-spacing: 0;
 @moon-sub-header-font-style: normal;
 @moon-sub-header-line-height: 2em;
 @moon-sub-header-below-font-family: @moon-font-family-light;
+@moon-sub-header-below-font-weight: 300;
 
 @moon-super-header-font-family: @moon-alt-font-family;
 @moon-super-header-font-weight: normal;
@@ -138,24 +139,24 @@
 @moon-super-header-line-height: normal;
 
 @moon-body-font-family: @moon-font-family-light;
-@moon-body-font-weight: normal;
-@moon-body-letter-spacing: 0;
+@moon-body-font-weight: 300;
 @moon-body-font-style: normal;
+@moon-body-letter-spacing: 0;
 // Body text line heights must be speified in px, since moon.ExpandableText requires precise line measurement
 @moon-body-line-height: @moon-body-font-size + 6;
 @moon-non-latin-body-line-height: 1.7em;
 
-@moon-divider-font-family: "MuseoSans 700 Italic";
-@moon-divider-font-weight: normal;
-@moon-divider-font-style: normal;
+@moon-divider-font-family: @moon-font-family;
+@moon-divider-font-weight: bold;
+@moon-divider-font-style: italic;
 @moon-divider-letter-spacing: 0;
 
 @moon-expandable-value-font-family: @moon-font-family-light;
-@moon-expandable-value-font-weight: normal;
+@moon-expandable-value-font-weight: 300;
 @moon-expandable-value-font-style: normal;
 
-@moon-button-font-family: "Moonstone Miso Bold";
-@moon-button-font-weight: normal;
+@moon-button-font-family: @moon-alt-font-family;
+@moon-button-font-weight: bold;
 @moon-button-font-style: normal;
 @moon-button-letter-spacing: normal;
 
@@ -255,6 +256,8 @@
 
 // Items
 // ---------------------------------------
+@moon-item-font-weight: bold;
+@moon-item-font-style: normal;
 @moon-item-line-height: 1.7em;
 @moon-item-indent: 36px;
 

--- a/src/ContextualPopupButton/ContextualPopupButton.less
+++ b/src/ContextualPopupButton/ContextualPopupButton.less
@@ -14,7 +14,7 @@
 		font-size: @moon-contextual-arrow-font-size;
 		line-height: @moon-button-height - 2 * @moon-button-border-width;
 		color: @moon-accent;
-		.font-kerning(none);
+		.font-kerning(none); // Moonstone Icons doesn't support "normal" kerning.
 	}
 	&.small:after {
 		line-height: @moon-button-small-height - 2 * @moon-button-border-width;

--- a/src/Icon/Icon.less
+++ b/src/Icon/Icon.less
@@ -11,12 +11,14 @@
 	margin: @moon-icon-margin;
 	font-family: "Moonstone", "Moonstone Icons";
 	font-size: (@moon-icon-size * 2);
+	font-weight: normal;
+	font-style: normal;
 	line-height: @moon-icon-size;
 	text-align: center;
 	position: relative;
 	color: @moon-icon-text-color;
 
-	.font-kerning(none);
+	.font-kerning(none); // Moonstone Icons doesn't support "normal" kerning.
 	.moon-taparea(@moon-icon-size);
 
 	&.small {

--- a/src/IntegerPicker/IntegerPicker.less
+++ b/src/IntegerPicker/IntegerPicker.less
@@ -18,6 +18,7 @@
 	border-top: solid 30px transparent;
 	border-bottom: solid 30px transparent;
 	border-radius: @moon-integer-picker-radius;
+	font-weight: bold;
 }
 
 .spotlight .moon-scroll-picker {
@@ -49,6 +50,8 @@
 	width: 100%;
 	height: @moon-integer-picker-overlay-height;
 	font-family: @moon-icon-font-family;
+	font-weight: normal;
+	font-style: normal;
 
 	&.next {
 		top: 0;

--- a/src/Item/Item.less
+++ b/src/Item/Item.less
@@ -1,6 +1,8 @@
 /* Item.css */
 .moon-item {
 	.moon-text-base (@moon-item-font-size);
+	font-weight: @moon-item-font-weight;
+	font-style: @moon-item-font-style;
 	line-height: @moon-item-line-height;
 	padding: 3px @moon-spotlight-outset;
 	position: relative;

--- a/src/SimplePicker/SimplePicker.less
+++ b/src/SimplePicker/SimplePicker.less
@@ -7,6 +7,7 @@
 	height: @moon-picker-button-width;
 	vertical-align: middle;
 	direction: ltr;
+	font-weight: bold;
 
 	&.block {
 		display: block;

--- a/src/Spinner/Spinner.less
+++ b/src/Spinner/Spinner.less
@@ -223,6 +223,7 @@
 		float: left;
 		line-height: @moon-spinner-size;
 		margin: 0 2.6ex 0 0;
+		font-weight: bold;
 	}
 }
 .enyo-locale-right-to-left .moon-spinner {


### PR DESCRIPTION
- All controls have either been explicitly or inherently upgraded to use a more traditional font family/weight/style assignment method.
- Weights have been appropriately assigned to the fonts definitions file.
- All weighted-names have been replaced by normal family-only names.
- The base `.moon` and `.moon-body-text` classes have been switched to normal weight from bold so their children behave more traditionally.
- Several controls were given explicit weights to reflect the design's specifications, due to the change above.
- Moonstone Icons appearing inside of buttons needed a kerning rule reset, as the Moonstone Icons font does not support kerning. (Commented in the code)

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
