### PR TITLE
PLAT-17663: Prevent reading ListAction's content

### DIFF
--- a/src/ListActions/ListActions.js
+++ b/src/ListActions/ListActions.js
@@ -226,7 +226,7 @@ var ListActions = ContextualPopupDecorator.kind({
 	*/
 	components: [
 		{name: 'activator', kind: IconButton},
-		{name: 'listActionsPopup', kind: ListActionsPopup, components: [
+		{name: 'listActionsPopup', kind: ListActionsPopup, accessibilityReadAll: false, components: [
 			{name: 'listActionsWrapper', classes: 'moon-hspacing top moon-list-actions-scroller', controlClasses: 'moon-list-actions-popup-width', onActivate: 'optionSelected'}
 		]}
 	],


### PR DESCRIPTION
Rebased #2753 on 2.6.0-dev

ListActionPopup extends contextualPopup, so alert role is set, then
TV will read all contents when ListAction popup is opened. To prevent it,
we add accessibilityReadAll:false to ListActionPopup

Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>