### PR TITLE
ENYO-3091: Set default spotlightRememberFocus as false for Popup and …

### DIFF
--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -77,6 +77,11 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	spotlightRememberFocus: false,
+
+	/**
+	* @private
+	*/
 	allowDefault: true,
 
 	/**


### PR DESCRIPTION
…ContextualPopup

Issue:
Current popup and contextualPopup is remembering last focused child and re focus on next show. Generally it is okay. But, there is some awkward cases  like selecting yes or no. HE UX want popup have always the same initial focus on show.

Fix:
Extend the use case of spotlightRememberFocus for general case. And set default value as false on Popup and ContextualPopup.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi kunmyon.choi@lge.com