### PR TITLE
Fixes ENYO-2837

### DIFF
--- a/src/ExpandableListItem/ExpandableListItem.less
+++ b/src/ExpandableListItem/ExpandableListItem.less
@@ -3,7 +3,10 @@
 	// Header
 	.moon-labeledtextitem-header {
 		.padding-start-end(0, @moon-spotlight-outset + 30px);
-		margin-bottom: 0px;
+		
+		&.with-text {
+			margin-bottom: 0px;
+		}
 
 		&:after {
 			position: absolute;

--- a/src/ExpandableListItem/ExpandableListItem.less
+++ b/src/ExpandableListItem/ExpandableListItem.less
@@ -3,9 +3,9 @@
 	// Header
 	.moon-labeledtextitem-header {
 		.padding-start-end(0, @moon-spotlight-outset + 30px);
-		
+
 		&.with-text {
-			margin-bottom: 0px;
+			margin-bottom: 0;
 		}
 
 		&:after {
@@ -29,7 +29,7 @@
 
 	.moon-labeledtextitem-text {
 		line-height: inherit;
-		margin-bottom: 0px;
+		margin-bottom: 0;
 	}
 
 	// Client Items
@@ -51,7 +51,7 @@
 		}
 		// Set spacing on the last element (the expand/collapse box) of the client area.
 		> :last-child {
-			margin-bottom: 12px;
+			margin-bottom: @moon-spotlight-outset;
 		}
 	}
 }

--- a/src/LabeledTextItem/LabeledTextItem.js
+++ b/src/LabeledTextItem/LabeledTextItem.js
@@ -75,7 +75,6 @@ module.exports = kind(
 	*/
 	bindings: [
 		{from: 'label', to: '$.header.content'},
-		{from: 'text', to: '$.text.content', transform: 'prepareText'},
 
 		// Accessibility
 		{from: '_accessibilityText', to: '$.text.accessibilityLabel'}
@@ -90,14 +89,21 @@ module.exports = kind(
 	],
 
 	/**
+	* @private
+	*/
+	create: function () {
+		Item.prototype.create.apply(this, arguments);
+		this.textChanged();
+	},
+
+	/**
 	/* @private
 	*/
-	prepareText: function (val) {
-		var validValue = val || val === 0;
+	textChanged: function () {
+		var validValue = this.text || this.text === 0;
 		this.$.header.addRemoveClass('with-text', validValue);
-		this.$.text.set('showing', validValue);
-		if (validValue) this.$.text.detectTextDirectionality(val);
-		return val;
+		this.$.text.set('content', this.text);
+		if (validValue) this.$.text.detectTextDirectionality(this.text);
 	},
 
 	// Accessibility

--- a/src/LabeledTextItem/LabeledTextItem.less
+++ b/src/LabeledTextItem/LabeledTextItem.less
@@ -11,7 +11,7 @@
 		vertical-align: top;
 
 		&.with-text {
-			margin-bottom: 12px;
+			margin-bottom: @moon-spotlight-outset;
 		}
 	}
 
@@ -23,7 +23,7 @@
 		font-style: @moon-expandable-value-font-style;
 		line-height: @moon-body-line-height;
 		text-transform: none;
-		margin: -12px 0 12px 0;
+		margin: -@moon-spotlight-outset 0 @moon-spotlight-outset 0;
 		color: @moon-expandable-picker-text-color;
 
 		.enyo-locale-right-to-left & {

--- a/src/LabeledTextItem/LabeledTextItem.less
+++ b/src/LabeledTextItem/LabeledTextItem.less
@@ -23,8 +23,7 @@
 		font-style: @moon-expandable-value-font-style;
 		line-height: @moon-body-line-height;
 		text-transform: none;
-		margin-top: -12px;
-		margin-bottom: @moon-spotlight-outset - 3px;
+		margin: -12px 0 12px 0;
 		color: @moon-expandable-picker-text-color;
 
 		.enyo-locale-right-to-left & {

--- a/src/LabeledTextItem/LabeledTextItem.less
+++ b/src/LabeledTextItem/LabeledTextItem.less
@@ -23,7 +23,8 @@
 		font-style: @moon-expandable-value-font-style;
 		line-height: @moon-body-line-height;
 		text-transform: none;
-		margin: -@moon-spotlight-outset 0 @moon-spotlight-outset 0;
+		margin-top: -@moon-spotlight-outset;
+		margin-bottom: @moon-spotlight-outset - 3px;
 		color: @moon-expandable-picker-text-color;
 
 		.enyo-locale-right-to-left & {


### PR DESCRIPTION
Alter the CSS of LabeledTextItem without text to match Item sizing
Move logic into observer from binding transform and remove showing
logic to prevent overriding ExpandableListItemHeader's textShowing
Update ExpandableListItem to override .with-text for specificity

Issue: ENYO-2837
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)