### PR TITLE
ENYO-2644: Scrollable: Snap to boundaries

### DIFF
--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -5,6 +5,7 @@
 var
 	kind = require('enyo/kind'),
 	utils = require('enyo/utils'),
+	resolution = require('enyo/resolution'),
 	ScrollMath = require('enyo/ScrollMath');
 
 var
@@ -45,7 +46,7 @@ var Scrollable = {
 	},
 
 	// Override ScrollMath params
-	scrollMath: {kind: ScrollMath, kFrictionDamping: 0.93},
+	scrollMath: {kind: ScrollMath, kFrictionDamping: 0.93, boundarySnapThreshold: resolution.scale(100)},
 
 	/**
 	* @private


### PR DESCRIPTION
When we 5-way scroll to an item near the boundary of a scrollable
region, we often (always?) want to scroll all the way to the
boundary.

We've added an option (boundarySnapThreshold) to enyo/ScrollMath,
and we'll use it in moonstone/Scrollable to scroll all the way to
a boundary if our target is within 100 pixels of the boundary.

Both the ScrollMath feature and the way we're using it here should
be considered experimental for the time being and subject to
change.

This change was precipitated by an issue filed against NewDataList,
in which scroll controls weren't being disabled after 5-way
scrolling to the last list item, since the scroll position was a
few pixels shy of the boundary.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)