### PR TITLE
ENYO-2650: It doesn't read complete value of ProgressBar because of c…

### DIFF
--- a/src/Panels/PanelsAccessibilitySupport.js
+++ b/src/Panels/PanelsAccessibilitySupport.js
@@ -1,0 +1,52 @@
+/**
+* Provides a mixin to add accessibility support to
+* {@link module:moonstone/Panels~Panels}
+*
+* @module moonstone/Panels/PanelsAccessibilitySupport
+* @private
+*/
+
+var
+	kind = require('enyo/kind');
+
+var
+	Panel = require('../Panel');
+
+/**
+* @name PanelsAccessibilitySupport
+* @mixin
+*/
+module.exports = {
+
+	/**
+	* @private
+	*/
+	rendered: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.setAriaRole();
+		};
+	}),
+
+	_setIndex: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			this.setAriaRole();
+		};
+	}),
+
+	setAriaRole: function () {
+		console.log('aaa');
+		var panels = this.getPanels(),
+			active = this.getActive(),
+			l = panels.length,
+			panel;
+
+		while (--l >= 0) {
+			panel = panels[l];
+			if (panel instanceof Panel && panel.title) {
+				panel.set('accessibilityRole', panel === active ? 'alert' : 'region');
+			}
+		}
+	}
+};

--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -754,6 +754,24 @@ module.exports = kind(
 	accessibilityRole: 'progressbar',
 
 	/**
+	* Custom value for accessibility (ignored if `null`).
+	*
+	* @type {String|null}
+	* @default null
+	* @public
+	*/
+	accessibilityValueText: null,
+
+	/**
+	* When `true`, VoiceReadout will be prevented.
+	*
+	* @default true
+	* @type {Boolean}
+	* @public
+	*/
+	accessibilityDisabled: true,
+
+	/**
 	* ProgressBar isn't spottable so we'll make it focusable manually
 	*
 	* @private
@@ -766,7 +784,10 @@ module.exports = kind(
 	ariaObservers: [
 		// TODO: Observing $.popupLabel.content to minimize the observed members. Some refactoring
 		// of the label determination could help here - rjd
-		{path: ['progress', 'popup', '$.popupLabel.content'], method: 'ariaValue'}
+		{path: ['progress', 'popup', '$.popupLabel.content'], method: 'ariaValue'},
+		{path: ['accessibilityValueText'], method: function () {
+			this.setAriaAttribute('aria-valuetext', this.accessibilityValueText);
+		}}
 	],
 
 	/**
@@ -776,6 +797,8 @@ module.exports = kind(
 	*/
 	ariaValue: function () {
 		var attr = this.popup ? 'aria-valuetext' : 'aria-valuenow';
-		this.setAriaAttribute(attr, (this.popup && this.$.popupLabel)? this.$.popupLabel.get('content') : this.progress);
+		if (!this.accessibilityValueText) {
+			this.setAriaAttribute(attr, (this.popup && this.$.popupLabel)? this.$.popupLabel.get('content') : this.progress);
+		}
 	}
 });

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -943,6 +943,15 @@ module.exports = kind(
 	accessibilityValueText: null,
 
 	/**
+	* When `true`, VoiceReadout will be prevented.
+	*
+	* @default false
+	* @type {Boolean}
+	* @public
+	*/
+	accessibilityDisabled: false,
+
+	/**
 	* @private
 	*/
 	ariaObservers: [
@@ -981,7 +990,7 @@ module.exports = kind(
 				this.$.buttonRight.set('accessibilityLabel', this.accessibilityValueText);
 			}
 		}},
-		{path: ['value', 'popupContent', 'dragging'], method: 'ariaValue'}
+		{path: ['value', 'popup', '$.popupLabel.content', 'dragging'], method: 'ariaValue'}
 	],
 
 	/**


### PR DESCRIPTION
…hanging fast

Issue
It doesn't read complete value of ProgressBar because of changing fast

Cause
ProgressBar is used on like channel tuning, downloading and so on, the value is changed very fast.
It tried to read every changed value, so it can't read complete value.

Fix
Remove observing popup content and value and only support custom value
through accessibilityValueText.
If developer want to read something during on progress, can set
accessibilityValueText to read it.

https://jira2.lgsvl.com/browse/ENYO-2650
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang jaewon98.jang@lgepartner.com