### PR TITLE
ENYO-2666: upadate small header's title to apply allowhtml properly

### DIFF
--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -676,6 +676,8 @@ module.exports = kind(
 					: (this.get('title') || this.get('content')),
 			subtitle = this.get('titleBelow');
 		if ((this.get('type') == 'small') && subtitle) {
+			title = this.allowHtml? title: dom.escape(title);
+			subtitle = this.allowHtml? subtitle: dom.escape(subtitle);
 			this.$.title.set('allowHtml', true);
 			this.$.title.set('content', Control.prototype.rtl && !util.isRtl(subtitle + title) ?
 				'<span class="moon-sub-header-text moon-header-sub-title">' + subtitle + '</span>' + '   ' + title :

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -676,9 +676,11 @@ module.exports = kind(
 					: (this.get('title') || this.get('content')),
 			subtitle = this.get('titleBelow');
 		if ((this.get('type') == 'small') && subtitle) {
-			title = this.allowHtml? title: dom.escape(title);
-			subtitle = this.allowHtml? subtitle: dom.escape(subtitle);
 			this.$.title.set('allowHtml', true);
+			if (!this.allowHtml) {
+				title = dom.escape(title);
+				subtitle = dom.escape(subtitle);
+			}
 			this.$.title.set('content', Control.prototype.rtl && !util.isRtl(subtitle + title) ?
 				'<span class="moon-sub-header-text moon-header-sub-title">' + subtitle + '</span>' + '   ' + title :
 				title + '   ' + '<span class="moon-sub-header-text moon-header-sub-title">' + subtitle + '</span>');


### PR DESCRIPTION
## issue
Title and titleBelow are always {allowHtml:true} in small header even header's allowHtml property is true

## fix
Based on header's allowHtml property, escape title and titleBelow string before set title of small header.

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.ch@lge.com