### PR TITLE
the spinner ball is not perfectly circular in rtl case

### DIFF
--- a/src/Spinner/Spinner.less
+++ b/src/Spinner/Spinner.less
@@ -167,10 +167,8 @@
 	}
 	.moon-spinner-ball-decorator {
 		position: relative;
-		width: @moon-spinner-size;  // Subtracting 1 here forces the Blink compositor to change the way anti-aliasing on the spinner balls render, eliminating artifacts on their round edges
+		width: @moon-spinner-size;
 		height: @moon-spinner-size;
-		margin-left: 1px;
-		margin-right: 1px;
 		float: left;
 	}
 	.moon-spinner-ball {
@@ -183,7 +181,8 @@
 		-webkit-animation-play-state: paused;
 		animation-play-state: paused;
 		height: @moon-spinner-ball-height;
-		width: @moon-spinner-ball-width;
+		width: @moon-spinner-ball-width;		// While we're using a font-icon as our ball, we need extra clearance around it, so it's not clipped by the browser's layer composer.
+		padding: 0 1px;
 		left: (50% - (@moon-spinner-ball-width / 2));
 		bottom: (50% - @moon-spinner-ball-height - @moon-spinner-ball-disatance);
 		-webkit-transform-origin: center ((@moon-spinner-ball-disatance / @moon-spinner-ball-height) * -100);

--- a/src/Spinner/Spinner.less
+++ b/src/Spinner/Spinner.less
@@ -167,8 +167,10 @@
 	}
 	.moon-spinner-ball-decorator {
 		position: relative;
-		width: @moon-spinner-size - 1;  // Subtracting 1 here forces the Blink compositor to change the way anti-aliasing on the spinner balls render, eliminating artifacts on their round edges
+		width: @moon-spinner-size;  // Subtracting 1 here forces the Blink compositor to change the way anti-aliasing on the spinner balls render, eliminating artifacts on their round edges
 		height: @moon-spinner-size;
+		margin-left: 1px;
+		margin-right: 1px;
 		float: left;
 	}
 	.moon-spinner-ball {


### PR DESCRIPTION
Cause
--------
This issue for ltr case is fixed with Blake's fix, but rtl case, we need more.

Fix
----
I suggest margin-left:1 px and margin-right:1px for eliminating the blip
Then, we can handle ltr case with margin-right: 1px and rtl case with margin-left:1px

Enyo-DCO-1.1-Signed-off-by: Suhyung Lee suhyung2.lee@lge.com