### PR TITLE
ENYO-2751 Prevent to toggle drawer when spotlightBlur event triggered

### DIFF
--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -214,7 +214,7 @@ module.exports = kind(
 	*/
 	inputSpotBlurred: function (inSender, inEvent) {
 		var eventType = Spotlight.getLastEvent().type;
-		if (Spotlight.getPointerMode() && eventType !== 'onSpotlightFocus' && eventType !== 'mouseover') {
+		if (this.open && Spotlight.getPointerMode() && eventType !== 'onSpotlightFocus' && eventType !== 'mouseover') {
 			this.expandContract();
 		}
 	},

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -215,7 +215,7 @@ module.exports = kind(
 	inputSpotBlurred: function (inSender, inEvent) {
 		var eventType = Spotlight.getLastEvent().type;
 		if (this.open && Spotlight.getPointerMode() && eventType !== 'onSpotlightFocus' && eventType !== 'mouseover') {
-			this.expandContract();
+			this.closeDrawerAndHighlightHeader();
 		}
 	},
 

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -213,9 +213,12 @@ module.exports = kind(
 	* @private
 	*/
 	inputSpotBlurred: function (inSender, inEvent) {
-		var eventType = Spotlight.getLastEvent().type;
-		if (this.open && Spotlight.getPointerMode() && eventType !== 'onSpotlightFocus' && eventType !== 'mouseover') {
-			this.closeDrawerAndHighlightHeader();
+		var eventType;
+		if (this.open && Spotlight.getPointerMode()) {
+			eventType = Spotlight.getLastEvent().type;
+			if (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover') {
+				this.closeDrawerAndHighlightHeader();
+			}
 		}
 	},
 
@@ -256,7 +259,7 @@ module.exports = kind(
 		if (this.lockBottom) {
 			this.focusInput();
 		} else {
-			this.expandContract();
+			this.closeDrawerAndHighlightHeader();
 		}
 		return true;
 	},


### PR DESCRIPTION
Issue
-------
VKB is showing up again when we click 'enter' button without mouse moving

Cause
--------
Recently added event like {{keyboardStateChange}} and {{webOSMouse}} will trigger {{spotlightBlur}} event. moon.ExpandableInput has a {{spotlightBlur}} event hander which toggle drawer.
Its purpose is closing drawer when user clicks outside of drawer.
But it toggles drawer from close to open when {{spotlightBlur}} event is triggered.

Fix
----
Add a condition to condition check.

Enyo-DCO-1.1-Signed-off-by: David Um david.um@lge.com