### PR TITLE
PLAT-15388: Change Slider default focus behavior

### DIFF
--- a/src/Slider/Slider.less
+++ b/src/Slider/Slider.less
@@ -29,6 +29,12 @@
 		}
 	}
 
+	.moon-progress-bar-bar {
+		&.selected {
+			background-color: @moon-slider-spotlight-bar-color;
+		}
+	}
+
 	&.moon-progress-bar-horizontal {
 		margin: 60px 48px;
 
@@ -112,10 +118,6 @@
 	}
 
 	&.spotlight {
-		> .moon-progress-bar-bar {
-			background-color: @moon-slider-spotlight-bar-color;
-		}
-
 		> .moon-slider-knob {
 			background-color: @moon-slider-spotlight-knob-color;
 


### PR DESCRIPTION
Squashed version of https://github.com/enyojs/moonstone/pull/2687.

PLAT-15388: Remove spotlight color in progress bar
Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

PLAT-15388: Show popup on focus
Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

PLAT-15388: Cleanup and change name for hideKnobStatus
Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

PLAT-15388: Change bar to highlight on press

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

PLAT-15388: Remove selected status on knob up

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

refactor knob/bar class updates into property observers

Class assignment was sprinkled throughout the kind making it more
difficult to reason when the classes would be applied (and introducing
a minor bug in which the bar would not be highlighted when dragging
started off the knob). Consolidating them into property observers
simplifies things.

Issue: PLAT-15388
Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)

More cleanup

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>