### PR TITLE
ENYO-3184: Utilize standard Event property target, instead of srcElement.

### DIFF
--- a/src/VideoPlayer/VideoPlayer.js
+++ b/src/VideoPlayer/VideoPlayer.js
@@ -1979,7 +1979,7 @@ module.exports = kind(
 	*/
 	timeUpdate: function (sender, e) {
 		//* Update _this.duration_ and _this.currentTime_
-		if (!e && e.srcElement || e.currentTime === null) {
+		if (!e && e.target || e.currentTime === null) {
 			return;
 		}
 
@@ -2063,7 +2063,7 @@ module.exports = kind(
 	* @private
 	*/
 	_progress: function (sender, e) {
-		var buffered = this._getBufferedProgress(e.srcElement);
+		var buffered = this._getBufferedProgress(e.target);
 		if (this.isFullscreen() || !this.getInline()) {
 			this.$.slider.setBgProgress(buffered.value);
 		} else {
@@ -2096,10 +2096,10 @@ module.exports = kind(
 	*/
 	_pause: function (sender, e) {
 		// Don't send pause feedback if we are rewinding
-		if (e.srcElement.playbackRate < 0) {
+		if (e.target.playbackRate < 0) {
 			return;
 		}
-		if (e.srcElement.currentTime === 0) {
+		if (e.target.currentTime === 0) {
 			this.sendFeedback('Stop', {}, true);
 			return;
 		}


### PR DESCRIPTION
### Issue
We had been utilizing the non-standard `Event.srcElement` property (https://developer.mozilla.org/en-US/docs/Web/API/Event/srcElement), which is not supported at all in Firefox, and was throwing fatal errors.

### Fix
We have made an update to utilize the standard `Event.target` property, instead.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>