### PR TITLE
ENYO-2789: Add ariaObserver for preventing reading a password type in…

### DIFF
--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -278,9 +278,11 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: 'type', method: function () {
-			if ( this.$.header && this.type == 'password') {
+		{path: ['type', 'value'], method: function () {
+			if ( this.$.header && this.type == 'password' && this.value) {
 				this.$.header._accessibilityText = $L('Password');
+			} else {
+				this.$.header._accessibilityText = '';
 			}
 		}}
 	]

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -272,5 +272,16 @@ module.exports = kind(
 	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityHint
 	* @public
 	*/
-	accessibilityHint: $L('TEXT INPUT')
+	accessibilityHint: $L('TEXT INPUT'),
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: 'type', method: function () {
+			if ( this.$.header && this.type == 'password') {
+				this.$.header._accessibilityText = $L('Password');
+			}
+		}}
+	]
 });

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -372,5 +372,19 @@ module.exports = kind(
 			this.bubble('onRequestSetupBounds');
 		}
 		return true;
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* ExpandableListItem has not spotlight, its child (this.$.header) is spottable item,
+	* so we remove unneccessary aria-related attributes.
+	*
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['accessibilityLabel', 'accessibilityHint'], method: function () {
+			this.setAriaAttribute('aria-label', null);
+		}}
+	]
 });


### PR DESCRIPTION
## Issue 
It reads the real value of password in ExpandableInput

## Cause
ExpandableInput binds client input value to header ( LabeledTextItem ) text, so screen reader reads this text and accessibilityHint ( 'Text Input' ). 
 
## Fix
Set _accessibilityText to 'password' if input type is password, because screen reader reads _accessibilityText value instead of header text

https://jira2.lgsvl.com/browse/ENYO-2789
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>