### PR TITLE
Fixes ENYO-2733 prevent a11y-related scrolling in Drawers

### DIFF
--- a/src/Drawers/Drawers.js
+++ b/src/Drawers/Drawers.js
@@ -176,6 +176,14 @@ module.exports = kind(
 	_activated: false,
 
 	/**
+	* If a fullscreen control is spotted within the drawers while the handle container is open, the
+	* activator will get scrolled out of view without scrolling prevented.
+	*
+	* @private
+	*/
+	accessibilityPreventScroll: true,
+
+	/**
 	* @private
 	*/
 	handlers: {


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
