### PR TITLE
ENYO-2832: Adjust tooltip direction towards left by default in RTL

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -392,20 +392,36 @@ module.exports = kind(
 				}
 			}
 
-			//* When there is not enough room on the left, using right-arrow for the tooltip
-			if (window.innerWidth - moonDefaultPadding - pBounds.left - pBounds.width / 2 < b.width){
-				//* use the right-arrow
-				this.removeClass('left-arrow');
-				this.addClass('right-arrow');
-				this.applyPosition({'margin-left': dom.unit(- b.width, 'rem'), 'left': 'auto'});
-				if (this.floating) {
-					this.applyStyle('right', dom.unit(acBounds.width / 2 + acRight + moonDefaultPadding, 'rem'));
+			if (this.rtl) {
+				if (moonDefaultPadding + pBounds.left + pBounds.width / 2 < b.width) {
+					this.removeClass('right-arrow');
+					this.addClass('left-arrow');
 				} else {
-					this.applyStyle('right', dom.unit(acBounds.width / 2 + paRightDiff, 'rem'));
+					this.removeClass('left-arrow');
+					this.addClass('right-arrow');
+					this.applyPosition({'margin-left': dom.unit(- b.width, 'rem'), 'left': 'auto'});
+					if (this.floating) {
+						this.applyStyle('right', dom.unit(acBounds.width / 2 + acRight + moonDefaultPadding, 'rem'));
+					} else {
+						this.applyStyle('right', dom.unit(acBounds.width / 2 + paRightDiff, 'rem'));
+					}
 				}
 			} else {
-				this.removeClass('right-arrow');
-				this.addClass('left-arrow');
+				//* When there is not enough room on the left, using right-arrow for the tooltip
+				if (window.innerWidth - moonDefaultPadding - pBounds.left - pBounds.width / 2 < b.width){
+					//* use the right-arrow
+					this.removeClass('left-arrow');
+					this.addClass('right-arrow');
+					this.applyPosition({'margin-left': dom.unit(- b.width, 'rem'), 'left': 'auto'});
+					if (this.floating) {
+						this.applyStyle('right', dom.unit(acBounds.width / 2 + acRight + moonDefaultPadding, 'rem'));
+					} else {
+						this.applyStyle('right', dom.unit(acBounds.width / 2 + paRightDiff, 'rem'));
+					}
+				} else {
+					this.removeClass('right-arrow');
+					this.addClass('left-arrow');
+				}
 			}
 		}
 	},

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -364,7 +364,8 @@ module.exports = kind(
 			var paTopDiff = pBounds.top - acBounds.top,
 				paLeftDiff =  acBounds.left - pBounds.left,
 				paRightDiff = pBounds.left + pBounds.width - acBounds.left - acBounds.width,
-				acRight = window.innerWidth - moonDefaultPadding - acBounds.left - acBounds.width;
+				acRight = window.innerWidth - moonDefaultPadding - acBounds.left - acBounds.width,
+				anchorLeft, offset;
 
 			//* When there is not enough room in the bottom, move it above the
 			//* decorator; when the tooltip bottom is within window height but
@@ -393,35 +394,22 @@ module.exports = kind(
 			}
 
 			if (this.rtl) {
-				if (moonDefaultPadding + pBounds.left + pBounds.width / 2 < b.width) {
-					this.removeClass('right-arrow');
-					this.addClass('left-arrow');
-				} else {
-					this.removeClass('left-arrow');
-					this.addClass('right-arrow');
-					this.applyPosition({'margin-left': dom.unit(- b.width, 'rem'), 'left': 'auto'});
-					if (this.floating) {
-						this.applyStyle('right', dom.unit(acBounds.width / 2 + acRight + moonDefaultPadding, 'rem'));
-					} else {
-						this.applyStyle('right', dom.unit(acBounds.width / 2 + paRightDiff, 'rem'));
-					}
-				}
+				anchorLeft = moonDefaultPadding + pBounds.left + pBounds.width / 2 < b.width;
 			} else {
 				//* When there is not enough room on the left, using right-arrow for the tooltip
-				if (window.innerWidth - moonDefaultPadding - pBounds.left - pBounds.width / 2 < b.width){
-					//* use the right-arrow
-					this.removeClass('left-arrow');
-					this.addClass('right-arrow');
-					this.applyPosition({'margin-left': dom.unit(- b.width, 'rem'), 'left': 'auto'});
-					if (this.floating) {
-						this.applyStyle('right', dom.unit(acBounds.width / 2 + acRight + moonDefaultPadding, 'rem'));
-					} else {
-						this.applyStyle('right', dom.unit(acBounds.width / 2 + paRightDiff, 'rem'));
-					}
-				} else {
-					this.removeClass('right-arrow');
-					this.addClass('left-arrow');
-				}
+				anchorLeft = window.innerWidth - moonDefaultPadding - pBounds.left - pBounds.width / 2 >= b.width;
+			}
+
+			offset = this.floating ? acRight + moonDefaultPadding : paRightDiff;
+
+			if (anchorLeft) {
+				this.removeClass('right-arrow');
+				this.addClass('left-arrow');
+			} else {
+				this.removeClass('left-arrow');
+				this.addClass('right-arrow');
+				this.applyPosition({'margin-left': dom.unit(- b.width, 'rem'), 'left': 'auto'});
+				this.applyStyle('right', dom.unit(acBounds.width / 2 + offset, 'rem'));
 			}
 		}
 	},


### PR DESCRIPTION
### Issue
The default tooltip direction is towards the right which causes text to align left no matter what locale it is. This can result in unwanted left alignment for RTL languages.

### Fix 
Change the default direction of tooltip to face left-wards for RTL as a default.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>