### PR TITLE
ENYO-2651: Deburred the Spinner Balls

### DIFF
--- a/src/Spinner/Spinner.less
+++ b/src/Spinner/Spinner.less
@@ -173,7 +173,7 @@
 	}
 	.moon-spinner-ball-decorator {
 		position: relative;
-		width: @moon-spinner-size;
+		width: @moon-spinner-size - 1;  // Subtracting 1 here forces the Blink compositor to change the way anti-aliasing on the spinner balls render, eliminating artifacts on their round edges
 		height: @moon-spinner-size;
 		float: left;
 	}


### PR DESCRIPTION
Due to low-quality anti-aliasing settings, the spinner had an occasional extra pixel where it visually probably shouldn't. This change subtracts 1px from the size of the spinner to alter the Blink compositor and trick it into rendering a higher-quality edge for each ball, eliminating the blip. 🙅