### PR TITLE
ENYO-3221: Removed conflicting lighter definition of @moon-gray

### DIFF
--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -3,7 +3,6 @@
 @moon-dark-gray:   #4d4d4d;
 @moon-gray:        #a6a6a6;
 @moon-light-gray:  #ededed;
-@moon-gray:        #bebebe;
 @moon-black:       #000;
 @moon-accent:      #cf0652;
 @moon-white:       #fff;

--- a/css/moonstone-variables-light.less
+++ b/css/moonstone-variables-light.less
@@ -3,7 +3,6 @@
 @moon-dark-gray: #4B4B4B;
 @moon-gray: #a6a6a6;
 @moon-light-gray: #EDEDED;
-@moon-gray: #BEBEBE;
 @moon-black: #000000;
 @moon-accent: #cf0652;
 @moon-white: #ffffff;


### PR DESCRIPTION
This was originally the result of several complex merges and conflicts, as well as new line numbers. Related hashes: 1d3f8ae610996beb1886c1ef2e6f4a58a393320b, 3444b6af9c9b9604ce5c3737b27bc759888bb3cb, 7647ddf982e9318fe51d513754cd1c7a0b059cde
Original version/value: 0f91d4b97d05cbfcc53d2d39d21a84fb8584118c

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>