### PR TITLE
PLAT-10341: Removed customized vertical ProgressBar tooltip

### DIFF
--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -375,27 +375,13 @@ module.exports = kind(
 		var orient = this.get('orientation');
 		this.addRemoveClass('moon-progress-bar-vertical', orient == 'vertical');
 		this.addRemoveClass('moon-progress-bar-horizontal', orient == 'horizontal');
-
-		if (orient == 'vertical') {
-			this.popupSideChanged();
-		}
 	},
 
 	/**
 	* @private
 	*/
 	popupSideChanged: function () {
-		if (this.$.popup) {
-			var orient = this.get('orientation'),
-				side = this.get('popupSide');
-			// If we have switched orientations, we should be sure to remove all of our orientation classes.
-			this.$.popup.removeClass('moon-progress-bar-popup-on-left');
-			this.$.popup.removeClass('moon-progress-bar-popup-on-right');
-
-			if (orient == 'vertical' && side) {
-				this.$.popup.addClass('moon-progress-bar-popup-on-' + side);
-			}
-		}
+		this.updatePopup();
 	},
 
 	/**
@@ -523,13 +509,11 @@ module.exports = kind(
 			usePercentage = this.showPercentage && this.popupContent === null;
 			percent = this.calcPercent(val);
 			popupLabel = usePercentage ? percent : this.progress;
-			flip = percent > 50;
+			flip = (this.get('orientation') == 'vertical') ? (this.get('popupSide') == 'left') : percent > 50;
 
 			this.updatePopupPosition(percent);
-			if (this.get('orientation') == 'horizontal') {
-				this.$.popup.addRemoveClass('moon-progress-bar-popup-flip-h', flip);
-				this.$.popupLabel.addRemoveClass('moon-progress-bar-popup-flip-h', flip);
-			}
+			this.$.popup.addRemoveClass('moon-progress-bar-popup-flip-h', flip);
+			this.$.popupLabel.addRemoveClass('moon-progress-bar-popup-flip-h', flip);
 
 			this.updatePopupLabel(popupLabel);
 		}
@@ -542,7 +526,7 @@ module.exports = kind(
 	*/
 	updatePopupPosition: function (percent) {
 		if (this.popup) {
-			this.$.popup.applyStyle(this.get('orientation') == 'vertical' ? 'bottom' :'left', percent + '%');
+			this.$.popup.applyStyle(this.get('orientation') == 'vertical' ? 'bottom' : 'left', percent + '%');
 		}
 	},
 
@@ -562,11 +546,7 @@ module.exports = kind(
 	updatePopupOffset: function () {
 		if (this.popup) {
 		// console.log("updatePopupOffset:", this.getPopupHeight(), this.getPopupOffset(), ri.scale(this.getPopupHeight() + this.getPopupOffset() + 5));
-			if (this.get('orientation') == 'horizontal') {
-				this.$.popup.applyStyle('top', dom.unit(-(ri.scale(this.getPopupHeight() + this.getPopupOffset() + 5)), 'rem'));
-			} else {
-				this.$.popup.applyStyle('top', null);
-			}
+			this.$.popup.applyStyle('top', dom.unit(-(ri.scale(this.getPopupHeight() + this.getPopupOffset() + 5)), 'rem'));
 		}
 	},
 
@@ -597,16 +577,14 @@ module.exports = kind(
 	* @private
 	*/
 	updatePopupHeight: function () {
-		if (this.popup && this.get('orientation') == 'horizontal') {
-			var h = this.getPopupHeight(),
-				hRem = ri.scale(h);
+		var h = this.getPopupHeight(),
+			hRem = ri.scale(h);
 
-			this.$.drawingLeft.setAttribute('height', hRem);
-			this.$.drawingRight.setAttribute('height', hRem);
-			this.$.popupLabel.applyStyle('height', dom.unit(ri.scale(h - 7), 'rem'));
-			this.$.popup.applyStyle('height', dom.unit(ri.scale(h), 'rem'));
-			this.$.popup.applyStyle('line-height', dom.unit(ri.scale(h - 6), 'rem'));
-		}
+		this.$.drawingLeft.setAttribute('height', hRem);
+		this.$.drawingRight.setAttribute('height', hRem);
+		this.$.popupLabel.applyStyle('height', dom.unit(ri.scale(h - 7), 'rem'));
+		this.$.popup.applyStyle('height', dom.unit(hRem, 'rem'));
+		this.$.popup.applyStyle('line-height', dom.unit(ri.scale(h - 6), 'rem'));
 	},
 
 	/**

--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -545,7 +545,6 @@ module.exports = kind(
 	*/
 	updatePopupOffset: function () {
 		if (this.popup) {
-		// console.log("updatePopupOffset:", this.getPopupHeight(), this.getPopupOffset(), ri.scale(this.getPopupHeight() + this.getPopupOffset() + 5));
 			this.$.popup.applyStyle('top', dom.unit(-(ri.scale(this.getPopupHeight() + this.getPopupOffset() + 5)), 'rem'));
 		}
 	},

--- a/src/ProgressBar/ProgressBar.less
+++ b/src/ProgressBar/ProgressBar.less
@@ -84,25 +84,7 @@
 		}
 
 		.moon-progress-bar-popup {
-			&.moon-progress-bar-popup-on-left {
-				right: 100%;
-				transform: translateY(50%) translateX(-12px);
-			}
-			&.moon-progress-bar-popup-on-right {
-				left: 100%;
-				transform: translateY(50%) translateX(12px);
-			}
-
-			.moon-progress-bar-popup-center {
-				border-radius: 60px;
-				line-height: 60px;
-				padding: 0 24px;
-			}
-
-			.moon-progress-bar-popup-left,
-			.moon-progress-bar-popup-right {
-				display: none;
-			}
+			left: 50%;
 		}
 	}
 }

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -632,7 +632,7 @@ module.exports = kind(
 		if (this.disabled) {
 			return; // return nothing
 		}
-		
+
 		e.preventDefault();
 		this.set('dragging', true);
 		Spotlight.freeze();


### PR DESCRIPTION
All tooltips used on ProgressBar and Slider look the same. Choosing a side in vertical progress bar is still an option, since the tooltip orientation shouldn't automatically change when progress is more than 50%.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>