### PR TITLE
PLAT-10833: Add Text to Speech Accessibility support to PanelsHandle

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -22,6 +22,9 @@ var
 	Spotlight = require('spotlight');
 
 var
+	$L = require('../i18n');
+
+var
 	options = require('../options'),
 	BreadcrumbArranger = require('../BreadcrumbArranger'),
 	Panel = require('../Panel'),
@@ -1349,6 +1352,14 @@ module.exports = kind(
 				active = this.getActive(),
 				l = panels.length,
 				panel;
+
+			if (this.$.showHideHandle) {
+				if (active.title) {
+					this.$.showHideHandle.set('accessibilityLabel', (this.showing ? $L('Close') : $L('Open')) + ' ' + active.title);
+				} else {
+					this.$.showHideHandle.set('accessibilityLabel', this.showing ? $L('Close') : $L('Open'));
+				}
+			}
 
 			while (--l >= 0) {
 				panel = panels[l];


### PR DESCRIPTION
According to UX guide, we add accessibilityLabel on PanelsHandle.
When panels is showing, it should be read 'close' + 'panel title'.
When panels isn't showing, it should be read 'open' + 'panel title'.

https://jira2.lgsvl.com/browse/PLAT-10833
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>