### PR TITLE
ENYO-2685: It doesn't read accessibilityLabel of expandable item on E…

### DIFF
--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -197,6 +197,7 @@ module.exports = kind(
 		{from: 'currentValueText', to: '$.header.text'},
 
 		// Accessibility
+		{from: 'selectedAccessibilityLabel', to: '$.header._accessibilityText'},
 		{from: 'accessibilityHint', to: '$.header.accessibilityHint'},
 		{from: 'accessibilityLabel', to: '$.header.accessibilityLabel'},
 		{from: 'accessibilityDisabled', to: '$.header.accessibilityDisabled'}

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -197,7 +197,6 @@ module.exports = kind(
 		{from: 'currentValueText', to: '$.header.text'},
 
 		// Accessibility
-		{from: 'selectedAccessibilityLabel', to: '$.header._accessibilityText'},
 		{from: 'accessibilityHint', to: '$.header.accessibilityHint'},
 		{from: 'accessibilityLabel', to: '$.header.accessibilityLabel'},
 		{from: 'accessibilityDisabled', to: '$.header.accessibilityDisabled'}

--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -209,7 +209,7 @@ module.exports = kind(
 		{from: 'selected.content', to: 'selectedText'},
 
 		// Accessibility
-		{from: 'selected.accessibilityLabel', to: 'selectedAccessibilityLabel'}
+		{from: 'selected.accessibilityLabel', to: '$.header._accessibilityText'}
 	],
 
 	computed: {

--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -206,7 +206,10 @@ module.exports = kind(
 	],
 
 	bindings: [
-		{from: 'selected.content', to: 'selectedText'}
+		{from: 'selected.content', to: 'selectedText'},
+
+		// Accessibility
+		{from: 'selected.accessibilityLabel', to: 'selectedAccessibilityLabel'}
 	],
 
 	computed: {

--- a/src/LabeledTextItem/LabeledTextItem.js
+++ b/src/LabeledTextItem/LabeledTextItem.js
@@ -59,7 +59,7 @@ module.exports = kind(
 		* @public
 		*/
 		label: '',
-		
+
 		/** 
 		* The text to be displayed in the item.
 		*
@@ -75,7 +75,10 @@ module.exports = kind(
 	*/
 	bindings: [
 		{from: 'label', to: '$.header.content'},
-		{from: 'text', to: '$.text.content', transform: 'setTextWithDirection'}
+		{from: 'text', to: '$.text.content', transform: 'setTextWithDirection'},
+
+		// Accessibility
+		{from: '_accessibilityText', to: '$.text.accessibilityLabel'}
 	],
 
 	/**
@@ -99,9 +102,15 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	_accessibilityText: '',
+
+	/**
+	* @private
+	*/
 	ariaObservers: [
 		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
-			var content = this.label + ' ' + this.text ,
+			var text = this._accessibilityText ? this._accessibilityText : this.text,
+				content = this.label + ' ' + text ,
 				prefix = this.accessibilityLabel || content || null,
 				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityHint ||


### PR DESCRIPTION
…xpandablePicker

Issue
When the ExpandablePicker is focused, it doesn't read accessibilityLabel of Item but previous value.

Cause
We don't bind accessibilityLabel of expandable item to the ExpandablePicker.
So when the item is focused it reads accessibilityLabel but if ExpandablePicker
is focused it just reads previous value not accessibilityLabel.

Fix
When the selected is changed, bind accessibilityLabel of expandable items
to the accessibilityLabel of header text.

https://jira2.lgsvl.com/browse/ENYO-2685
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>