### PR TITLE
ENYO-2482 :[Accessibility] Fix reading title when panels is not showing

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1341,7 +1341,7 @@ module.exports = kind(
 	// Accessibility
 
 	ariaObservers: [
-		{path: 'index', method: function () {
+		{path: ['showing', 'index'], method: function () {
 			var panels = this.getPanels(),
 				active = this.getActive(),
 				l = panels.length,
@@ -1350,7 +1350,7 @@ module.exports = kind(
 			while (--l >= 0) {
 				panel = panels[l];
 				if (panel instanceof Panel && panel.title) {
-					panel.set('accessibilityRole', panel === active ? 'alert' : 'region');
+					panel.set('accessibilityRole', (panel === active) && this.get('showing') ? 'alert' : 'region');
 				}
 			}
 		}}


### PR DESCRIPTION
## Issue 
Screen reader reads the title of the panel has 'showing: false'

## Cause
The active panel has 'alert' role when panel is initially loaded. However, alwaysviewing pattern panel is not shown when TV application is loaded. When user taps the right handle, panel is shown. At that time, 
panels also is shown. 

## Fix
Add 'showing' property to ariaObservers for observing if panels is showing or hiding.
In addition, add alert role when panels is showing.

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com