### PR TITLE
ENYO-3161: Always adjust panel when changing indices.

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1527,14 +1527,14 @@ module.exports = kind(
 	indexChanged: function (was) {
 		var current, delta, deltaAbs, idx;
 
+		this.adjustFirstPanelBeforeTransition();
+
 		if (this.getPanels().length > 0) {
 			this.assignBreadcrumbIndex();
 
 			// Set animation direction to use proper timing function before start animation
 			// This direction is only consumed by MoonAnimator.
 			this.$.animator.direction = this.getDirection();
-
-			this.adjustFirstPanelBeforeTransition();
 
 			// Push or drop history, based on the direction of the index change
 			if (this.allowBackKey) {


### PR DESCRIPTION
### Issue
We had made a tweak in https://github.com/enyojs/moonstone-extra/pull/167 to prevent running the `indexChanged` logic when there are no panels. Unfortunately, there are certain scenarios where `createComponent[s]` is utilized to create a single panel, and was relying on the fact that `indexChanged` was run unbounded, which adjusted the viewport to be full-width as the default index is 0.

### Fix
We moved the call to adjust the panel out of the guard, in `indexChanged`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>