### PR TITLE
ENYO-3183: Corrected opacity level for input Headers' placeholders

### DIFF
--- a/src/Header/Header.less
+++ b/src/Header/Header.less
@@ -172,6 +172,7 @@
 					color: @moon-input-header-placeholder-color;
 					margin-top: 12px;
 					line-height: 1.25em;
+					opacity: 1;
 				});
 			}
 

--- a/src/Input/Input.less
+++ b/src/Input/Input.less
@@ -34,11 +34,11 @@
 	.moon-disabled .moon-input {
 		cursor: default;
 	}
-	> input::-webkit-input-placeholder {
-		color: @moon-input-placeholder-color;
-	}
-	> input:-moz-placeholder {
-		color: @moon-input-placeholder-color;
+	> input {
+		.input-placeholder({
+			color: @moon-input-placeholder-color;
+			opacity: 1;
+		});
 	}
 }
 


### PR DESCRIPTION
... In Firefox

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>