### PR TITLE
ENYO-2467: Ensure header gets spotted when IntegerPicker gets selecte…

### DIFF
--- a/src/ExpandableIntegerPicker/ExpandableIntegerPicker.js
+++ b/src/ExpandableIntegerPicker/ExpandableIntegerPicker.js
@@ -140,7 +140,7 @@ module.exports = kind(
 	* @private
 	*/
 	drawerComponents: [
-		{name: 'picker', kind: SimpleIntegerPicker, deferInitialization: true, onSelect: 'toggleActive', onChange: 'pickerValueChanged'}
+		{name: 'picker', kind: SimpleIntegerPicker, deferInitialization: true, onSelect: 'closeDrawerAndHighlightHeader', onChange: 'pickerValueChanged'}
 	],
 
 	/**


### PR DESCRIPTION
…d in ExpandableIntegerPicker

## Issue
When integer picker is set using 5-way key, it will move spotlight to the top item instead of header.

## Cause
When selected, it's only setting the active value and does not spot back to header. When it closes without setting spotlight back to header, it will lost spotlight and sets to default disappear spotlight, the first child of root in this case.

## Fix
Set spotlight back to header before closing

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>