### PR TITLE
ENYO-2710: "Scroll to boundary" support for Moonstone scroller

### DIFF
--- a/src/Scroller/Scroller.js
+++ b/src/Scroller/Scroller.js
@@ -297,14 +297,14 @@ if (platform.touch) {
 		* @private
 		*/
 		bindings: [
-			{from: '.scrollInterval',				to:'.$.strategy.interval'},
-			{from: '.scrollWheelMultiplier',		to:'.$.strategy.scrollWheelMultiplier'},
-			{from: '.scrollWheelPageMultiplier',	to:'.$.strategy.scrollWheelPageMultiplier'},
-			{from: '.paginationPageMultiplier',		to:'.$.strategy.paginationPageMultiplier'},
-			{from: '.paginationScrollMultiplier',	to:'.$.strategy.paginationScrollMultiplier'},
-			{from: '.hideScrollColumnsWhenFit',		to:'.$.strategy.hideScrollColumnsWhenFit'},
-			{from: '.scrollToBoundaryDelay',		to:'.$.strategy.scrollToBoundaryDelay'},
-			{from: '.scrollToBoundaryAnimate',		to:'.$.strategy.scrollToBoundaryAnimate'}
+			{from: 'scrollInterval',				to:'$.strategy.interval'},
+			{from: 'scrollWheelMultiplier',			to:'$.strategy.scrollWheelMultiplier'},
+			{from: 'scrollWheelPageMultiplier',		to:'$.strategy.scrollWheelPageMultiplier'},
+			{from: 'paginationPageMultiplier',		to:'$.strategy.paginationPageMultiplier'},
+			{from: 'paginationScrollMultiplier',	to:'$.strategy.paginationScrollMultiplier'},
+			{from: 'hideScrollColumnsWhenFit',		to:'$.strategy.hideScrollColumnsWhenFit'},
+			{from: 'scrollToBoundaryDelay',			to:'$.strategy.scrollToBoundaryDelay'},
+			{from: 'scrollToBoundaryAnimate',		to:'$.strategy.scrollToBoundaryAnimate'}
 		],
 
 		/**

--- a/src/Scroller/Scroller.js
+++ b/src/Scroller/Scroller.js
@@ -190,12 +190,39 @@ if (platform.touch) {
 			onSpotlightScrollUp:'spotlightWheel',
 			onSpotlightScrollDown:'spotlightWheel',
 			onSpotlightContainerEnter:'enablePageUpDownKey',
-			// Temporary fix for ENYO-2277 -- see note below
+			onSpotlightFocus: 'checkBounce',
 			onSpotlightContainerLeave:'containerLeaveHandler',
 			onenter:'enablePageUpDownKey',
 			onleave:'disablePageUpDownKey',
 			onmove:'move'
 		},
+
+		/**
+		* Need this to prevent the web engine from adjusting the native
+		* scrollTop / scrollLeft props behind our backs under certain
+		* circumstances (when an element inside the scroller is
+		* programatically focused).
+		*
+		* @private
+		*/
+		accessibilityPreventScroll: true,
+
+		// The scrollToBoundary configuration parameters below
+		// are considered private for now, but have been factored
+		// this way and are sync'd with moonstone/ScrollStrategy so that
+		// they can be changed in one place and could be overridden in case
+		// of emergency.
+
+		/**
+		* @private
+		*/
+		scrollToBoundaryDelay: 100,
+
+		/**
+		* @private
+		*/
+		scrollToBoundaryAnimate: true,
+
 
 		/**
 		* If `true`, scroll events are not allowed to propagate.
@@ -275,7 +302,9 @@ if (platform.touch) {
 			{from: '.scrollWheelPageMultiplier',	to:'.$.strategy.scrollWheelPageMultiplier'},
 			{from: '.paginationPageMultiplier',		to:'.$.strategy.paginationPageMultiplier'},
 			{from: '.paginationScrollMultiplier',	to:'.$.strategy.paginationScrollMultiplier'},
-			{from: '.hideScrollColumnsWhenFit',		to:'.$.strategy.hideScrollColumnsWhenFit'}
+			{from: '.hideScrollColumnsWhenFit',		to:'.$.strategy.hideScrollColumnsWhenFit'},
+			{from: '.scrollToBoundaryDelay',		to:'.$.strategy.scrollToBoundaryDelay'},
+			{from: '.scrollToBoundaryAnimate',		to:'.$.strategy.scrollToBoundaryAnimate'}
 		],
 
 		/**
@@ -360,38 +389,64 @@ if (platform.touch) {
 		},
 
 		/**
-		* This is a temporary fix for ENYO-2277. We intend to replace
-		* it with a solution that doesn't wait until focus leaves the container
-		* to scroll to the edge.
-		*
 		* @private
 		*/
+		checkBounce: function (sender, event) {
+			if (event.focusType === '5-way bounce') {
+				this.stopJob('scrollToBoundary');
+			}
+		},
 
+		/**
+		* @private
+		*/
 		containerLeaveHandler: function (sender, event) {
-			var strategy = this.getStrategy(),
-				b = strategy.getScrollBounds(),
-				o5WayEvent = Spotlight.getLast5WayEvent(),
-				lastControl = Spotlight.getLastControl();
-
-			// We are similarly scrolling horizontally to show disabled controls to the left or right of the scroller.
-			if (event.originator == this && o5WayEvent && lastControl && lastControl.kindName != 'moon.PagingControl') {
-				switch (o5WayEvent.type) {
-					case 'onSpotlightUp': 
-						if (strategy.getScrollTop() > 0) strategy.setScrollTop(0);
-						break;
-					case 'onSpotlightDown':
-						if (strategy.getScrollTop() < b.maxTop) strategy.setScrollTop(b.maxTop);
-						break;
-					case 'onSpotlightLeft':
-						if (strategy.getScrollLeft() > 0) strategy.setScrollLeft(0);
-						break;
-					case 'onSpotlightRight':
-						if (strategy.getScrollLeft() < b.maxLeft) strategy.setScrollLeft(b.maxLeft);
-						break;
-				}
+			// We want to scroll to the boundary when 5-way focus leaves the scroller,
+			// but we do this in a job to prevent scrolling in the case where focus
+			// immediately "bounces" back into the scroller because there's nothing
+			// spottable in the given direction
+			if (event.originator === this) {
+				this.startJob('scrollToBoundary', this.scrollToBoundary, this.scrollToBoundaryDelay);
 			}
 
 			this.disablePageUpDownKey();
+		},
+
+		/**
+		* If 5-way focus is leaving the scroller, we scroll to the scroller's
+		* boundary in the direction of the move. This logic works in
+		* conjunction with related logic in moonstone/ScrollStrategy to allow users
+		* to 5-way scroll all the way to the edge of a scroller, even when
+		* the controls nearest the scroller boundary are disabled or otherwise
+		* unfocusable.
+		*
+		* @private
+		*/
+		scrollToBoundary: function () {
+			var strategy = this.getStrategy(),
+				b = strategy.getScrollBounds(),
+				o5WayEvent = Spotlight.getLast5WayEvent(),
+				lastControl = Spotlight.getLastControl(),
+				top = strategy.getScrollTop(),
+				left = strategy.getScrollLeft(),
+				animate = this.scrollToBoundaryAnimate;
+
+			if (o5WayEvent && lastControl && lastControl.kindName != 'moon.PagingControl') {
+				switch (o5WayEvent.type) {
+					case 'onSpotlightUp': 
+						if (top > 0) strategy.scrollTo(left, 0, animate);
+						break;
+					case 'onSpotlightDown':
+						if (top < b.maxTop) strategy.scrollTo(left, b.maxTop, animate);
+						break;
+					case 'onSpotlightLeft':
+						if (left > 0) strategy.scrollTo(0, top, animate);
+						break;
+					case 'onSpotlightRight':
+						if (left < b.maxLeft) strategy.scrollTo(b.maxLeft, top, animate);
+						break;
+				}
+			}
 		},
 
 		/**


### PR DESCRIPTION
The primary way to scroll in Moonstone when in 5-way mode is to
move focus from one item to another and allow the scroller to
continually scroll the focused item into view as you go.

This means that if the elements closest to a scroller boundary
happen to be unfocusable (either because they're disabled or
because they don't support focus at all), you sometimes can't
scroll all the way to the edge of the scroller.

In this change, we add logic to detect when the just-focused
element is the last focusable element in the direction we're
moving. If it is the last focusable element, then we go ahead and
scroll all the way to the scroller boundary, provided that the
element will still be in view.

A partial solution to the same problem previously went in for
ENYO-2277, but that solution waited until focus left the scroller
to scroll to the boundary. We leave an enhanced version of that
solution intact, since it is still required to handle the case
where we can't scroll all the way to the boundary at the time of
focus because the last focusable element is far enough from the
scroller boundary that it would no longer be visible.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)