### PR TITLE
PLAT-15389: Add back key support to Expandables.

### DIFF
--- a/src/DateTimePickerBase/DateTimePickerBase.js
+++ b/src/DateTimePickerBase/DateTimePickerBase.js
@@ -263,9 +263,13 @@ module.exports = kind(
 	* @private
 	*/
 	expandContract: function () {
-		// if currently closed and without a value, set it to now before opening
-		if (!this.open && !this.value) {
-			this.set('value', new Date());
+		if (!this.open) {
+			// if currently closed and handling the back key, keep track of the initial value in
+			// case we need to restore this value
+			if (this.allowBackKey) this._initialValue = this.value && new Date(this.value.getTime());
+
+			// if currently closed and without a value, set it to now before opening
+			if (!this.value) this.set('value', new Date());
 		}
 		ExpandableListItem.prototype.expandContract.apply(this, arguments);
 	},
@@ -306,15 +310,23 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	refresh: function (){
+	refresh: function () {
 		this.destroyClientControls();
 		this.pickers = null;
 		delete this._tf;
 		if (this.value) {
-			this.localeValue = dateFactory({unixtime: this.value.getTime(), timezone: "local"});
+			this.localeValue = dateFactory({unixtime: this.value.getTime(), timezone: 'local'});
 		}
 		this.set('open', false);
 		this.initDefaults();
 		this.render();
+	},
+
+	/**
+	* @private
+	*/
+	backKeyHandler: function () {
+		this.set('value', this._initialValue);
+		ExpandableListItem.prototype.backKeyHandler.apply(this, arguments);
 	}
 });

--- a/src/DateTimePickerBase/DateTimePickerBase.js
+++ b/src/DateTimePickerBase/DateTimePickerBase.js
@@ -209,10 +209,7 @@ module.exports = kind(
 		this.syncingPickers = true;
 		this.setChildPickers(inOld);
 		this.syncingPickers = false;
-
-		if (this.value) {
-			this.doChange({name:this.name, value:this.value});
-		}
+		this.doChange({name:this.name, value:this.value});
 	},
 
 	/**

--- a/src/DateTimePickerBase/DateTimePickerBase.js
+++ b/src/DateTimePickerBase/DateTimePickerBase.js
@@ -326,7 +326,7 @@ module.exports = kind(
 	* @private
 	*/
 	backKeyHandler: function () {
-		this.set('value', this._initialValue);
+		if (this.open) this.set('value', this._initialValue);
 		ExpandableListItem.prototype.backKeyHandler.apply(this, arguments);
 	}
 });

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -216,12 +216,10 @@ module.exports = kind(
 	* @private
 	*/
 	inputSpotBlurred: function (inSender, inEvent) {
-		var eventType, lastEvent;
+		var eventType;
 		if (this.open && Spotlight.getPointerMode()) {
-			lastEvent = Spotlight.getLastEvent();
-			eventType = lastEvent.type;
-			if (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover'
-				&& (!lastEvent.dispatchTarget || !lastEvent.dispatchTarget.isDescendantOf(this))) {
+			eventType = Spotlight.getLastEvent().type;
+			if (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover') {
 				this.closeDrawerAndHighlightHeader();
 			}
 		}

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -186,6 +186,7 @@ module.exports = kind(
 	openChanged: function () {
 		ExpandableListItem.prototype.openChanged.apply(this, arguments);
 		if (this.open) {
+			if (this.allowBackKey) this._initialValue = this.value;
 			Spotlight.unspot();
 			this.focusInput();
 		} else {
@@ -213,10 +214,12 @@ module.exports = kind(
 	* @private
 	*/
 	inputSpotBlurred: function (inSender, inEvent) {
-		var eventType;
+		var eventType, lastEvent;
 		if (this.open && Spotlight.getPointerMode()) {
-			eventType = Spotlight.getLastEvent().type;
-			if (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover') {
+			lastEvent = Spotlight.getLastEvent();
+			eventType = lastEvent.type;
+			if (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover'
+				&& (!lastEvent.dispatchTarget || !lastEvent.dispatchTarget.isDescendantOf(this))) {
 				this.closeDrawerAndHighlightHeader();
 			}
 		}
@@ -262,6 +265,24 @@ module.exports = kind(
 			this.closeDrawerAndHighlightHeader();
 		}
 		return true;
+	},
+
+	/**
+	* @private
+	*/
+	handleContainerEnter: function () {},
+
+	/**
+	* @private
+	*/
+	handleContainerLeave: function () {},
+
+	/**
+	* @private
+	*/
+	backKeyHandler: function () {
+		this.set('value', this._initialValue);
+		ExpandableListItem.prototype.backKeyHandler.apply(this, arguments);
 	},
 
 	// Accessibility

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -186,7 +186,9 @@ module.exports = kind(
 	openChanged: function () {
 		ExpandableListItem.prototype.openChanged.apply(this, arguments);
 		if (this.open) {
+			// keep track of initial value in case we need to restore it later
 			if (this.allowBackKey) this._initialValue = this.value;
+
 			Spotlight.unspot();
 			this.focusInput();
 		} else {
@@ -270,18 +272,8 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	handleContainerEnter: function () {},
-
-	/**
-	* @private
-	*/
-	handleContainerLeave: function () {},
-
-	/**
-	* @private
-	*/
 	backKeyHandler: function () {
-		this.set('value', this._initialValue);
+		if (this.open) this.set('value', this._initialValue);
 		ExpandableListItem.prototype.backKeyHandler.apply(this, arguments);
 	},
 

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -23,9 +23,6 @@ var
 	ExpandableListItemHeader = require('./ExpandableListItemHeader'),
 	ExpandableListItemDrawer = require('./ExpandableListItemDrawer');
 
-var
-	hasHistoryEntry = false; // used to track whether or not we have pushed a history entry for ourselves
-
 /**
 * {@link module:moonstone/ExpandableListItem~ExpandableListItem}, which extends {@link module:moonstone/Item~Item}, displays a header
 * while also allowing additional content to be stored in an {@link module:enyo/Drawer~Drawer}. When
@@ -178,6 +175,13 @@ module.exports = kind(
 	* @private
 	*/
 	defaultKind: Item,
+
+	/**
+	* This is used to track whether or not we have pushed a history entry for ourselves.
+	*
+	* @private
+	*/
+	hasHistoryEntry: false,
 
 	/**
 	* @private
@@ -374,9 +378,9 @@ module.exports = kind(
 	* @protected
 	*/
 	addHistoryEntry: function () {
-		if (this.allowBackKey && !hasHistoryEntry && this.open) {
+		if (this.allowBackKey && !this.hasHistoryEntry && this.open) {
 			this.pushBackHistory();
-			hasHistoryEntry = true;
+			this.hasHistoryEntry = true;
 		}
 	},
 
@@ -384,9 +388,9 @@ module.exports = kind(
 	* @protected
 	*/
 	removeHistoryEntry: function () {
-		if (this.allowBackKey && hasHistoryEntry) {
+		if (this.allowBackKey && this.hasHistoryEntry) {
 			EnyoHistory.drop();
-			hasHistoryEntry = false;
+			this.hasHistoryEntry = false;
 		}
 	},
 
@@ -422,7 +426,7 @@ module.exports = kind(
 	backKeyHandler: function () {
 		var current = Spotlight.getCurrent();
 
-		hasHistoryEntry = false;
+		this.hasHistoryEntry = false;
 
 		// In the case where Spotlight focus is not on one of the items in the expandable, but there
 		// was still an entry history from this control, we must be in a situation where the pointer

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -371,6 +371,9 @@ module.exports = kind(
 		}
 	},
 
+	/**
+	* @private
+	*/
 	handleContainerEnter: function (sender, ev) {
 		// We only want to add a history entry if the expandable is open.
 		if (this.allowBackKey && this.open) {
@@ -378,6 +381,9 @@ module.exports = kind(
 		}
 	},
 
+	/**
+	* @private
+	*/
 	handleContainerLeave: function (sender, ev) {
 		// We guard against dropping a history entry if the expandable is closed, since this should
 		// have already been handled when the expandable was collapsed.

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -9,12 +9,14 @@ var
 	kind = require('enyo/kind'),
 	Component = require('enyo/Component'),
 	Control = require('enyo/Control'),
+	EnyoHistory = require('enyo/History'),
 	Group = require('enyo/Group');
 
 var
 	Spotlight = require('spotlight');
 
 var
+	HistorySupport = require('../HistorySupport'),
 	Item = require('../Item');
 
 var
@@ -97,6 +99,11 @@ module.exports = kind(
 
 	/**
 	* @private
+	*/
+	mixins: [HistorySupport],
+
+	/**
+	* @private
 	* @lends module:moonstone/ExpandableListItem~ExpandableListItem.prototype
 	*/
 	published: {
@@ -162,12 +169,20 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	spotlight: false,
+	spotlight: 'container',
 
 	/**
 	* @private
 	*/
 	defaultKind: Item,
+
+	/**
+	* @private
+	*/
+	handlers: {
+		onSpotlightContainerEnter: 'handleContainerEnter',
+		onSpotlightContainerLeave: 'handleContainerLeave'
+	},
 
 	/**
 	* @private
@@ -301,6 +316,11 @@ module.exports = kind(
 				var first = Spotlight.getFirstChild(this.$.drawer);
 				Spotlight.spot(first);
 			}
+			// As we could have entered the expandable when it was closed, we need to explicitly add
+			// the history entry when it is opened.
+			if (this.allowBackKey) {
+				this.pushBackHistory();
+			}
 		}
 	},
 
@@ -317,6 +337,10 @@ module.exports = kind(
 	closeDrawerAndHighlightHeader: function () {
 		var current = Spotlight.getPointerMode() ? Spotlight.getLastControl() : Spotlight.getCurrent();
 
+		if (this.allowBackKey && !EnyoHistory.isProcessing()) {
+			EnyoHistory.drop();
+		}
+
 		// If the spotlight is elsewhere, we don't want to hijack it (e.g. after the delay in
 		// ExpandablePicker)
 		if (!current || current.isDescendantOf(this)) {
@@ -328,8 +352,8 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	drawerSpotUp: function (sender, event) {
-		if (this.autoCollapse && event.originator == this.$.drawer) {
+	drawerSpotUp: function (sender, ev) {
+		if (this.autoCollapse && ev.originator == this.$.drawer) {
 			this.closeDrawerAndHighlightHeader();
 			return true;
 		}
@@ -338,19 +362,34 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	drawerSpotDown: function (sender, event) {
-		if (this.lockBottom && event.originator == this.$.drawer && event._originator) {
+	drawerSpotDown: function (sender, ev) {
+		if (this.lockBottom && ev.originator == this.$.drawer && ev._originator) {
 			// Spotlight containers redispatch 5-way events with the original event originator
 			// saved as _originator which we'll use to respot if lockBottom === true
-			Spotlight.spot(event._originator, {direction: 'DOWN'});
+			Spotlight.spot(ev._originator, {direction: 'DOWN'});
 			return true;
+		}
+	},
+
+	handleContainerEnter: function (sender, ev) {
+		// We only want to add a history entry if the expandable is open.
+		if (this.allowBackKey && this.open) {
+			this.pushBackHistory();
+		}
+	},
+
+	handleContainerLeave: function (sender, ev) {
+		// We guard against dropping a history entry if the expandable is closed, since this should
+		// have already been handled when the expandable was collapsed.
+		if (this.allowBackKey && this.open) {
+			EnyoHistory.drop();
 		}
 	},
 
 	/**
 	* @private
 	*/
-	headerTapped: function (sender, event) {
+	headerTapped: function (sender, ev) {
 		this.expandContract();
 	},
 
@@ -370,6 +409,25 @@ module.exports = kind(
 		} else {
 			this.bubble('onRequestSetupBounds');
 		}
+		return true;
+	},
+
+	/**
+	* @private
+	*/
+	backKeyHandler: function () {
+		var current = Spotlight.getCurrent();
+
+		// In the case where Spotlight focus is not on one of the items in the expandable, but there
+		// was still an entry history from this control, we must be in a situation where the pointer
+		// has moved away from the control and we have yet to spot another item. We should then
+		// effectively "pass on" the back action by calling the "pop" method of History.
+		if (current && current.isDescendantOf(this)) {
+			this.closeDrawerAndHighlightHeader();
+		} else {
+			EnyoHistory.pop();
+		}
+
 		return true;
 	},
 

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -23,6 +23,9 @@ var
 	ExpandableListItemHeader = require('./ExpandableListItemHeader'),
 	ExpandableListItemDrawer = require('./ExpandableListItemDrawer');
 
+var
+	hasHistoryEntry = false; // used to track whether or not we have pushed a history entry for ourselves
+
 /**
 * {@link module:moonstone/ExpandableListItem~ExpandableListItem}, which extends {@link module:moonstone/Item~Item}, displays a header
 * while also allowing additional content to be stored in an {@link module:enyo/Drawer~Drawer}. When
@@ -180,8 +183,8 @@ module.exports = kind(
 	* @private
 	*/
 	handlers: {
-		onSpotlightContainerEnter: 'handleContainerEnter',
-		onSpotlightContainerLeave: 'handleContainerLeave'
+		onSpotlightContainerEnter: 'addHistoryEntry',
+		onSpotlightContainerLeave: 'removeHistoryEntry'
 	},
 
 	/**
@@ -318,9 +321,7 @@ module.exports = kind(
 			}
 			// As we could have entered the expandable when it was closed, we need to explicitly add
 			// the history entry when it is opened.
-			if (this.allowBackKey) {
-				this.pushBackHistory();
-			}
+			this.addHistoryEntry();
 		}
 	},
 
@@ -337,9 +338,7 @@ module.exports = kind(
 	closeDrawerAndHighlightHeader: function () {
 		var current = Spotlight.getPointerMode() ? Spotlight.getLastControl() : Spotlight.getCurrent();
 
-		if (this.allowBackKey && !EnyoHistory.isProcessing()) {
-			EnyoHistory.drop();
-		}
+		this.removeHistoryEntry();
 
 		// If the spotlight is elsewhere, we don't want to hijack it (e.g. after the delay in
 		// ExpandablePicker)
@@ -372,23 +371,22 @@ module.exports = kind(
 	},
 
 	/**
-	* @private
+	* @protected
 	*/
-	handleContainerEnter: function (sender, ev) {
-		// We only want to add a history entry if the expandable is open.
-		if (this.allowBackKey && this.open) {
+	addHistoryEntry: function () {
+		if (this.allowBackKey && !hasHistoryEntry && this.open) {
 			this.pushBackHistory();
+			hasHistoryEntry = true;
 		}
 	},
 
 	/**
-	* @private
+	* @protected
 	*/
-	handleContainerLeave: function (sender, ev) {
-		// We guard against dropping a history entry if the expandable is closed, since this should
-		// have already been handled when the expandable was collapsed.
-		if (this.allowBackKey && this.open) {
+	removeHistoryEntry: function () {
+		if (this.allowBackKey && hasHistoryEntry) {
 			EnyoHistory.drop();
+			hasHistoryEntry = false;
 		}
 	},
 
@@ -423,6 +421,8 @@ module.exports = kind(
 	*/
 	backKeyHandler: function () {
 		var current = Spotlight.getCurrent();
+
+		hasHistoryEntry = false;
 
 		// In the case where Spotlight focus is not on one of the items in the expandable, but there
 		// was still an entry history from this control, we must be in a situation where the pointer

--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -466,6 +466,11 @@ module.exports = kind(
 		}
 
 		if (this.getAutoCollapseOnSelect() && this.$.drawer.hasRendered && this.getOpen()) {
+			// this is needed due to the select and close delay, during which other history entries
+			// could have been pushed - we drop the entry immediately to prevent dropping the wrong
+			// entry later
+			this.removeHistoryEntry();
+
 			this.startJob('selectAndClose', 'expandContract', this.selectAndCloseDelayMS);
 		}
 


### PR DESCRIPTION
### Issue
We want to support the back key in `Expandable*` controls (basically, anything that subkinds `moonstone/ExpandableListItem`), such that pressing the back key closes the control if it is open and has Spotlight focus.

### Fix
We have added this functionality primarily to `moonstone/ExpandableListItem`. Specifically, we have converted this control to be a Spotlight container to allow for easier handling of both the header + drawer as a whole, and we maintain an internal property to ensure we only add/remove history entries as appropriate. We have also added some logic to `moonstone/DateTimePickerBase` and `moonstone/ExpandableInput` to reset their respective values when the back key is pressed.

### Notes
I considered adding an API called `resetOnBack` (or something to that effect) that would be defaulted to `false`, and set to `true` for `moonstone/DateTimePickerbase` and `moonstone/ExpandableInput`. This would allow for the reset logic to be written once in `moonstone/ExpandableListItem`'s `backKeyHandler`, but in the interest of being more opinionated and not unnecessarily expanding the API surface area, have decided against it, especially because the shared logic is a single call. Also, the setting of the initial value varies between the controls and was not easily generalizable. I can probably be convinced otherwise, though.

This PR is dependent on https://github.com/enyojs/enyo/pull/1366.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>