### PR TITLE
ENYO-1224: ContextualPopup: Nothing is Spottable outside of Spotlight Modal Off

### DIFF
--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -572,7 +572,7 @@ module.exports = kind(
 			} else {
 				this._scrim.hideAtZIndex(this._scrimZ);
 			}
-			util.call(scrim, 'addRemoveClass', [this.scrimClassName, this._scrim.showing]);
+			util.call(this._scrim, 'addRemoveClass', [this.scrimClassName, this._scrim.showing]);
 		} else {
 			// clean up scrim here when showHideScrim is not called from showingChanged
 			this._scrim && this._scrim.hideAtZIndex(this._scrimZ);

--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -239,8 +239,7 @@ module.exports = kind(
 	*/
 	syncProperties: function () {
 		if (this.modal == this.spotlightModal) return;
-		if (this.hasOwnProperty('spotlightModal')) this.modal = this.spotlightModal;
-		if (this.hasOwnProperty('modal')) this.spotlightModal = this.modal;
+		this.modal = this.spotlightModal;
 	},
 
 	/**
@@ -574,21 +573,24 @@ module.exports = kind(
 	* @private
 	*/
 	showHideScrim: function (show) {
-		if (this.floating && (this.scrim || (this.modal && this.scrimWhenModal))) {
-			this._scrim = this.getScrim();
-			if (show) {
-				// move scrim to just under the popup to obscure rest of screen
-				var i = this.getScrimZIndex();
-				this._scrimZ = i;
-				this._scrim.showAtZIndex(i);
-			} else {
-				this._scrim.hideAtZIndex(this._scrimZ);
-			}
+		var scrim = this.getScrim();
+
+		if (this._scrim && scrim != this._scrim) {
+			// hide if there was different kind of scrim
+			this._scrim.hideAtZIndex(this._scrimZ);
 			util.call(this._scrim, 'addRemoveClass', [this.scrimClassName, this._scrim.showing]);
-		} else {
-			// clean up scrim here when showHideScrim is not called from showingChanged
-			this._scrim && this._scrim.hideAtZIndex(this._scrimZ);
 		}
+
+		if (show && this.floating && (this.scrim || (this.modal && this.scrimWhenModal))) {
+			// move scrim to just under the popup to obscure rest of screen
+			var i = this.getScrimZIndex();
+			this._scrimZ = i;
+			scrim.showAtZIndex(i);
+		} else {
+			scrim.hideAtZIndex(this._scrimZ);
+		}
+		util.call(scrim, 'addRemoveClass', [this.scrimClassName, scrim.showing]);
+		this._scrim = scrim;
 	},
 
 	/**

--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -125,14 +125,14 @@ module.exports = kind(
 
 		/**
 		* If `true`, focus cannot leave the constraints of the popup unless the
-		* popup is explicitly closed. This property is copied to
-		* [modal]{@link module:enyo/Popup~Popup#modal} on initiation time.
-		* And, these two proverties are synced whenever one of
+		* popup is explicitly closed. This property's value is copied to
+		* [modal]{@link module:enyo/Popup~Popup#modal} at initialization time.
+		* Additionally, these two properties are synced whenever one of the following properties changes:
 		* [spotlightModal]{@link module:moonstone/ContextualPopup~ContextualPopup#spotlightModal},
 		* [modal]{@link module:enyo/Popup~Popup#modal},
 		* [modal]{@link module:enyo/Popup~Popup#scrim},
 		* [modal]{@link module:enyo/Popup~Popup#scrimWhenModal},
-		* [modal]{@link module:enyo/Popup~Popup#floating} property changes.
+		* [modal]{@link module:enyo/Popup~Popup#floating}.
 		*
 		* @type {Boolean}
 		* @default false

--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -125,7 +125,14 @@ module.exports = kind(
 
 		/**
 		* If `true`, focus cannot leave the constraints of the popup unless the
-		* popup is explicitly closed.
+		* popup is explicitly closed. This property is copied to
+		* [modal]{@link module:enyo/Popup~Popup#modal} on initiation time.
+		* And, these two proverties are synced whenever one of
+		* [spotlightModal]{@link module:moonstone/ContextualPopup~ContextualPopup#spotlightModal},
+		* [modal]{@link module:enyo/Popup~Popup#modal},
+		* [modal]{@link module:enyo/Popup~Popup#scrim},
+		* [modal]{@link module:enyo/Popup~Popup#scrimWhenModal},
+		* [modal]{@link module:enyo/Popup~Popup#floating} property changes.
 		*
 		* @type {Boolean}
 		* @default false
@@ -229,16 +236,6 @@ module.exports = kind(
 	initComponents: function () {
 		this.createChrome(this.tools);
 		Popup.prototype.initComponents.apply(this, arguments);
-		this.syncProperties();
-	},
-
-	/**
-	* Sync spotlightModal and modal properties on creation time.
-	*
-	* @private
-	*/
-	syncProperties: function () {
-		if (this.modal == this.spotlightModal) return;
 		this.modal = this.spotlightModal;
 	},
 
@@ -560,8 +557,8 @@ module.exports = kind(
 		if (this._updateScrimMutex) return;
 		this._updateScrimMutex = true;
 
-		// We sync modal and spotlightModal here because binding doesn't guarantee sequence
-		// when it is used with observers.
+		// We sync modal and spotlightModal here because binding doesn't
+		// guarantee sequence when it is used with observers.
 		if (source == 'modal') this.set('spotlightModal', this.modal);
 		if (source == 'spotlightModal') this.set('modal', this.spotlightModal);
 		this.showHideScrim(this.showing);
@@ -578,7 +575,7 @@ module.exports = kind(
 		if (this._scrim && scrim != this._scrim) {
 			// hide if there was different kind of scrim
 			this._scrim.hideAtZIndex(this._scrimZ);
-			util.call(this._scrim, 'addRemoveClass', [this.scrimClassName, this._scrim.showing]);
+			if (this.scrimClassName) this._scrim.removeClass(this.scrimClassName);
 		}
 
 		if (show && this.floating && (this.scrim || (this.modal && this.scrimWhenModal))) {

--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -606,7 +606,6 @@ module.exports = kind(
 	showingChanged: function () {
 		Popup.prototype.showingChanged.apply(this, arguments);
 		this.alterDirection();
-		//this.showHideScrim(this.showing);
 
 		if (this.allowBackKey) {
 			if (this.showing) {

--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -229,6 +229,18 @@ module.exports = kind(
 	initComponents: function () {
 		this.createChrome(this.tools);
 		Popup.prototype.initComponents.apply(this, arguments);
+		this.syncProperties();
+	},
+
+	/**
+	* Sync spotlightModal and modal properties on creation time.
+	*
+	* @private
+	*/
+	syncProperties: function () {
+		if (this.modal == this.spotlightModal) return;
+		if (this.hasOwnProperty('spotlightModal')) this.modal = this.spotlightModal;
+		if (this.hasOwnProperty('modal')) this.spotlightModal = this.modal;
 	},
 
 	/**


### PR DESCRIPTION
### Issue:

The components outside the contextual popup were not spottable even after the spotlightModal property set to false for the contextual popup. The spotlightModal property doesn't use for show/hide the scrim which caused this issue.

### Fix:

It was the modal property used for show/hide the scrim, so that the modal and spotlightModal are binded together and the this.showHideScrim() function called on modelChanged will solve the issue.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi kunmyon.choi@lge.com