### PR TITLE
ENYO-2907: Ignore text directionality of CheckboxItem

### DIFF
--- a/src/CheckboxItem/CheckboxItem.js
+++ b/src/CheckboxItem/CheckboxItem.js
@@ -227,9 +227,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	detectTextDirectionality: function () {
-		this.applyStyle('direction', null);
-	},
+	detectTextDirectionality: function () {},
 
 	/**
 	* @private

--- a/src/CheckboxItem/CheckboxItem.js
+++ b/src/CheckboxItem/CheckboxItem.js
@@ -227,6 +227,13 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	detectTextDirectionality: function () {
+		this.applyStyle('direction', null);
+	},
+
+	/**
+	* @private
+	*/
 	disabledChanged: function () {
 		Item.prototype.disabledChanged.apply(this, arguments);
 		this.$.input.set('disabled', this.disabled);


### PR DESCRIPTION
Issue
---
Checkbox icon is right aligned when contents are RTL text even in LTR locale. Its base kind, `moon/Item` which mixins MarqueeItem, checks for text directionality and sets its `direction` style according to its text. We only need to run that against client's MarqueeItem and not the entire CheckboxItem.

Fix
--- 
Ignore text directionality for CheckboxItem.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>