### PR TITLE
Fixes ENYO-2907

### DIFF
--- a/src/CheckboxItem/CheckboxItem.less
+++ b/src/CheckboxItem/CheckboxItem.less
@@ -19,6 +19,7 @@
 		// Checkbox
 		.moon-checkbox {
 			left: @moon-spotlight-outset - 3;
+			right: auto;
 		}
 		// Label
 		.moon-checkbox-item-label-wrapper {


### PR DESCRIPTION
## Issue
When the locale was LTR but the CheckboxItem's text directionality is RTL, the checkbox item would
be right-aligned causing it to overlap with the content.

## Fix
Use `right: auto` for left-handed checkboxes to override the default `right` value set for the checkbox.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)