### PR TITLE
Fixes ENYO-2815

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	gesture = require('enyo/gesture'),
 	Control = require('enyo/Control'),
 	Animator = require('enyo/Animator');
 
@@ -903,6 +904,8 @@ module.exports = kind(
 		}
 		else if (Spotlight.Accelerator.isAccelerating()) {
 			Spotlight.Accelerator.cancel();
+		} else {
+			gesture.drag.endHold();
 		}
 	},
 

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -901,10 +901,8 @@ module.exports = kind(
 				else this.next();
 				this._jumpSender = sender;
 			}
-		}
-		else if (Spotlight.Accelerator.isAccelerating()) {
-			Spotlight.Accelerator.cancel();
 		} else {
+			Spotlight.Accelerator.cancel();
 			gesture.drag.endHold();
 		}
 	},


### PR DESCRIPTION
The logic within spotlight to handle cancelling the hold is subverted
because Slider disables the jump button onSpolightKeyDown (before
spotlight registers the button as the last 5-way control) so
_onDisappear doesn't cancel the hold (again because it wasn't
registered as the last 5-way control).

A more thorough refactoring of Slider would be warranted but manually
cancelling the hold when not accelerating and when the spotlight has
changed jump buttons resolves the issue in the interim.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)