### PR TITLE
ENYO-2744: moon/DataList: Restore state on render

### DIFF
--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -40,7 +40,16 @@ var DataListSpotlightSupport = {
 		* @default -1
 		* @public
 		*/
-		initialFocusIndex: -1
+		initialFocusIndex: -1,
+
+		/**
+		* Restores focus to the last spotted item when the DataList is re-rendered.
+		*
+		* @type {Boolean}
+		* @default false
+		* @public
+		*/
+		rememberFocusIndex: false
 	},
 
 	/**
@@ -50,7 +59,8 @@ var DataListSpotlightSupport = {
 		onSpotlightUp    : '_spotlightPrev',
 		onSpotlightLeft  : '_spotlightPrev',
 		onSpotlightDown  : '_spotlightNext',
-		onSpotlightRight : '_spotlightNext'
+		onSpotlightRight : '_spotlightNext',
+		onSpotlightBlur  : '_spotlightBlur'
 	},
 
 	/**
@@ -154,6 +164,15 @@ var DataListSpotlightSupport = {
 	*/
 	_spotlightPrev: function (inSender, inEvent) {
 		return this._spotlightSelect(inEvent, -1);
+	},
+
+	/**
+	* @private
+	*/
+	_spotlightBlur: function (sender, event) {
+		if (this.rememberFocusIndex) {
+			this.rememberFocus();
+		}
 	},
 
 	/**
@@ -387,13 +406,22 @@ var DataListSpotlightSupport = {
 	* @private
 	*/
 	unspotAndRememberFocus: function () {
+		if (this.rememberFocus()) {
+			Spotlight.unspot();
+		}
+	},
+
+	/**
+	* @private
+	*/
+	rememberFocus: function () {
 		var current = this.getFocusedChild(),
 			focusedItem;
 		if (current) {
 			focusedItem = this.getItemFromChild(current);
 			this._indexToFocus = focusedItem.index;
 			this._subChildToFocus = focusedItem === current ? null : Spotlight.getChildren(focusedItem).indexOf(current);
-			Spotlight.unspot();
+			return true;
 		}
 	},
 

--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -465,11 +465,17 @@ var DataListSpotlightSupport = {
 			c = this.collection,
 			callback;
 		if (c && c.length && (index > -1 || maxVisibleIndex > -1)) {
-			if (index > -1) {
-				callback = this.bindSafely(function () {
+			callback = (index > -1) ?
+				this.bindSafely(function () {
 					this.focusOnIndex(index, subChild);
+				}) :
+				this.bindSafely(function () {
+					// This ugly hack is required because scrolling to a control
+					// in Moonstone by default sets that control to be the last focused
+					// child (even if we don't actually focus it). In this case, we
+					// don't want that, so we need to clean up after ourselves.
+					Spotlight.Container.setLastFocusedChild(this.$.scroller, null);
 				});
-			}
 			this.scrollToIndex(maxVisibleIndex, callback);
 			this.clearState();
 		}


### PR DESCRIPTION
We have recently started getting more aggressive about view
virtualization for performance reasons. One tactic in this area
involves tearing down the DOM representation of a Control and then
restoring it later as needed ("view caching").

In the case where the view being cached / restored contains a
DataList, the state of the view was not being preserved as expected
because DataList effectively resets upon being (re-)rendered.

The proper fix for this issue would involve rethinking the DataList
lifecycle with view-virtualization scenarios in mind, but this
would be a significant effort and the current DataList is on a
relatively short road to replacement, so for now we'll go with a
lighter-weight, Moonstone-specific solution.

In a nutshell, we remember both the current focus and the scroll
position (as aproximated by the range of elements currently in
view) when the list is torn down, and optionally restore this state
when the list is re-rendered.

These changes necessitated a number of small tweaks to Enyo core,
so this change is dependent on those changes.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)