### PR TITLE
PLAT-16501 TV UX requirement: moon.Input provides validator to prevent inputting wrong range's number

### DIFF
--- a/src/Input/Input.less
+++ b/src/Input/Input.less
@@ -23,6 +23,30 @@
 	}
 }
 
+.moon-divider-text .input-validation {
+	position: relative;
+	width: 30px;
+	text-align: center;
+	font-family: "Moonstone", "Moonstone Icons";
+	font-size: 54px;
+	line-height: 39px;
+}
+
+.moon-input[type=number]:focus:invalid ~ .input-validation::after {
+	content: "\0EFFF5";
+	color: red;
+}
+
+.moon-input[type=number]:focus:valid ~ .input-validation::after {
+	content: "\02713";
+	color: green;
+}
+
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+}
+
 .moon-input-decorator {
 	&.spotlight {
 		color: @moon-spotlight-text-color;

--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -7,6 +7,7 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	Control = require('enyo/Control'),
 	ToolDecorator = require('enyo/ToolDecorator');
 
 var
@@ -18,6 +19,8 @@ var
 	RichText = require('../RichText'),
 	TextArea = require('../TextArea');
 
+var
+	ContextualPopup = require('../ContextualPopup');
 /**
 * {@link module:moonstone/InputDecorator~InputDecorator} is a control that provides input styling. Any controls
 * in the InputDecorator will appear to be inside an area styled as an input. Usually,
@@ -95,6 +98,8 @@ module.exports = kind(
 	*/
 	handlers: {
 		onDisabledChange    : 'disabledChangeHandler',
+		onShowValidityPopup : 'showValidityPopupHandler',
+		onHideValidityPopup : 'hideValidityPopupHandler',
 		onfocus             : 'focusHandler',
 		onblur              : 'blurHandler',
 		onSpotlightFocused  : 'spotlightFocusedHandler',
@@ -110,6 +115,15 @@ module.exports = kind(
 	* @private
 	*/
 	_oInputControl: null,
+
+	/**
+	* @private
+	*/
+	tools: [
+		{name: 'validityPopup', kind: ContextualPopup, direction: 'right', floating: false, components: [
+			{name: 'message', content: ''}
+		]}
+	],
 
 	/**
 	* Returns boolean indicating whether passed-in control is an input field.
@@ -226,6 +240,28 @@ module.exports = kind(
 	*/
 	disabledChangeHandler: function (oSender, oEvent) {
 		this.addRemoveClass('moon-disabled', oEvent.originator.disabled);
+	},
+
+	/**
+	* @private
+	*/
+	showValidityPopupHandler: function (oSender, oEvent) {
+		if (!this.$.validityPopup) {
+			this.createChrome(this.tools);
+			var direction = this.rtl ? 'left' : 'right';
+			this.$.validityPopup.set('direction', direction);
+			!this.$.validityPopup.floating && this.$.validityPopup.render();
+		}
+		this.$.message.set('content', oEvent.message);
+		this.waterfallDown('onRequestShowPopup', {activator: this});
+	},
+
+	/**
+	* @private
+	*/
+	hideValidityPopupHandler: function () {
+		if (!this.$.validityPopup) return;
+		this.waterfallDown('onRequestHidePopup');
 	},
 
 	// Spotlight Event handlers:


### PR DESCRIPTION
### Issue
This is new UX requirement for 2017 TV. 
moonstone input provides validator to prevent inputting invalid number.

### Fix
I added published some variables to make range from default values and to set validity.
Contextual popup is added to inputDecorator to notify invalid value. It is created dynamically.
And getPangeOffset is changed to calculate pageOffset because I set 'floating' is false to fix position with scrolling.
Plus, I added some classes to add icon using with dingbats and to remove spin buttons of the number type input.


Enyo-DCO-1.1-Signed-off-by: Sangwook Lee <sangwook1203.lee@lge.com>