### PR TITLE
ENYO-3109: Prevent unwanted shifting of drawer contents.

### DIFF
--- a/src/Drawers/Drawers.js
+++ b/src/Drawers/Drawers.js
@@ -175,6 +175,12 @@ module.exports = kind(
 	*/
 	_activated: false,
 
+
+	/**
+	* @private
+	*/
+	accessibilityPreventScroll: true,
+
 	/**
 	* @private
 	*/


### PR DESCRIPTION
### Issue
When the drawer has been opened and has shifted some of its contents down, focusing on the shifted contents can cause some unexpected shifting, due to the contents being focused by accessibility and scrolled into view.

### Fix
We have used the `accessibilityPreventScroll` property on `moonstone/Drawers` to prevent this unwanted shifting.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>