### PR TITLE
ENYO-2485: Accessibility: When cardArranger panels are switched, scre…

### DIFF
--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -633,7 +633,9 @@ module.exports = kind(
 	*/
 	ariaObservers: [
 		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing'], method: function () {
-			this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+			this.startJob('alert', function () {
+				this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+			}, 100);
 		}}
 	]
 });

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -612,7 +612,9 @@ module.exports = kind(
 	*/
 	ariaObservers: [
 		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing'], method: function () {
-			this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+			this.startJob('alert', function () {
+				this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+			}, 100);
 		}}
 	]
 });

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -440,7 +440,9 @@ module.exports = kind(
 	*/
 	ariaObservers: [
 		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing'], method: function () {
-			this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+			this.startJob('alert', function () {
+				this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+			}, 100);
 		}}
 	]
 });


### PR DESCRIPTION
…en reader doesn't read the focused item.

add time delay for alert setting on ContextualPopup, Tooltip and Popup
to read the focused item earlier than popup content(alert).

https://jira2.lgsvl.com/browse/ENYO-2485
Enyo-DCO-1.1-Signed-off-by: Jaewon Jang <jaewon98.jang@lgepartner.com>