### PR TITLE
ENYO-2650: It doesn't read complete value of ProgressBar because of c…

### DIFF
--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -777,6 +777,15 @@ module.exports = kind(
 	accessibilityRole: 'progressbar',
 
 	/**
+	* Custom value for accessibility (ignored if `null`).
+	*
+	* @type {String|null}
+	* @default null
+	* @public
+	*/
+	accessibilityValueText: null,
+
+	/**
 	* ProgressBar isn't spottable so we'll make it focusable manually
 	*
 	* @private
@@ -787,18 +796,8 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		// TODO: Observing $.popupLabel.content to minimize the observed members. Some refactoring
-		// of the label determination could help here - rjd
-		{path: ['progress', 'popup', '$.popupLabel.content'], method: 'ariaValue'}
-	],
-
-	/**
-	* Determines the text or value to set as the accessible value for the progress bar
-	*
-	* @private
-	*/
-	ariaValue: function () {
-		var attr = this.popup ? 'aria-valuetext' : 'aria-valuenow';
-		this.setAriaAttribute(attr, (this.popup && this.$.popupLabel)? this.$.popupLabel.get('content') : this.progress);
-	}
+		{path: ['accessibilityValueText'], method: function () {
+			this.setAriaAttribute('aria-valuetext', this.accessibilityValueText);
+		}}
+	]
 });

--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -786,6 +786,15 @@ module.exports = kind(
 	accessibilityValueText: null,
 
 	/**
+	* When `true`, VoiceReadout will be prevented.
+	*
+	* @default true
+	* @type {Boolean}
+	* @public
+	*/
+	accessibilityDisabled: true,
+
+	/**
 	* ProgressBar isn't spottable so we'll make it focusable manually
 	*
 	* @private
@@ -796,8 +805,23 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
+		// TODO: Observing $.popupLabel.content to minimize the observed members. Some refactoring
+		// of the label determination could help here - rjd
+		{path: ['progress', 'popup', '$.popupLabel.content'], method: 'ariaValue'},
 		{path: ['accessibilityValueText'], method: function () {
 			this.setAriaAttribute('aria-valuetext', this.accessibilityValueText);
 		}}
-	]
+	],
+
+	/**
+	* Determines the text or value to set as the accessible value for the progress bar
+	*
+	* @private
+	*/
+	ariaValue: function () {
+		var attr = this.popup ? 'aria-valuetext' : 'aria-valuenow';
+		if (!this.accessibilityValueText) {
+			this.setAriaAttribute(attr, (this.popup && this.$.popupLabel)? this.$.popupLabel.get('content') : this.progress);
+		}
+	}
 });

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -979,7 +979,7 @@ module.exports = kind(
 				this.$.buttonRight.set('accessibilityLabel', this.accessibilityValueText);
 			}
 		}},
-		{path: ['value', 'popupContent', 'dragging'], method: 'ariaValue'}
+		{path: ['value', 'popup', '$.popupLabel.content', 'dragging'], method: 'ariaValue'}
 	],
 
 	/**

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -941,6 +941,15 @@ module.exports = kind(
 	accessibilityValueText: null,
 
 	/**
+	* When `true`, VoiceReadout will be prevented.
+	*
+	* @default false
+	* @type {Boolean}
+	* @public
+	*/
+	accessibilityDisabled: false,
+
+	/**
 	* @private
 	*/
 	ariaObservers: [


### PR DESCRIPTION
…hanging fast

Issue
It doesn't read complete value of ProgressBar because of changing fast

Cause
ProgressBar is used on like channel tuning, downloading and so on, the value is changed very fast.
It tried to read every changed value, so it can't read complete value.

Fix
Remove observing popup content and value and only support custom value
through accessibilityValueText.
If developer want to read something during on progress, can set
accessibilityValueText to read it.

https://jira2.lgsvl.com/browse/ENYO-2650
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>