### PR TITLE
PLAT-11511: Delete Text to Speech Accessibility support to Meridiem o…

### DIFF
--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -767,7 +767,9 @@ var TimePicker = module.exports = kind(
 		{path: ['hourText', 'minuteText', 'meridiemText'], method: function () {
 			this.$.hour.set('accessibilityLabel', this.hourText);
 			this.$.minute.set('accessibilityLabel', this.minuteText);
-			if (this.$.meridiem) this.$.meridiem.set('accessibilityLabel', this.meridiemText);
+			if (this.$.meridiem && this.meridiemText != $L('meridiem')) {
+				this.$.meridiem.set('accessibilityLabel', this.meridiemText);
+			}
 		}}
 	]
 });


### PR DESCRIPTION
…f TimePicker.

AM/PM is no need to read the unit because its meaning is clear.
Korean don't have a special unit word about meridiem so the value is
read in duplicated.
e.g.> The value is '오전'. The unit is '오전/오후'.
Therefore, the screen reader will read as '오전 오전 오후'.
In consultation with TV Lab's UX team, we decline to do not read.
We don't set the accessibilityLabel for default meridiemText and only
support customized meridiemText.

https://jira2.lgsvl.com/browse/PLAT-11511
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>