### PR TITLE
Fixes ENYO-2847 propagate 5-way direction when respotting ExpandableListItem child

### DIFF
--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -343,7 +343,7 @@ module.exports = kind(
 		if (this.lockBottom && event.originator == this.$.drawer && event._originator) {
 			// Spotlight containers redispatch 5-way events with the original event originator
 			// saved as _originator which we'll use to respot if lockBottom === true
-			Spotlight.spot(event._originator);
+			Spotlight.spot(event._originator, {direction: 'DOWN'});
 			return true;
 		}
 	},


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)