### PR TITLE
ENYO-2736 Don't call unspot() manually in pointerMode

### DIFF
--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -320,9 +320,8 @@ module.exports = kind(
 
 		// If the spotlight is elsewhere, we don't want to hijack it (e.g. after the delay in
 		// ExpandablePicker)
-		if (!current || current.isDescendantOf(this)) {
-			if (Spotlight.getPointerMode()) Spotlight.unspot();
-			else Spotlight.spot(this.$.header);
+		if ((!current || current.isDescendantOf(this)) && !Spotlight.getPointerMode()) {
+			Spotlight.spot(this.$.header);
 		}
 		this.set('active', false);
 	},


### PR DESCRIPTION
Issue
-----
When we select item of ExpandablePicker with pointerMode,
we lose spotlight focus if we do not move mouse cursor.

Cause
-------
{{closeDrawerAndHighlightHeader}} unspot its focus manually and close picker
Due to that, it does not execute onDisappear routine of Spotlight.

Fix
-----
Remove unspot(). 
Selected item will lose its focus naturally according to disappear routine of Spotlight

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com