### PR TITLE
adjust Tooltip's posistion when locale is rtl

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -366,7 +366,7 @@ module.exports = kind(
 	adjustPosition: function (belowActivator) {
 		if (this.showing && this.hasNode()) {
 			var b = this.node.getBoundingClientRect(),
-				moonDefaultPadding = ri.scale(20),
+				moonDefaultPadding = ri.scale(18),
 				defaultMargin = ri.scale(15),
 				pBounds = this.parent.getAbsoluteBounds(),
 				acBounds = null;

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -161,7 +161,8 @@ module.exports = kind(
 	published: {
 		/**
 		* This value overrides the default value of
-		* [autoDismiss]{@link module:enyo/Popup~Popup#autoDismiss} inherited from {@link module:enyo/Popup~Popup}.
+		* [autoDismiss]{@link module:enyo/Popup~Popup#autoDismiss} inherited from
+		* {@link module:enyo/Popup~Popup}.
 		* If `true`, the tooltip will hide when the user taps outside of it or presses
 		* ESC. Note that this property only affects behavior when the tooltip is used
 		* independently, not when it is used with
@@ -174,9 +175,12 @@ module.exports = kind(
 		autoDismiss: false,
 
 		/**
-		* If 'false', the tooltip won't be rendered in a
-		* [floating layer]{@link module:enyo/Control/floatingLayer~FloatingLayer}
-		* This may be used to guarantee whether the tooltip will be shown on top of other controls or not.
+		* This value overrides the default value of
+		* [floating]{@link module:enyo/Popup~Popup#floating} inherited from
+		* {@link module:enyo/Popup~Popup}.
+		* If 'false', the tooltip will not be rendered in a
+		* [floating layer]{@link module:enyo/Control/floatingLayer~FloatingLayer} and can be ocluded
+		* by other controls. Otherwise if `true`, the tooltip will be shown on top of other controls.
 		*
 		* @type {Boolean}
 		* @default true

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -174,6 +174,17 @@ module.exports = kind(
 		autoDismiss: false,
 
 		/**
+		* If 'false', the tooltip won't be rendered in a
+		* [floating layer]{@link module:enyo/Control/floatingLayer~FloatingLayer}
+		* This may be used to guarantee whether the tooltip will be shown on top of other controls or not.
+		*
+		* @type {Boolean}
+		* @default true
+		* @public
+		*/
+		floating: true,
+
+		/**
 		* Hovering over the decorator for this length of time (in milliseconds) causes the
 		* tooltip to appear.
 		*
@@ -394,7 +405,7 @@ module.exports = kind(
 			}
 
 			if (this.rtl) {
-				anchorLeft = moonDefaultPadding + pBounds.left + pBounds.width / 2 < b.width;
+				anchorLeft = pBounds.left + pBounds.width / 2 - moonDefaultPadding < b.width;
 			} else {
 				//* When there is not enough room on the left, using right-arrow for the tooltip
 				anchorLeft = window.innerWidth - moonDefaultPadding - pBounds.left - pBounds.width / 2 >= b.width;


### PR DESCRIPTION
## Issue
Tooltip is cut off in the panels when locale is rtl, because
* Tooltip doesn't calculate panel's breadchromb width.
* Tooltip miscalculate 'moonDefaultPadding' in adjustPosition function.

## Fix
* So far, I couldn't find proper way to calculate panel's breadcumb. So apply 'floating:true' on tooltip although it is a big change.
* Take away 'moonDefaultPadding' from the original code for deciding 'anchorLeft'

Enyo-DCO-1.1-Signed-off-by: Sungbae Cho sb.cho@lge.com