### PR TITLE
ENYO-3075: ContextualPopup should use the neutral BG color, not its own.

### DIFF
--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -120,7 +120,7 @@
 @moon-drawer-activator-font-color: #a6a6a6;
 @moon-drawer-activator-open-font-color: #4b4b4b;
 
-@moon-contextual-popup-bg-color: #686868;
+@moon-contextual-popup-bg-color: @moon-neutral-bg-color;
 @moon-contextual-popup-text-color: @moon-white;
 @moon-contextual-popup-border-color: rgba(0,0,0,0.5);
 


### PR DESCRIPTION
This will have *no* visible effect right now (the two values are the same color), but if one changes in the near future, this will be relevant. Also important for customization for the public release.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>