### PR TITLE
Fixes ENYO-2230

### DIFF
--- a/src/ContextualPopupDecorator/ContextualPopupDecorator.js
+++ b/src/ContextualPopupDecorator/ContextualPopupDecorator.js
@@ -68,6 +68,16 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	spotlight: 'container',
+
+	/**
+	* @private
+	*/
+	spotlightRememberFocus: false,
+
+	/**
+	* @private
+	*/
 	handlers: {
 		onActivate: 'activated',
 		onShow: 'popupShown',


### PR DESCRIPTION
add spotlight container to ContextualPopupDecorator

Keeps the spotlight on the activator when the last spotted control is
within the popup before it hides.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)