### PR TITLE
ENYO-2788: Use new `beforeTeardown()` lifecycle method...

### DIFF
--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -493,19 +493,19 @@ var DataListSpotlightSupport = {
 	},
 
 	/**
-	* Override `teardownChildren()` so that we can remember which
-	* controls were on screen and restore them upon re-rendering
+	* Implement the `beforeTeardown()` lifecycle method so that we
+	* can remember which controls were on screen and restore them
+	* upon re-rendering
 	*
 	* @private
 	*/
-	teardownChildren: function () {
+	beforeTeardown: function () {
 		if (this.restoreStateOnRender) {
 			this.rememberScrollState();
 		}
 		else {
 			this.clearState();
 		}
-		DataList.prototype.teardownChildren.apply(this, arguments);
 	},
 
 	/**


### PR DESCRIPTION
...instead of overriding `teardownChildren()`.

Enyo-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)