### PR TITLE
Fixes ENYO-2758

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -867,7 +867,13 @@ module.exports = kind(
 	* @private
 	*/
 	sendChangeEvent: function (data) {
-		this.throttleJob('sliderChange', function () { this.doChange(data); }, this.changeDelayMS);
+		var value = this.value;
+		this.throttleJob('sliderChange', function () {
+			this.doChange(data);
+			this.startJob('sliderChangePost', function () {
+				if (this.value !== value) this.doChange({value: this.value});
+			}, this.changeDelayMS);
+		}, this.changeDelayMS);
 	},
 
 	/**


### PR DESCRIPTION
When quickly changing the value of a slider, the final one/few change
events can be suppressed by throttleJob resulting in the last onChange
event received by the UI being out of sync with the true value of the
Slider.

To resolve, start a job in the throttleJob callback with the same
duration that fires a final onChange if the value has changed since the
last time onChange was fired.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)