### PR TITLE
ENYO-2846: Always calculate distance using marqueeText control.

### DIFF
--- a/src/Marquee/Marquee.js
+++ b/src/Marquee/Marquee.js
@@ -862,23 +862,24 @@ var MarqueeItem = {
 	* @private
 	*/
 	_marquee_startAnimation: function (sender, ev) {
+		var distance;
+
 		// if this control hasn't been generated, there's no need to follow through on
 		// marquee requests as we'll be unable to correctly measure the distance delta yet
 		if (!this.generated) return;
 
-		var distance = this._marquee_calcDistance();
+		// Lazy creation of _this.$.marqueeText_
+		if (!this.$.marqueeText) {
+			this._marquee_createMarquee();
+		}
+
+		distance = this._marquee_calcDistance();
 
 		// If there is no need to animate, return early
 		if (!this._marquee_shouldAnimate(distance)) {
 			this._marquee_fits = true;
 			this.doMarqueeEnded();
 			return;
-		}
-
-		// Lazy creation of _this.$.marqueeText_
-		if (!this.$.marqueeText) {
-			this._marquee_createMarquee();
-			distance = this._marquee_calcDistance();
 		}
 
 		this._marquee_addAnimationStyles(distance);
@@ -947,22 +948,24 @@ var MarqueeItem = {
 	* @private
 	*/
 	_marquee_calcDistance: function () {
-		var node = this.$.marqueeText ? this.$.marqueeText.hasNode() : this.hasNode(),
-			rect;
+		var node, rect;
 
-		if (node && this._marquee_distance == null && this.getAbsoluteShowing()) {
-			rect = node.getBoundingClientRect();
-			this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
+		if (this.$.marqueeText) {
+			node = this.$.marqueeText.hasNode();
+			if (node && this._marquee_distance == null && this.getAbsoluteShowing()) {
+				rect = node.getBoundingClientRect();
+				this._marquee_distance = Math.floor(Math.abs(node.scrollWidth - rect.width));
 
-			//if the distance is exactly 0, then the ellipsis
-			//most likely are hiding the content, and marquee does not
-			//need to animate
-			if(this._marquee_distance === 0) {
-				this.applyStyle('text-overflow', 'clip');
-				this.$.marqueeText && this.$.marqueeText.applyStyle('text-overflow', 'clip');
-			} else {
-				this.applyStyle('text-overflow', 'ellipsis');
-				this.$.marqueeText && this.$.marqueeText.applyStyle('text-overflow', 'ellipsis');
+				//if the distance is exactly 0, then the ellipsis
+				//most likely are hiding the content, and marquee does not
+				//need to animate
+				if(this._marquee_distance === 0) {
+					this.applyStyle('text-overflow', 'clip');
+					this.$.marqueeText && this.$.marqueeText.applyStyle('text-overflow', 'clip');
+				} else {
+					this.applyStyle('text-overflow', 'ellipsis');
+					this.$.marqueeText && this.$.marqueeText.applyStyle('text-overflow', 'ellipsis');
+				}
 			}
 		}
 


### PR DESCRIPTION
### Issue
Because we are lazily creating the `marqueeText` control, we initially use the bounds of the control we wish to add marquee support to. When this control has a border, the border is added to the width and we compute a marquee distance that is short by the sum of the left and right border width. This value is cached and used for the `marqueeText` control when it is created, causing it to not marquee the correct distance.

### Fix
It didn't seem like we needed to specifically measure the bounds of the control that was mixing in marquee support, and that we should always base our measurements on the `marqueeText` control for maximum accuracy. As a result, we guard against distance calculation until the {{marqueeText}} control has been created. This effectively relies on the `text-overflow:ellipsis` style to initially style the pre-promoted marquee control.

### Notes
We may need to dig up the test cases related to applying the explicit `text-overflow` styles, where we had encountered edge cases when the width of the content was slightly larger or smaller than the control width. I'll take a look at these before officially submitting this for review, but wanted to get some eyes on this to start.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>