### PR TITLE
ENYO-3036: End hold job when control is blurred.

### DIFF
--- a/src/PagingControl/PagingControl.js
+++ b/src/PagingControl/PagingControl.js
@@ -244,7 +244,6 @@ module.exports = kind(
 	undepress: function (sender, event) {
 		this.set('pressed', false);
 		IconButton.prototype.undepress.apply(this, arguments);
-		this.downCount = 0;
 		this.endHold(sender, event);
 	},
 
@@ -256,6 +255,7 @@ module.exports = kind(
 			return;
 		}
 
+		this.downCount = 0;
 		this.stopHoldJob();
 		this.sendPaginateEvent();
 		this.downTime = null;
@@ -316,9 +316,10 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	spotlightBlurred: function () {
+	spotlightBlurred: function (sender, event) {
 		IconButton.prototype.spotlightBlurred.apply(this, arguments);
 		this.set('spotted', false);
+		this.endHold(sender, event);
 	},
 
 	/**


### PR DESCRIPTION
### Issue
Due to some refactoring for accessibility, we separated out the logic for handling `onSpotlightKeyUp` and `onSpotlightBlur`. As a result, the call to `endHold` was only being made when handling `onSpotlightKeyUp`, and pressing a 5-way key to move off of the held `moonstone/PagingControl` control did not stop the scrolling.

### Fix
We have added a call to `endHold` when handling `onSpotlightBlur`, and have moved/consolidated the clean-up logic into the `endHold` method.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>