### PR TITLE
ENYO-2645: Prevent spotting of header when in pointer mode.

### DIFF
--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -321,7 +321,8 @@ module.exports = kind(
 		// If the spotlight is elsewhere, we don't want to hijack it (e.g. after the delay in
 		// ExpandablePicker)
 		if (!current || current.isDescendantOf(this)) {
-			Spotlight.spot(this.$.header);
+			if (Spotlight.getPointerMode()) Spotlight.unspot();
+			else Spotlight.spot(this.$.header);
 		}
 		this.set('active', false);
 	},


### PR DESCRIPTION
### Issue
When we close the drawer in an `ExpandableListItem`, we attempt to spot the header if there is nothing currently spotted. Spotting when in pointer mode has no effect on setting the currently spotted item, but it does call `unspot` and updates the `_oLastControl` reference. In the specific scenario encountered, there is a 600ms default delay in `ExpandablePicker` when an item is selected, before the drawer collapses, potentially causing the spotting of the header to occur after something else has been spotted in response to the item being selected. The `_oLastControl` reference is used for firing container events when there is no currently spotted item, and thus if a container control such as `Popup` is shown when an item is selected, the container events will not fire for the `Popup` as it attempts to spot itself when the showing state changes, but the delayed spotting of the `ExpandablePicker` header occurs afterwards.

### Fix
In normal circumstances, Spotlight works correctly in the case when a `Popup` is shown, because `_oLastControl` references the popup, and thus the container events are properly fired for the correct control, allowing `Popup` to capture focus and spot its contained controls. I could not find a case where we needed to effectively allow `_oLastControl` to be updated when in pointer mode while closing the drawer (in pointer mode, we are not actually updating the currently spotted control, here), and so I've guarded the call with a check of the current pointer mode, only allowing for `unspot` to be called. This will prevent unnecessary updating of the `_oLastControl` reference and will still unhighlight the currently selected item when we close the drawer. I believe this fix to be relatively safe, whose root cause is a side effect of the whole `ExpandableListItem` header re-highlighting logic.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>