### PR TITLE
ENYO-2728: Restored the caption color assignment to GridListImageItem

### DIFF
--- a/src/GridListImageItem/GridListImageItem.less
+++ b/src/GridListImageItem/GridListImageItem.less
@@ -1,7 +1,3 @@
-/*
-	Put anything you reference with url in ../assets/
-	This way, you can minify your application, and just remove the "source" folder for production
-*/
 .moon-gridlist-imageitem {
 	display: inline-block;
 	overflow: hidden;
@@ -9,10 +5,12 @@
 
 	.caption {
 		.moon-sub-header-text;
+		color: @moon-gridlist-caption-color;
 	}
 
 	.sub-caption {
 		.moon-body-text;
+		color: @moon-gridlist-sub-caption-color;
 	}
 
 	&.selected {


### PR DESCRIPTION
It was removed ages ago with reliance on a mixin, then later the mixin was changed to be more efficient to omit the color when it wasn't explicitly requested and this was dependent on that, and it slipped through review undetected.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>