### PR TITLE
Fixes ENYO-2814

### DIFF
--- a/src/RadioItem/RadioItem.less
+++ b/src/RadioItem/RadioItem.less
@@ -1,6 +1,7 @@
 /* Radio Item */
 .moon-radio-item {
 	display: inline-block;
+	vertical-align: middle;
 	max-width: 240px;
 	margin-right: @moon-radio-item-gap;
 


### PR DESCRIPTION
The default value, baseline, produced extra space below the baseline to
account for characters that would below. As a result, the new scroll to
boundary logic would animate a slight scroll when the last RadioItem in
a scroller was spotted. Since RadioItem isn't designed to be used
inline with text, we'll specify the vertical-align to middle so all
are aligned correctly without the space below the baseline.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)