### PR TITLE
ENYO-3186: All children of spotted items get a reasonable color.

### DIFF
--- a/src/Item/Item.less
+++ b/src/Item/Item.less
@@ -8,6 +8,10 @@
 	&.spotlight {
 		background-color: @moon-accent;
 		color: @moon-white;
+
+		* {
+			color: inherit;
+		}
 	}
 
 	&.allow-wrap {


### PR DESCRIPTION
This is a low-specificity rule that is/will be easy to override, if some case finds a reason to need to.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>