### PR TITLE
ENYO-2850: update multiSelectCurrentValue function to handle wrong odrder

### DIFF
--- a/src/DayPicker/DayPicker.js
+++ b/src/DayPicker/DayPicker.js
@@ -211,7 +211,7 @@ module.exports = kind(
 		if (str) {
 			return str;
 		}
-
+		this.selectedIndex.sort();
 		for (var i=0; i < this.selectedIndex.length; i++) {
 			if (!str) {
 				str = this.days[this.selectedIndex[i]];


### PR DESCRIPTION
## Issue
In some case, currentValueText is different from header text because selectedIndex's oder is changed sunddenly. (header text is right result)

## Fix
Update multiSelectCurrentValue function to handle wrong selectedIndex's odrder

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho (sb.cho@lge.com)