### PR TITLE
ENYO-2628: Reduce the non-latin Header font-size to prevent layout issues

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -93,7 +93,7 @@
 @moon-non-latin-divider-font-size:      27px;
 @moon-non-latin-button-large-font-size: 36px;
 @moon-non-latin-button-small-font-size: 27px;
-@moon-non-latin-header-font-size:       114px;
+@moon-non-latin-header-font-size:       102px;
 @moon-non-latin-expandable-client-item-font-size: 27px;
 
 


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>