### PR TITLE
ENYO-2804: Set panelHandle to blur when panels is hidden

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -353,13 +353,6 @@ module.exports = kind(
 	transitioning: false,
 
 	/**
-	* Observer property for accessibility. Determine whether or not panelsHandle dom is blurred.
-	*
-	* @private
-	*/
-	_spotted: false,
-
-	/**
 	* Checks the state of panel transitions.
 	*
 	* @return {Boolean} `true` if a transition between panels is currently in progress;
@@ -721,11 +714,10 @@ module.exports = kind(
 	*/
 	handleBlur: function (sender, event) {
 		if (this.isHandleFocused) {
-			this.isHandleFocused = false;
+			this.set('isHandleFocused', false);
 			if (!Spotlight.getPointerMode()) {
 				if (!this.showing) {
 					this.panelsHiddenAsync();
-					this.set('_spotted', false);
 				}
 			}
 		}
@@ -777,9 +769,8 @@ module.exports = kind(
 	handleFocused: function () {
 		this.unstashHandle();
 		this.startJob('autoHide', 'handleSpotLeft', this.getAutoHideTimeout());
-		this.isHandleFocused = true;
+		this.set('isHandleFocused', true);
 		Signals.send('onPanelsHandleFocused');
-		this.set('_spotted', true);
 	},
 
 	/**
@@ -1377,8 +1368,8 @@ module.exports = kind(
 			}
 		}},
 		// If panels is hidden and panelsHandle is spotlight blured, also make panelsHandle's dom blur.   
-		{path: '_spotted', method: function () {
-			if (this.$.showHideHandle && this.$.showHideHandle.hasNode() && !this._spotted) {
+		{path: 'isHandleFocused', method: function () {
+			if (this.$.showHideHandle && this.$.showHideHandle.hasNode() && !this.isHandleFocused) {
 				this.$.showHideHandle.hasNode().blur();
 			}
 		}}

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -718,6 +718,7 @@ module.exports = kind(
 			if (!Spotlight.getPointerMode()) {
 				if (!this.showing) {
 					this.panelsHiddenAsync();
+					this.set('spotted', false);
 				}
 			}
 		}
@@ -771,6 +772,7 @@ module.exports = kind(
 		this.startJob('autoHide', 'handleSpotLeft', this.getAutoHideTimeout());
 		this.isHandleFocused = true;
 		Signals.send('onPanelsHandleFocused');
+		this.set('spotted', true);
 	},
 
 	/**
@@ -1365,6 +1367,11 @@ module.exports = kind(
 				if (panel instanceof Panel && panel.title) {
 					panel.set('accessibilityRole', (panel === active) && this.get('showing') ? 'alert' : 'region');
 				}
+			}
+		}},
+		{path: 'spotted', method: function () {
+			if (this.$.showHideHandle && this.$.showHideHandle.hasNode() && !this.spotted) {
+				this.$.showHideHandle.hasNode().blur();
 			}
 		}}
 	]

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -353,6 +353,13 @@ module.exports = kind(
 	transitioning: false,
 
 	/**
+	* Observer property for accessibility. Determine whether or not panelsHandle dom is blurred.
+	*
+	* @private
+	*/
+	_spotted: false,
+
+	/**
 	* Checks the state of panel transitions.
 	*
 	* @return {Boolean} `true` if a transition between panels is currently in progress;
@@ -718,8 +725,7 @@ module.exports = kind(
 			if (!Spotlight.getPointerMode()) {
 				if (!this.showing) {
 					this.panelsHiddenAsync();
-					// Observer property for accessibility. Determine whether or not panelsHandle dom is blurred.
-					this.set('spotted', false);
+					this.set('_spotted', false);
 				}
 			}
 		}
@@ -773,8 +779,7 @@ module.exports = kind(
 		this.startJob('autoHide', 'handleSpotLeft', this.getAutoHideTimeout());
 		this.isHandleFocused = true;
 		Signals.send('onPanelsHandleFocused');
-		// Observer property for accessibility. Determine whether or not panelsHandle dom is blurred.
-		this.set('spotted', true);
+		this.set('_spotted', true);
 	},
 
 	/**
@@ -1372,8 +1377,8 @@ module.exports = kind(
 			}
 		}},
 		// If panels is hidden and panelsHandle is spotlight blured, also make panelsHandle's dom blur.   
-		{path: 'spotted', method: function () {
-			if (this.$.showHideHandle && this.$.showHideHandle.hasNode() && !this.spotted) {
+		{path: '_spotted', method: function () {
+			if (this.$.showHideHandle && this.$.showHideHandle.hasNode() && !this._spotted) {
 				this.$.showHideHandle.hasNode().blur();
 			}
 		}}

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -718,6 +718,7 @@ module.exports = kind(
 			if (!Spotlight.getPointerMode()) {
 				if (!this.showing) {
 					this.panelsHiddenAsync();
+					// Observer property for accessibility. Determine whether or not panelsHandle dom is blurred.
 					this.set('spotted', false);
 				}
 			}
@@ -772,6 +773,7 @@ module.exports = kind(
 		this.startJob('autoHide', 'handleSpotLeft', this.getAutoHideTimeout());
 		this.isHandleFocused = true;
 		Signals.send('onPanelsHandleFocused');
+		// Observer property for accessibility. Determine whether or not panelsHandle dom is blurred.
 		this.set('spotted', true);
 	},
 
@@ -1369,6 +1371,7 @@ module.exports = kind(
 				}
 			}
 		}},
+		// If panels is hidden and panelsHandle is spotlight blured, also make panelsHandle's dom blur.   
 		{path: 'spotted', method: function () {
 			if (this.$.showHideHandle && this.$.showHideHandle.hasNode() && !this.spotted) {
 				this.$.showHideHandle.hasNode().blur();


### PR DESCRIPTION
## Issue 
Do not read the PanelsHandle if the hidden handle is refocused in the screen without any focused item

## Cause
The focused panelHandle is not blurred when screen has not any spottable item.

## Fix
Set panelHandle to blur when panels is hidden and screen has not any spottable item.

https://jira2.lgsvl.com/browse/ENYO-2804
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>