### PR TITLE
ENYO-2485: When cardArranger panels are switched, screen reader doesn…

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1052,6 +1052,7 @@ module.exports = kind(
 		var panels = this.getPanels(),
 			toIndex = this.toIndex,
 			fromIndex = this.fromIndex,
+			active = this.getActive(),
 			i, panel, info, popFrom;
 
 		this.notifyPanels('transitionFinished');
@@ -1082,7 +1083,9 @@ module.exports = kind(
 
 		Spotlight.unmute(this);
 		// Spot the active panel
-		Spotlight.spot(this.getActive());
+		this.startJob('spot', function () {
+			Spotlight.spot(active);
+		}, 50);
 	},
 
 	/**


### PR DESCRIPTION
…'t read the focused item.

Issue
We can't guarantee reading order title and focused item.
According to UX guide we should read title and then read focused item.

Cause
The events for alert role and dom focus occur almost same time.

Fix
On blink side, once the alert event occurs before dome focus
the web engine read alert text(less than 30 characters) and then
read focused text.
On moonstone side, set 50 milliseconds delay on Spot() to occur focus
event later.

https://jira2.lgsvl.com/browse/ENYO-2485
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>