### PR TITLE
ENYO-3222: Use updated cancelAnimationFrame API.

### DIFF
--- a/src/IntegerPicker/IntegerPicker.js
+++ b/src/IntegerPicker/IntegerPicker.js
@@ -585,7 +585,7 @@ module.exports = kind(
 			var count = Math.abs(newIndex - oldIndex) + 1;
 			this.updateRepeater(index, count);
 
-			if (this._rAF) animation.cancelRequestAnimationFrame(this._rAF);
+			if (this._rAF) animation.cancelAnimationFrame(this._rAF);
 			this._rAF = animation.requestAnimationFrame(function () {
 				this.scrollToIndex(oldIndex, false);
 				this._rAF = animation.requestAnimationFrame(function () {

--- a/src/NewPagingControl/NewPagingControl.js
+++ b/src/NewPagingControl/NewPagingControl.js
@@ -244,7 +244,7 @@ module.exports = kind(
 	* @private
 	*/
 	stopHoldJob: function () {
-		this.job = animation.cancelRequestAnimationFrame(this.job);
+		this.job = animation.cancelAnimationFrame(this.job);
 	},
 
 	/**

--- a/src/PagingControl/PagingControl.js
+++ b/src/PagingControl/PagingControl.js
@@ -288,7 +288,7 @@ module.exports = kind(
 	* @private
 	*/
 	stopHoldJob: function () {
-		this.job = animation.cancelRequestAnimationFrame(this.job);
+		this.job = animation.cancelAnimationFrame(this.job);
 	},
 
 	/**


### PR DESCRIPTION
### Issue
Due to the changes in https://github.com/enyojs/enyo/pull/1414, the API being used has been deprecated.

### Fix
Updated to use `cancelAnimationFrame`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>