### PR TITLE
ENYO-2783: Revert previous fix for ENYO-2644, implement new one

### DIFF
--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -5,7 +5,6 @@
 var
 	kind = require('enyo/kind'),
 	utils = require('enyo/utils'),
-	resolution = require('enyo/resolution'),
 	ScrollMath = require('enyo/ScrollMath');
 
 var
@@ -54,7 +53,7 @@ var Scrollable = {
 	},
 
 	// Override ScrollMath params
-	scrollMath: {kind: ScrollMath, kFrictionDamping: 0.93, boundarySnapThreshold: resolution.scale(100)},
+	scrollMath: {kind: ScrollMath, kFrictionDamping: 0.93},
 
 	/**
 	* @private

--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -96,7 +96,7 @@ var Scrollable = {
 					),
 					behavior: def.behavior
 				};
-				this.scrollToControl(event.originator, opts);
+				this.scrollToChild(event.originator, opts);
 			} else {
 				// If we don't need to scroll, bubble onRequestScrollIntoView so that
 				// any scrollers above us in the control hierarchy can scroll as needed


### PR DESCRIPTION
We revert the previous fix for ENYO-2644, which cased the regression described in ENYO-2783, and make a minor change to support the new fix. Most of the work for the new fix is done in ENYO -- see the related PR: https://github.com/enyojs/enyo/pull/1331.

ENYO-DCO-1.1-Signed-Off-By: Gray Norton (gray.norton@lge.com)