### PR TITLE
ENYO-3149: Disable handle, by default, when using activity pattern.

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -734,7 +734,7 @@ module.exports = kind(
 				this.setAlertRole();
 			}
 			this.notifyObservers('index');
-		}	
+		}
 
 		this.isModifyingPanels = false;
 
@@ -1693,7 +1693,7 @@ module.exports = kind(
 		case 'alwaysviewing':
 		case 'activity':
 			this.addClass(this.pattern);
-			this.useHandle = (this.useHandle === 'auto') ? true : this.useHandle;
+			this.useHandle = (this.useHandle === 'auto') ? (this.pattern == 'activity' ? false : true) : this.useHandle;
 			this.createChrome(this.handleTools);
 			this.tools = this.animatorTools;
 			break;


### PR DESCRIPTION
### Issue
The previous behavior (in standard Moonstone) was to disable the panel handle when using the activity pattern, if `useHandle: 'auto'` was specified. When making some changes to consolidate some logic (I believe related to the close button), this logic was changed so that the default in this scenario is reversed (panel handle is enabled).

### Fix
I considered making a documentation change such that both the activity and always-viewing patterns behaved the same with respect to the panels handle and a value of `auto` for `useHandle`, but this would effectively defeat the purpose of having the `auto` value of the `useHandle` property and would effectively change the default behavior for the use of activity panels, even if the handles were not intended to be used. I am not quite sure why this has not come up before (either applications are not using this pattern, or had been specifying `useHandle:false` explicitly), but making this change should have no effect unless they are expecting panels handle to appear by default (which they should not). For now, maybe we just make these changes for the public release, in any case.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>