### PR TITLE
PLAT-16231: Deprecate entire module

### DIFF
--- a/src/ContextualPopupButton/ContextualPopupButton.js
+++ b/src/ContextualPopupButton/ContextualPopupButton.js
@@ -2,6 +2,7 @@ require('moonstone');
 
 /**
 * Contains the declaration for the {@link module:moonstone/ContextualPopupButton~ContextualPopupButton} kind.
+* @deprecated Since 2.6
 * @module moonstone/ContextualPopupButton
 */
 

--- a/src/ToggleText/ToggleText.js
+++ b/src/ToggleText/ToggleText.js
@@ -2,6 +2,7 @@ require('moonstone');
 
 /**
 * Contains the declaration for the {@link module:moonstone/ToggleText~ToggleText} kind.
+* @deprecated Since 2.6
 * @module moonstone/ToggleText
 */
 


### PR DESCRIPTION
### Issue
We should deprecate the entire `ContextualPopupButton` module, and not just the class.

### Fix
The entire module has been marked as deprecated. As a bonus, we did the same thing for `ToggleText`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>