### PR TITLE
Fixes ENYO-3101

### DIFF
--- a/src/ExpandableDataPicker/ExpandableDataPicker.js
+++ b/src/ExpandableDataPicker/ExpandableDataPicker.js
@@ -70,6 +70,7 @@ module.exports = kind(
 	*/
 	collectionChanged: function () {
 		this.$.list.set('collection', this.collection);
+		if (this.collection && !this.$.list.hasNode()) this.$.list.refresh();
 	},
 	
 	/**


### PR DESCRIPTION
If the client code relies on the data in the collection to drive the
initial selection, it will not do so on create because the repeater has
not rendered yet so the onActivate event doesn't fire. So, if the
collection for an ExpandableDataPicker changes and the list hasn't
rendered yet, force a refresh to trigger the onActivate event, update
the selected item, and display the correct text in currentValueText.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)