### PR TITLE
ENYO-3001 DayPicker: String is changed in DayPicker

### DIFF
--- a/src/DayPicker/DayPicker.js
+++ b/src/DayPicker/DayPicker.js
@@ -87,7 +87,7 @@ module.exports = kind(
 		* @default 'Every Day'
 		* @public
 		*/
-		everyDayText: $L('Every Day'),
+		everyDayText: $L('Everyday'),
 
 		/**
 		* Text to be displayed when all of the weekdays are selected.
@@ -96,7 +96,7 @@ module.exports = kind(
 		* @default 'Every Weekday'
 		* @public
 		*/
-		everyWeekdayText: $L('Every Weekday'),
+		everyWeekdayText: $L('Weekday'),
 
 		/**
 		* Text to be displayed when all of the weekend days are selected.
@@ -105,7 +105,7 @@ module.exports = kind(
 		* @default 'Every Weekend'
 		* @public
 		*/
-		everyWeekendText: $L('Every Weekend'),
+		everyWeekendText: $L('Weekend'),
 
 		/**
 		* Text to be displayed if no item is currently selected.


### PR DESCRIPTION
This change is that everyText is changed of moonstone DayPicker.
For example, Scheduler application have used 'Weekday' to express everyWeekdayText by UX change.
But DayPicker have used 'Every Weekday' yet.

I just removed 'Every' in everyText as everyDayText, everyWeekdayText and everyWeekendText.

Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com