### PR TITLE
ENYO-2849: Set text-overflow for marqueeText to account for text leng…

### DIFF
--- a/src/Marquee/Marquee.js
+++ b/src/Marquee/Marquee.js
@@ -959,8 +959,10 @@ var MarqueeItem = {
 			//need to animate
 			if(this._marquee_distance === 0) {
 				this.applyStyle('text-overflow', 'clip');
+				this.$.marqueeText && this.$.marqueeText.applyStyle('text-overflow', 'clip');
 			} else {
 				this.applyStyle('text-overflow', 'ellipsis');
+				this.$.marqueeText && this.$.marqueeText.applyStyle('text-overflow', 'ellipsis');
 			}
 		}
 


### PR DESCRIPTION
…th changed

### Issue
When `MarqueeItem`'s content change, there is an edge case where the length of text become just long enough that it does not animate, but keep the ellipsis.

### Cause
`text-overflow: ellipsis` is applied to `marqueeText` component by `.moon-marquee-text` class in LESS file. Though we calculate distance and set `text-overflow: clip` when the text is not long enough to animate, `this.$.marqueeText` still has that `text-overflow: ellipsis`

### Fix
Set `text-overflow` for `this.$.marqueeText` accordingly.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>