### PR TITLE
Fixes ENYO-2597

### DIFF
--- a/src/SimplePicker/SimplePicker.js
+++ b/src/SimplePicker/SimplePicker.js
@@ -281,7 +281,7 @@ module.exports = kind(
 		Control.prototype.addControl.apply(this, arguments);
 		var addedIdx = this.getClientControls().indexOf(ctl),
 			selectedIdx = this.selectedIndex;
-		if (this.generated) {
+		if (this._created) {
 			if ((selectedIdx < 0) || (addedIdx < selectedIdx)) {
 				this.setSelectedIndex(selectedIdx + 1);
 			} else if (selectedIdx == addedIdx) {

--- a/src/SimplePicker/SimplePicker.js
+++ b/src/SimplePicker/SimplePicker.js
@@ -288,8 +288,8 @@ module.exports = kind(
 				// Force change handler, since the currently selected item actually changed
 				this.selectedIndexChanged();
 			}
+			this.showHideNavButtons();
 		}
-		if (this._created) this.showHideNavButtons();
 	},
 
 	/**


### PR DESCRIPTION
If controls are added to the SimplePicker after it is created but
before it is rendered, the internal state is updated correctly. The
guard appears to be there to avoid unnecessary work which will be done
during create() so we'll use the internal state member, _created, to
guard instead of generated.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)