### PR TITLE
ENYO-2790: Accessibility: The slider value does not change while no p…

### DIFF
--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -793,6 +793,8 @@ module.exports = kind(
 		// of the label determination could help here - rjd
 		{path: ['progress', 'popup', '$.popupLabel.content'], method: 'ariaValue'},
 		{path: ['accessibilityValueText'], method: function () {
+			this.setAriaAttribute('aria-valuetext', null);
+			this.setAriaAttribute('aria-valuenow', null);
 			this.setAriaAttribute('aria-valuetext', this.accessibilityValueText);
 		}}
 	],
@@ -805,6 +807,8 @@ module.exports = kind(
 	ariaValue: function () {
 		var attr = this.popup ? 'aria-valuetext' : 'aria-valuenow';
 		if (!this.accessibilityValueText) {
+			this.setAriaAttribute('aria-valuetext', null);
+			this.setAriaAttribute('aria-valuenow', null);
 			this.setAriaAttribute(attr, (this.popup && this.$.popupLabel)? this.$.popupLabel.get('content') : this.progress);
 		}
 	}

--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -480,6 +480,7 @@ module.exports = kind(
 	* @private
 	*/
 	progressAnimatorStep: function (inSender) {
+		this.set('_isAnimating', true);
 		this.setProgress(inSender.value);
 		return true;
 	},
@@ -490,6 +491,7 @@ module.exports = kind(
 	*/
 	progressAnimatorComplete: function (inSender) {
 		this.doAnimateProgressFinish();
+		this.set('_isAnimating', false);
 		return true;
 	},
 
@@ -786,15 +788,20 @@ module.exports = kind(
 	tabIndex: -1,
 
 	/**
+	* Distinguish ProgressBar animation is ongoing or not
+	*
+	* @private
+	*/
+	_isAnimating: false,
+
+	/**
 	* @private
 	*/
 	ariaObservers: [
 		// TODO: Observing $.popupLabel.content to minimize the observed members. Some refactoring
 		// of the label determination could help here - rjd
-		{path: ['progress', 'popup', '$.popupLabel.content'], method: 'ariaValue'},
+		{path: ['_isAnimating', 'progress', 'popup', '$.popupLabel.content'], method: 'ariaValue'},
 		{path: ['accessibilityValueText'], method: function () {
-			this.setAriaAttribute('aria-valuetext', null);
-			this.setAriaAttribute('aria-valuenow', null);
 			this.setAriaAttribute('aria-valuetext', this.accessibilityValueText);
 		}}
 	],
@@ -806,7 +813,7 @@ module.exports = kind(
 	*/
 	ariaValue: function () {
 		var attr = this.popup ? 'aria-valuetext' : 'aria-valuenow';
-		if (!this.accessibilityValueText) {
+		if (!this.accessibilityValueText && !this._isAnimating) {
 			this.setAriaAttribute('aria-valuetext', null);
 			this.setAriaAttribute('aria-valuenow', null);
 			this.setAriaAttribute(attr, (this.popup && this.$.popupLabel)? this.$.popupLabel.get('content') : this.progress);

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -967,7 +967,7 @@ module.exports = kind(
 
 
 	/**
-	* Distinguish ProgressBar animation is ongogin or not
+	* Distinguish Slider animation is ongoing or not
 	*
 	* @private
 	*/

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -999,6 +999,12 @@ module.exports = kind(
 		this.set('accessibilityRole', !this.enableJumpIncrement ? 'spinbutton' : null);
 		this.set('accessibilityLive', null);
 		this.set('accessibilityHint', null);
+		this.setAriaAttribute('aria-valuetext', null);
+		this.setAriaAttribute('aria-valuenow', null);
+		if (this.$.slider) {
+			this.$.slider.setAriaAttribute('aria-valuetext', null);
+			this.$.slider.setAriaAttribute('aria-valuenow', null);
+		}
 	},
 
 	/**

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -719,6 +719,7 @@ module.exports = kind(
 	animatorStep: function (sender) {
 		var	v = sender.value;
 
+		this.set('_isSliderAnimating', true);
 		this.updateValues(v);
 
 		this.sendChangingEvent({value: v});
@@ -734,6 +735,7 @@ module.exports = kind(
 			this._setValue(sender.value);
 			this.animatingTo = null;
 			this.doAnimateFinish(sender);
+			this.set('_isSliderAnimating', false);
 		}
 		return true;
 	},
@@ -963,6 +965,14 @@ module.exports = kind(
 	*/
 	accessibilityDisabled: false,
 
+
+	/**
+	* Distinguish ProgressBar animation is ongogin or not
+	*
+	* @private
+	*/
+	_isSliderAnimating: false,
+
 	/**
 	* @private
 	*/
@@ -989,19 +999,19 @@ module.exports = kind(
 				this.$.buttonRight.set('accessibilityLabel', this.accessibilityValueText);
 			}
 		}},
-		{path: ['value', 'popup', '$.popupLabel.content', 'dragging'], method: 'ariaValue'}
+		{path: ['_isSliderAnimating', 'value', 'popup', '$.popupLabel.content', 'dragging'], method: 'ariaValue'}
 	],
 
 	/**
 	* @private
 	*/
 	resetAccessibilityProperties: function () {
-		this.set('accessibilityRole', !this.enableJumpIncrement ? 'spinbutton' : null);
+		this.set('accessibilityRole', !this.enableJumpIncrement ? 'slider' : null);
 		this.set('accessibilityLive', null);
 		this.set('accessibilityHint', null);
 		this.setAriaAttribute('aria-valuetext', null);
 		this.setAriaAttribute('aria-valuenow', null);
-		if (this.$.slider) {
+		if (this.enableJumpIncrement) {
 			this.$.slider.setAriaAttribute('aria-valuetext', null);
 			this.$.slider.setAriaAttribute('aria-valuenow', null);
 		}
@@ -1018,7 +1028,7 @@ module.exports = kind(
 			text = (this.popup && this.$.popupLabel && this.$.popupLabel.getContent())?
 					this.$.popupLabel.getContent() : this.value;
 
-		if (!this.dragging && !this.accessibilityValueText) {
+		if (!this.dragging && !this.accessibilityValueText && !this._isSliderAnimating) {
 			this.resetAccessibilityProperties();
 			this.setAriaAttribute(attr, text);
 			if (this.enableJumpIncrement) {


### PR DESCRIPTION
…opup.

Issue
The slider value does not change while no popup.

Cause
After the popup property is changed from true to false, both
'aria-valuetext' and 'aria-valuenow' are exist.
Web engine reads only 'aria-valuetext' if two of them are in a dom node.

Fix
Before setting 'aria-valuetext' or 'aria-valuenow', set them to null.

https://jira2.lgsvl.com/browse/ENYO-2790
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>