### PR TITLE
PLAT-16501 moon.Input provides validator to prevent inputting invalid number

### DIFF
--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -18,6 +18,8 @@ var
 	RichText = require('../RichText'),
 	TextArea = require('../TextArea');
 
+var
+	ContextualPopup = require('../ContextualPopup');
 /**
 * {@link module:moonstone/InputDecorator~InputDecorator} is a control that provides input styling. Any controls
 * in the InputDecorator will appear to be inside an area styled as an input. Usually,
@@ -87,6 +89,8 @@ module.exports = kind(
 	*/
 	handlers: {
 		onDisabledChange    : 'disabledChangeHandler',
+		onenabledValidity   : 'enabledValidityHandler',
+		ondisabledValidity  : 'disabledValidityHandler',
 		onfocus             : 'focusHandler',
 		onblur              : 'blurHandler',
 		onSpotlightFocused  : 'spotlightFocusedHandler',
@@ -102,6 +106,15 @@ module.exports = kind(
 	* @private
 	*/
 	_oInputControl: null,
+
+	/**
+	* @private
+	*/
+	tools: [
+		{name: 'rangeMsgPopup', kind: ContextualPopup, direction: 'right', components: [
+			{content: 'Invalid value !'}	// To DO : This content will be changed from UX. It is temporary content.
+		]}
+	],
 
 	/**
 	* Returns boolean indicating whether passed-in control is an input field.
@@ -218,6 +231,26 @@ module.exports = kind(
 	*/
 	disabledChangeHandler: function (oSender, oEvent) {
 		this.addRemoveClass('moon-disabled', oEvent.originator.disabled);
+	},
+
+	/**
+	* @private
+	*/
+	enabledValidityHandler: function (oSender, oEvent) {
+		if(!this.$.rangeMsgPopup) {
+			this.createChrome(this.tools);
+		}
+		this.waterfallDown('onRequestShowPopup', {activator: this});
+	},
+
+	/**
+	* @private
+	*/
+	disabledValidityHandler: function () {
+		if(!this.$.rangeMsgPopup) {
+			this.createChrome(this.tools);
+		}
+		this.waterfallDown('onRequestHidePopup');
 	},
 
 	// Spotlight Event handlers:


### PR DESCRIPTION
### Issue
This is new UX requirement in 2017 TV. 
User can input the invalid value out of correct range. So moon.input provides validator to prevent inputting invalid number.

### Fix
I added published variables(min, max) to make range from default values.
Also I implemented change handler to make it dynamically.
If moon.input has number type, min and max value, contexturePopup is shown by validity when user input the wrong number.

Enyo-DCO-1.1-Signed-off-by: Sangwook Lee <sangwook1203.lee@lge.com>