### PR TITLE
ENYO-2659: Accessibility: SimpleIntegerPicker reads the label twice.

### DIFF
--- a/src/IntegerPicker/IntegerPicker.js
+++ b/src/IntegerPicker/IntegerPicker.js
@@ -725,23 +725,10 @@ module.exports = kind(
 	ariaObservers: [
 		{from: 'min', to: 'aria-valuemin'},
 		{from: 'max', to: 'aria-valuemax'},
+		{path: 'generated',  method: 'ariaValue'},
 		{path: 'value',  method: function () {
 			// When value is changed, it reads only value
 			if (this.spotted) {
-				this.set('accessibilityHint', null);
-				this.ariaValue();
-			}
-		}},
-		{path: 'spotted',  method: function () {
-			// When spotlight is focused, it reads value with hint
-			if (this.spotted) {
-				if (!this.wrap && this.value == this.min) {
-					this.set('accessibilityHint', $L('change a value with up button'));
-				} else if (!this.wrap && this.value == this.max) {
-					this.set('accessibilityHint', $L('change a value with down button'));
-				} else {
-					this.set('accessibilityHint', $L('change a value with up down button'));
-				}
 				this.ariaValue();
 			}
 		}}

--- a/src/IntegerPicker/IntegerPicker.js
+++ b/src/IntegerPicker/IntegerPicker.js
@@ -19,9 +19,6 @@ var
 	ScrollStrategy = require('../ScrollStrategy'),
 	TouchScrollStrategy = ScrollStrategy.Touch;
 
-var
-	$L = require('../i18n');
-
 /**
 * Fires when the currently selected value changes.
 *

--- a/src/SimpleIntegerPicker/SimpleIntegerPicker.js
+++ b/src/SimpleIntegerPicker/SimpleIntegerPicker.js
@@ -12,9 +12,6 @@ var
 var
 	IntegerPicker = require('../IntegerPicker');
 
-var
-	$L = require('../i18n');
-
 /**
 * Fires when the currently selected item changes.
 *

--- a/src/SimpleIntegerPicker/SimpleIntegerPicker.js
+++ b/src/SimpleIntegerPicker/SimpleIntegerPicker.js
@@ -211,23 +211,10 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
+		{path: 'generated',  method: 'ariaValue'},
 		{path: ['value', 'unit'],  method: function () {
 			// When value is changed, it reads only value
 			if (this.spotted) {
-				this.set('accessibilityHint', null);
-				this.ariaValue();
-			}
-		}},
-		{path: 'spotted',  method: function () {
-			// When spotlight is focused, it reads value with hint
-			if (this.spotted) {
-				if (!this.wrap && this.value == this.min) {
-					this.set('accessibilityHint', $L('change a value with right button'));
-				} else if (!this.wrap && this.value == this.max) {
-					this.set('accessibilityHint', $L('change a value with left button'));
-				} else {
-					this.set('accessibilityHint', $L('change a value with left right button'));
-				}
 				this.ariaValue();
 			}
 		}}


### PR DESCRIPTION
Issue
IntegerPicker and SimpleIntegerPicker reads the label twice.

Cause
When spotlight focused, both dom focus event and set aria-valuenow event
are occured at the same time.

Fix
In case spotlight focus we don't update aria-vluenow, just read value and label
This commit has dependency on PLAT-10203, hint will be removed.

https://jira2.lgsvl.com/browse/ENYO-2659
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>