### PR TITLE
Fixes ENYO-2833

### DIFF
--- a/src/ScrollStrategy/ScrollStrategy.js
+++ b/src/ScrollStrategy/ScrollStrategy.js
@@ -406,8 +406,8 @@ var MoonScrollStrategy = module.exports = kind(
 	mousewheel: function(sender, event) {
 		if (this.useMouseWheel) {
 			var isScrolling = this.isScrolling();
-			this.scrollBounds = this._getScrollBounds();
 			this.setupBounds();
+			this.scrollBounds = this._getScrollBounds();
 
 			var x = null,
 				y = null,


### PR DESCRIPTION
When scrolling with mousewheel before the scroll bars had been set up,
the showing of the scroll bars would cause a resize and invalidate
scrollBounds. This caused mousewheel to throw and exception. Reordering
the calls resolves this behavior.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)