### PR TITLE
ENYO-2838: Normalized the heights of Item, LabeledListItems, and Expandables

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -237,6 +237,7 @@
 // Expandable Pickers
 // ---------------------------------------
 @moon-expandable-caret-icon-font-size: 48px;
+@moon-expandable-client-item-line-height: 45px;
 
 // Expandable Text
 // ---------------------------------------
@@ -255,7 +256,9 @@
 
 // Items
 // ---------------------------------------
-@moon-item-line-height: 1.7em;
+@moon-item-height: 60px;
+@moon-item-vertical-padding: 3px;
+@moon-item-line-height: @moon-item-height - (@moon-item-vertical-padding * 2);
 @moon-item-indent: 36px;
 
 // Divider

--- a/src/ExpandableListItem/ExpandableListItem.less
+++ b/src/ExpandableListItem/ExpandableListItem.less
@@ -4,10 +4,6 @@
 	.moon-labeledtextitem-header {
 		.padding-start-end(0, @moon-spotlight-outset + 30px);
 
-		&.with-text {
-			margin-bottom: 0;
-		}
-
 		&:after {
 			position: absolute;
 			top: @moon-spotlight-outset - 12px;
@@ -27,9 +23,11 @@
 		content: @moon-icon-arrowlargeup;
 	}
 
-	.moon-labeledtextitem-text {
+	.moon-labeledtextitem .moon-labeledtextitem-text {
 		line-height: inherit;
+		margin-top: -12px;
 		margin-bottom: 0;
+		padding-bottom: 0;
 	}
 
 	// Client Items
@@ -39,7 +37,7 @@
 			font-size: @moon-expandable-client-item-font-size;
 			font-weight: @moon-expandable-value-font-weight;
 			font-style: @moon-expandable-value-font-style;
-			line-height: @moon-item-line-height;
+			line-height: @moon-expandable-client-item-line-height;
 
 			.enyo-locale-non-latin & {
 				.enyo-locale-non-latin .moon-body-text;

--- a/src/Item/Item.less
+++ b/src/Item/Item.less
@@ -2,7 +2,7 @@
 .moon-item {
 	.moon-text-base (@moon-item-font-size);
 	line-height: @moon-item-line-height;
-	padding: 3px @moon-spotlight-outset;
+	padding: @moon-item-vertical-padding @moon-spotlight-outset;
 	position: relative;
 
 	&.spotlight {

--- a/src/LabeledTextItem/LabeledTextItem.js
+++ b/src/LabeledTextItem/LabeledTextItem.js
@@ -101,7 +101,7 @@ module.exports = kind(
 	*/
 	textChanged: function () {
 		var validValue = this.text || this.text === 0;
-		this.$.header.addRemoveClass('with-text', validValue);
+		this.addRemoveClass('with-text', validValue);
 		this.$.text.set('content', this.text);
 		if (validValue) this.$.text.detectTextDirectionality(this.text);
 	},

--- a/src/LabeledTextItem/LabeledTextItem.less
+++ b/src/LabeledTextItem/LabeledTextItem.less
@@ -1,5 +1,9 @@
 /* Labeled Text Item */
 .moon-labeledtextitem {
+	//// Locally scoped LESS variables ////
+	// Vertically shift the text element to position it closer to the header than the line-height naturally allows
+	@text-vertical-offset: 6px;
+
 	min-width: 336px;
 
 	// Header
@@ -9,10 +13,6 @@
 		max-width: 100%;
 		position: relative;
 		vertical-align: top;
-
-		&.with-text {
-			margin-bottom: @moon-spotlight-outset;
-		}
 	}
 
 	// Text
@@ -23,9 +23,10 @@
 		font-style: @moon-expandable-value-font-style;
 		line-height: @moon-body-line-height;
 		text-transform: none;
-		margin-top: -@moon-spotlight-outset;
-		margin-bottom: @moon-spotlight-outset - 3px;
 		color: @moon-expandable-picker-text-color;
+		// The following two margin values must cancel each other out, so there is zero layout impact when `text` is empty.
+		margin-top: -@text-vertical-offset;
+		margin-bottom: @text-vertical-offset;
 
 		.enyo-locale-right-to-left & {
 			padding-left: 0;
@@ -37,6 +38,12 @@
 
 		.moon-neutral & {
 			color: inherit;
+		}
+	}
+
+	&.with-text {
+		.moon-labeledtextitem-text {
+			padding-bottom: 3px;
 		}
 	}
 


### PR DESCRIPTION
* All items with only one line are now 60px tall.
* All 2 line items are 102px tall (42px taller, for the smaller second line).
* Items inside Items are 45px tall. (Equivalent to 1.7em, for tall-glyph support). _This seemed safer than using `em` in case font size changed._

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>