### PR TITLE
ENYO-2866: [LightPanel] during back key process, spotlight disappears

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -202,7 +202,7 @@ module.exports = kind(
 
 			spotlightPlaceholder.spotlight = false;
 			if (!Spotlight.isSpottable(this)) spotlightPlaceholder.spotlight = true;
-			if (!current || current === spotlightPlaceholder) Spotlight.spot(this);
+			if (!current || (!current.isDescendantOf(this) && current.isDescendantOf(this.owner)) || current === spotlightPlaceholder) Spotlight.spot(this);
 		}
 	},
 


### PR DESCRIPTION
## Issue

During back key process, there is a postTransition step. There is a checkSpottability, but there is nothing to spot.

## Fix

we added more condition to spot active panel
(!current.isDescendantOf(this) -> for current is not control in active panel(e.g. control in deactivated panel - previous panel)
current.isDescendantOf(this.owner) -> for control outside panels. In this case we do not need to spot active panel

Enyo-DCO-1.1-Signed-off-by: Suhyung.Lee (suhyung2.lee@lge.com)