### PR TITLE
ENYO-3189: Convert "more" icons references from SVG assets to icon font

### DIFF
--- a/src/VideoPlayer/VideoPlayer.js
+++ b/src/VideoPlayer/VideoPlayer.js
@@ -531,14 +531,14 @@ module.exports = kind(
 		*
 		* @private
 		*/
-		moreControlsIcon: libPath + '/images/ellipsis.svg',
+		moreControlsIcon: 'ellipsis',
 
 		/**
 		* Name of font-based icon or image file.
 		*
 		* @private
 		*/
-		lessControlsIcon: libPath + '/images/back.svg',
+		lessControlsIcon: 'arrowhookleft',
 
 		/**
 		* Name of font-based icon or image file.


### PR DESCRIPTION
I've left the "libPath" variable in place so it's available for future cases.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>