### PR TITLE
ENYO-2643: Each Scrollable needs its own options!

### DIFF
--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -60,15 +60,14 @@ var Scrollable = {
 	*/
 	create: kind.inherit(function (sup) {
 		return function () {
+			var opts = {
+				block: 'farthest',
+				behavior: 'smooth'
+			};
+
 			sup.apply(this, arguments);
 
-			if (!this.scrollIntoViewOptions) {
-				this.scrollIntoViewOptions = {
-					block: 'farthest',
-					behavior: 'smooth'
-				};
-			}
-
+			this.scrollIntoViewOptions = this.scrollIntoViewOptions ? utils.mixin(opts, this.scrollIntoViewOptions) : opts;
 			// Save original options so they can be restored after runtime changes
 			this._scrollIntoViewOptions = utils.clone(this.scrollIntoViewOptions);
 		};

--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -24,10 +24,18 @@ var Scrollable = {
 
 	suppressMouseEvents: true,
 
-	scrollIntoViewOptions: {
-		block: 'farthest',
-		behavior: 'smooth'
-	},
+	/**
+	* Specifies scrolling options to be used when scrolling an
+	* item into view. Defaults:
+	*
+	*	{
+	*		block: 'farthest',
+	*		behavior: 'smooth'
+	*	}
+	*
+	* @public
+	*/
+	scrollIntoViewOptions: null,
 
 	// TODO: At least in the case of onSpotlightFocus, we
 	// probably need to do something to ensure that we don't
@@ -53,7 +61,15 @@ var Scrollable = {
 	create: kind.inherit(function (sup) {
 		return function () {
 			sup.apply(this, arguments);
-			// Save default options so they can be restored after runtime changes
+
+			if (!this.scrollIntoViewOptions) {
+				this.scrollIntoViewOptions = {
+					block: 'farthest',
+					behavior: 'smooth'
+				};
+			}
+
+			// Save original options so they can be restored after runtime changes
 			this._scrollIntoViewOptions = utils.clone(this.scrollIntoViewOptions);
 		};
 	}),


### PR DESCRIPTION
Oops... `scrollIntoViewOptions` were being specified as an object
literal in the Scrollable mixin definition, which meant they were
inadvertently being shared by all instances. We'll initialize them
in the `create()` method instead.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)