### PR TITLE
Fixes ENYO-2638

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -729,9 +729,11 @@ module.exports = kind(
 	* @private
 	*/
 	animatorComplete: function (sender) {
-		this._setValue(sender.value);
-		this.animatingTo = null;
-		this.doAnimateFinish(sender);
+		if (!sender.isAnimating()) {
+			this._setValue(sender.value);
+			this.animatingTo = null;
+			this.doAnimateFinish(sender);
+		}
 		return true;
 	},
 


### PR DESCRIPTION
On repeated key events, an animation can be started before the onEnd
fires. The result can be an incorrect value set because the value on
the animator is mid-animation and not snapped to the increment value.
To avoid this, we'll skip handling the onEnd event when an animation is
in progress.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)