### PR TITLE
ENYO-2497: Accessibility: Screen reader doesn't read 'loading' messag…

### DIFF
--- a/src/VideoPlayer/VideoPlayer.js
+++ b/src/VideoPlayer/VideoPlayer.js
@@ -655,7 +655,7 @@ module.exports = kind(
 				onFastforward: '_fastforward', onSlowforward: '_slowforward', onRewind: '_rewind', onSlowrewind: '_slowrewind',
 				onJumpForward: '_jumpForward', onJumpBackward: '_jumpBackward', onratechange: 'playbackRateChange', ontap: 'videoTapped', oncanplay: '_setCanPlay', onwaiting: '_waiting', onerror: '_error'
 			},
-			{name: 'spinner', kind: Spinner, classes: 'moon-video-player-spinner'}
+			{name: 'spinner', kind: Spinner, accessibilityLabel: $L('Loading'), classes: 'moon-video-player-spinner'}
 		]},
 
 		//* Fullscreen controls


### PR DESCRIPTION
…e of the spinner in the VideoPlayer sample.

In case ther is no content in Spinner, the string 'Loading' should be added.
Add accessibilityLabel 'Loading' on Spinner in VideoPlayer

https://jira2.lgsvl.com/browse/ENYO-2497
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang jaewon98.jang@lgepartner.com