### PR TITLE
PLAT-14806: Add accessibilityValueText for reading custom string

### DIFF
--- a/src/IntegerPicker/IntegerPicker.js
+++ b/src/IntegerPicker/IntegerPicker.js
@@ -720,14 +720,23 @@ module.exports = kind(
 	accessibilityRole: 'spinbutton',
 
 	/**
+	* Custom value for accessibility (ignored if `null`).
+	*
+	* @type {String|null}
+	* @default null
+	* @public
+	*/
+	accessibilityValueText: null,
+
+	/**
 	* @private
 	*/
 	ariaObservers: [
 		{from: 'min', to: 'aria-valuemin'},
 		{from: 'max', to: 'aria-valuemax'},
-		{path: 'value',  method: function () {
-				this.set('accessibilityHint', null);
-				this.ariaValue();
+		{path: ['accessibilityValueText', 'value'], method: function () {
+			this.set('accessibilityHint', null);
+			this.ariaValue();
 		}},
 		{path: 'spotted',  method: function () {
 			// When spotlight is focused, it reads value with hint
@@ -747,6 +756,7 @@ module.exports = kind(
 	* @private
 	*/
 	ariaValue: function () {
-		this.setAriaAttribute('aria-valuenow', this.value);
+		var text = this.accessibilityValueText || this.value;
+		this.setAriaAttribute('aria-valuetext', text);
 	}
 });

--- a/src/SimpleIntegerPicker/SimpleIntegerPicker.js
+++ b/src/SimpleIntegerPicker/SimpleIntegerPicker.js
@@ -200,27 +200,10 @@ module.exports = kind(
 	// Accessibility
 
 	/**
-	* @default 'spinbutton'
-	* @type {String}
-	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityRole
-	* @public
-	*/
-	accessibilityRole: 'spinbutton',
-
-	/**
-	* Custom value for accessibility (ignored if `null`).
-	*
-	* @type {String|null}
-	* @default null
-	* @public
-	*/
-	accessibilityValueText: null,
-
-	/**
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['accessibilityValueText', 'value', 'unit'],  method: function () {
+		{path: 'unit',  method: function () {
 			this.set('accessibilityHint', null);
 			this.ariaValue();
 		}},

--- a/src/SimpleIntegerPicker/SimpleIntegerPicker.js
+++ b/src/SimpleIntegerPicker/SimpleIntegerPicker.js
@@ -208,12 +208,21 @@ module.exports = kind(
 	accessibilityRole: 'spinbutton',
 
 	/**
+	* Custom value for accessibility (ignored if `null`).
+	*
+	* @type {String|null}
+	* @default null
+	* @public
+	*/
+	accessibilityValueText: null,
+
+	/**
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['value', 'unit'],  method: function () {
-				this.set('accessibilityHint', null);
-				this.ariaValue();
+		{path: ['accessibilityValueText', 'value', 'unit'],  method: function () {
+			this.set('accessibilityHint', null);
+			this.ariaValue();
 		}},
 		{path: 'spotted',  method: function () {
 			// When spotlight is focused, it reads value with hint
@@ -233,7 +242,8 @@ module.exports = kind(
 	* @private
 	*/
 	ariaValue: function () {
-		var text = this.unit ? this.value + ' ' + this.unit : this.value;
+		var text = this.accessibilityValueText || 
+					(this.unit ? this.value + ' ' + this.unit : this.value);
 		this.setAriaAttribute('aria-valuetext', text);
 	}
 });


### PR DESCRIPTION
TV can read only simpleIntegerPicker's value and unit whenever
value or unit is changed, so accessibilityValueText is necessary for
reading other custom string.

https://jira2.lgsvl.com/browse/PLAT-14806
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>