### PR TITLE
Fixes PLAT-13387 add super call to beforeTeardown because we added a beforeTeardown method to enyo/DataList

### DIFF
--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -504,14 +504,17 @@ var DataListSpotlightSupport = {
 	*
 	* @private
 	*/
-	beforeTeardown: function () {
-		if (this.restoreStateOnRender) {
-			this.rememberScrollState();
-		}
-		else {
-			this.clearState();
-		}
-	},
+	beforeTeardown: kind.inherit(function (sup) {
+		return function () {
+			sup.apply(this, arguments);
+			if (this.restoreStateOnRender) {
+				this.rememberScrollState();
+			}
+			else {
+				this.clearState();
+			}
+		};
+	}),
 
 	/**
 	* @method


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)