### PR TITLE
ENYO-2552: Accessibility: When the value of slider is zero, the hint …

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -1001,7 +1001,8 @@ module.exports = kind(
 	*/
 	ariaValue: function () {
 		var attr = this.popup ? 'aria-valuetext' : 'aria-valuenow',
-			text = (this.popup && this.$.popupLabel)? this.$.popupLabel.getContent() : this.value;
+			text = (this.popup && this.$.popupLabel && this.$.popupLabel.getContent())?
+					this.$.popupLabel.getContent() : this.value;
 
 		if (!this.dragging && !this.accessibilityValueText) {
 			this.resetAccessibilityProperties();


### PR DESCRIPTION
…of the narrow doesn't contain the value.

Issue
Accessibility: When the value of slider is zero, the hint of the narrow doesn't contain the value.

Cause
At the initial time when value is 0, 'this.$.popupLabel.getContent()' is empty.
So it doesn't read popup conent on left/right button.

Fix
Add null check for this.$.popupLabel.getContent().

https://jira2.lgsvl.com/browse/ENYO-2552
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>