### PR TITLE
ENYO-2826: Accessibility: When the meridiem is changed, it reads the …

### DIFF
--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -225,7 +225,9 @@ var HourMinutePickerBase = kind(
 	ariaValue: function () {
 		if (this.date && this.range) {
 			var value = this.format(this.value % this.range);
-			this.setAriaAttribute('aria-valuenow', value);
+			if (this.getAttribute('aria-valuenow') != value) {
+				this.setAriaAttribute('aria-valuenow', value);
+			}
 		}
 	}
 });


### PR DESCRIPTION
…hour value.

Issue
When the meridiem is changed, it reads the hour value.

Cause
set 'aria-valuenow' again even though same value.

Fix
before setting 'aria-valuenow' compare with previous 'aria-valuenow'

https://jira2.lgsvl.com/browse/ENYO-2826
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>