### PR TITLE
ENYO-3074 Focus to wrong item in NewDataList

### DIFF
--- a/src/NewDataList/NewDataList.js
+++ b/src/NewDataList/NewDataList.js
@@ -124,5 +124,14 @@ module.exports = kind({
 			Spotlight.spot(fv);
 			return true;
 		}
+	},
+	isVisibleChild : function(control){
+		var controls = this.orderedChildren.slice(this.firstFullyVisibleI, this.lastFullyVisibleI + 1);
+		for(var i=0;i<controls.length;i++){			
+			if( control.isDescendantOf(controls[i]) ){
+				return true;
+			}
+		}
+		return false;
 	}
 });

--- a/src/NewDataList/NewDataList.js
+++ b/src/NewDataList/NewDataList.js
@@ -87,7 +87,7 @@ module.exports = kind({
 	* Spotlight focused. Currently, setting `focus: true` forces the
 	* scroll behavior to be `instant`, meaning that the scroller will
 	* jump to the item (with no animation).
-	* 
+	*
 	* @see module:enyo/NewDataList~NewDataList.scrollToItem
 	* @param {number} index - The (zero-based) index of the item to scroll to
 	* @param {Object} opts - Scrolling options (see module:enyo/Scrollable~Scrollable.scrollTo)
@@ -125,13 +125,21 @@ module.exports = kind({
 			return true;
 		}
 	},
-	isVisibleChild : function(control){
-		var controls = this.orderedChildren.slice(this.firstFullyVisibleI, this.lastFullyVisibleI + 1);
-		for(var i=0;i<controls.length;i++){			
-			if( control.isDescendantOf(controls[i]) ){
+	/**
+	* Called by moonstone/Scrollable.filterFocus()
+	* @private
+	*/
+	eventIsFromVisibleChild: function (event) {
+		var control = event.originator,
+			controls = this.orderedChildren.slice(this.firstFullyVisibleI, this.lastFullyVisibleI + 1),
+			i;
+
+		for (i = 0; i < controls.length; i++) {
+			if (control.isDescendantOf(controls[i])) {
 				return true;
 			}
 		}
+
 		return false;
 	}
 });

--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -138,8 +138,8 @@ var Scrollable = {
 				// default, we short-circuit the action because the child is
 				// potentially not in view, and focusing would cause it to
 				// scroll it into view for no reason apparent to the user.
-				// Instead, we should focus a child we know to be visible.				
-				if (this.eventIsFromScrollingChild(event) && !this.isVisibleChild(event.originator) ) {
+				// Instead, we should focus a child we know to be visible.
+				if (this.eventIsFromScrollingChild(event) && !this.eventIsFromVisibleChild(event)) {
 					return this.spotFirstVisibleChild();
 				}
 				break;
@@ -147,7 +147,14 @@ var Scrollable = {
 				return false;
 		}
 	},
-	isVisibleChild: kind.inherit(function (sup) {
+
+	/**
+	* This check is factored out of `filterFocus()` so that the logic can be
+	* overridden by the kind that includes the `Scrollable` mixin.
+	*
+	* @private
+	*/
+	eventIsFromVisibleChild: kind.inherit(function (sup) {
 		return function (event) {
 			if (sup === utils.nop) {
 				return false;

--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -138,8 +138,8 @@ var Scrollable = {
 				// default, we short-circuit the action because the child is
 				// potentially not in view, and focusing would cause it to
 				// scroll it into view for no reason apparent to the user.
-				// Instead, we should focus a child we know to be visible.
-				if (this.eventIsFromScrollingChild(event)) {
+				// Instead, we should focus a child we know to be visible.				
+				if (this.eventIsFromScrollingChild(event) && !this.isVisibleChild(event.originator) ) {
 					return this.spotFirstVisibleChild();
 				}
 				break;
@@ -147,6 +147,16 @@ var Scrollable = {
 				return false;
 		}
 	},
+	isVisibleChild: kind.inherit(function (sup) {
+		return function (event) {
+			if (sup === utils.nop) {
+				return false;
+			}
+			else {
+				return sup.apply(this, arguments);
+			}			
+		};
+	}),
 
 	/**
 	* This check is factored out of `filterFocus()` so that the logic can be


### PR DESCRIPTION
Issue
: NewDataList restore worng focus

Fix
: Before focus to first visible item, add condition that the item is visible or not in screen

Enyo-DCO-1.1-Signed-off-by:Changgi Lee changgi.lee@lge.com