### PR TITLE
ENYO-2782: fix for PLAT-10833 makes undefined error

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1356,7 +1356,7 @@ module.exports = kind(
 				panel;
 
 			if (this.$.showHideHandle) {
-				if (active.title) {
+				if (active && active.title) {
 					this.$.showHideHandle.set('accessibilityLabel', (this.showing ? $L('Close') : $L('Open')) + ' ' + active.title);
 				} else {
 					this.$.showHideHandle.set('accessibilityLabel', this.showing ? $L('Close') : $L('Open'));


### PR DESCRIPTION
Issue
When opening DynamicPanelsSample, undefined error occurs.

Cause
null checking is omitted

Fix
add null checking for active panel

https://jira2.lgsvl.com/browse/ENYO-2782
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>