### PR TITLE
Fixes ENYO-2707

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -531,6 +531,7 @@ module.exports = kind(
 			}
 			if (this.animate && allowAnimation) {
 				this.animateTo(was, is);
+				this.updateButtonStatus();
 			} else {
 				this._setValue(is);
 			}
@@ -589,8 +590,8 @@ module.exports = kind(
 	*/
 	updateButtonStatus: function () {
 		if (this.enableJumpIncrement) {
-			this.$.buttonLeft.set('disabled', this.disabled || this.value == this.min);
-			this.$.buttonRight.set('disabled', this.disabled || this.value == this.max);
+			this.$.buttonLeft.set('disabled', this.disabled || this.value <= this.min);
+			this.$.buttonRight.set('disabled', this.disabled || this.value >= this.max);
 		}
 	},
 
@@ -852,6 +853,7 @@ module.exports = kind(
 	* @private
 	*/
 	hideKnobStatus: function (sender, e) {
+		this._jumpSender = null;
 		if (this.popup) {
 			this.$.popup.hide();
 		}
@@ -883,14 +885,18 @@ module.exports = kind(
 	*/
 	jumpButtonTriggered: function (sender, ev) {
 		var isValidEvent = true;
-		if (!sender.disabled) {
+		if (!sender.disabled && (!this._jumpSender || this._jumpSender == sender)) {
 			if (ev.keyCode != 13 && ev.type == 'onSpotlightKeyDown') {
 				isValidEvent = false;
 			}
 			if (isValidEvent) {
 				if (sender === this.$.buttonLeft) this.previous();
 				else this.next();
+				this._jumpSender = sender;
 			}
+		}
+		else if (Spotlight.Accelerator.isAccelerating()) {
+			Spotlight.Accelerator.cancel();
 		}
 	},
 


### PR DESCRIPTION
When holding enter on the jump increment buttons of Slider, spotlight
would jump to the other button when the first was disabled. The key
events continued to fire since [Enter] had not been released so the
value would start changing in the other direction.

To resolve, note the sender of the keydown event and ignore future
events from other senders until the keyup fires and resets the value.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)