### PR TITLE
ENYO-2866: Unfreeze when deactivating panel with spotted control.

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -162,6 +162,7 @@ module.exports = kind(
 				}
 			}
 		} else if (this.state == States.DEACTIVATING && (isChild || !currentSpottable)) {
+			Spotlight.unfreeze();
 			Spotlight.unspot();
 		}
 


### PR DESCRIPTION
### Issue
If Spotlight has currently been frozen (i.e. we have spotted an `Input`), the `unspot` call for a deactivating panel will exit early and not perform the desired operations (such as nulling out the currently spotted control). This results in the control's Spotlight disappear routine being run. Previously, this did not cause any side effects as the first child of the root (the default control to spot in these cases) was not spottable. But a recent change via https://github.com/enyojs/spotlight/pull/229 caused Spotlight to attempt to spot the disappearing control's closest spottable parent, as well, preventing the incoming panel from being spotted.

### Fix
We call `unfreeze` if we have a currently spotted item in the panel that is being deactivated. Regardless of whether or not the first child of the root is spottable, or if there is a spottable parent, these items will not be spotted when transitioning panels.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>