### PR TITLE
ENYO-2717: Add spotlight container to 'client' in LightPanel

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -104,7 +104,7 @@ module.exports = kind(
 	*/
 	components: [
 		{kind: Header, name: 'header', type: 'medium', marqueeOnRenderDelay: 1000},
-		{name: 'client', classes: 'client'},
+		{name: 'client', classes: 'client', spotlight: 'container'},
 		{name: 'spotlightPlaceholder', spotlight: false, style: 'width:0;height:0;'}
 	],
 


### PR DESCRIPTION
## Issue
When going to previous or re-entering to a existing panel, spotlight should remain in the previous spot. In many cases, apps define their `clientComponents` inside a Scroller which has a spotlight container. But in other cases, it won't preserve the last focused item.

## Fix
Add `spotlight: 'container'` to `client` component

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>