### PR TITLE
ENYO-2820: change selected days string to use built-in string function

### DIFF
--- a/src/DayPicker/DayPicker.js
+++ b/src/DayPicker/DayPicker.js
@@ -208,17 +208,16 @@ module.exports = kind(
 	*/
 	multiSelectCurrentValue: function () {
 		var str = this.getRepresentativeString();
+		var selectedDays = [];
 		if (str) {
 			return str;
 		}
 
+		this.selectedIndex.sort();
 		for (var i=0; i < this.selectedIndex.length; i++) {
-			if (!str) {
-				str = this.days[this.selectedIndex[i]];
-			} else {
-				str = str + ', ' + this.days[this.selectedIndex[i]];
-			}
+			selectedDays.push(this.days[this.selectedIndex[i]]);
 		}
+		str = selectedDays.toLocaleString();
 		return str || this.getNoneText();
 	},
 


### PR DESCRIPTION
# Issue
DayPicker needs to translate comma "," to locale character

# Fix
Change appending string method to array's "toLocaleString()" function.
(So far, ilib doesn't support toLocaleString properly. But think they'll support it)

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho (sb.cho@lge.com)