### PR TITLE
ENYO-2955:

### DIFF
--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -461,7 +461,7 @@ module.exports = kind(
 		if (this.animate) {
 			return this.showing;
 		} else {
-			Popup.prototype.getShowing.apply(this, arguments);
+			return Popup.prototype.getShowing.apply(this, arguments);
 		}
 	},
 


### PR DESCRIPTION
Issue:
The return statement is removed from getShowing while converting syntax for
2.6 toolchain.

Fix:
Add return back to getShowing

Enyo-DCO-1.1-Signied-off-by: Kunmyon Choi kunmyon.choi@lge.com