### PR TITLE
PLAT-16501: Tooltip is added to be displayed for invalid message.

### DIFF
--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -6,6 +6,7 @@
 @moon-black:       #000;
 @moon-accent:      #cf0652;
 @moon-white:       #fff;
+@moon-red:         #ff0000;
 
 @moon-background-color:               @moon-black;
 @moon-text-color:                     @moon-gray;

--- a/css/moonstone-variables-light.less
+++ b/css/moonstone-variables-light.less
@@ -6,6 +6,7 @@
 @moon-black: #000000;
 @moon-accent: #cf0652;
 @moon-white: #ffffff;
+@moon-red: #ff0000;
 
 @moon-background-color: @moon-light-gray;
 @moon-text-color: @moon-dark-gray;

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -251,6 +251,7 @@
 // ---------------------------------------
 @moon-input-border-width: 6px;
 @moon-input-height:60px;
+@moon-invalid-text-color: @moon-red;
 
 // Pickers
 // ---------------------------------------

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -11,6 +11,10 @@ var
 	Input = require('enyo/Input');
 
 var
+	TooltipDecorator = require('../TooltipDecorator'),
+	Tooltip = require('../Tooltip');
+
+var
 	Spotlight = require('spotlight');
 
 /**
@@ -76,7 +80,43 @@ module.exports = kind(
 		* @default false
 		* @public
 		*/
-		dismissOnEnter: false
+		dismissOnEnter: false,
+
+		/**
+		* The min attribute specifies the minimum value for an [input]{@link module:enyo/Input~Input}.
+		*
+		* @type {Number}
+		* @default null
+		* @public
+		*/
+		min: null,
+
+		/**
+		* The max attribute specifies the maximum value for an [input]{@link module:enyo/Input~Input}.
+		*
+		* @type {Number}
+		* @default null
+		* @public
+		*/
+		max: null,
+
+		/**
+		* When `true`, 'input-invalid' class is added and message tooltip is shown if it exists.
+		*
+		* @type {Boolean}
+		* @default false
+		* @public
+		*/
+		invalid: false,
+
+		/**
+		* Text to be displayed as the tooltip content if invalidMessage is set not ''.
+		*
+		* @type {String}
+		* @default null
+		* @public
+		*/
+		invalidMessage: ''
 	},
 
 	/**
@@ -89,12 +129,37 @@ module.exports = kind(
 	},
 
 	/**
+	* @private
+	*/
+	components: [
+		{kind: TooltipDecorator, autoShow: false, components: [
+			{name: 'tooltip', kind: Tooltip, floating: false, position: 'below'}	// To Do : It's position has dependency with ENYO-2709.
+		]}
+	],
+
+	/**
+	* @private
+	*/
+	bindings: [
+		{from: 'invalidMessage', to: '$.tooltip.content'}
+	],
+
+	/**
 	* Used only for [dismissOnEnter]{@link module:moonstone/Input~Input#dismissOnEnter} feature;
 	* we cannot rely on `hasFocus()` in this case due to race condition.
 	*
 	* @private
 	*/
 	_bFocused: false,
+
+	/**
+	* @private
+	*/
+	create: function () {
+		Input.prototype.create.apply(this, arguments);
+		this.minChanged();
+		this.maxChanged();
+	},
 
 	/**
 	* @private
@@ -182,5 +247,28 @@ module.exports = kind(
 	*/
 	down: function () {
 		return false;
+	},
+
+	/**
+	* @private
+	*/
+	minChanged: function () {
+		this.setAttribute('min', this.min);
+	},
+
+	/**
+	* @private
+	*/
+	maxChanged: function () {
+		this.setAttribute('max', this.max);
+	},
+
+	/**
+	* @private
+	*/
+	invalidChanged: function () {
+		this.addRemoveClass('input-invalid', this.invalid);
+		this.$.tooltip.activator = this;
+		this.$.tooltip.set('showing', this.invalid && this.invalidMessage);
 	}
 });

--- a/src/Input/Input.less
+++ b/src/Input/Input.less
@@ -23,6 +23,15 @@
 	}
 }
 
+.moon-input.input-invalid {
+	color: @moon-invalid-text-color;
+}
+
+.moon-input[type=number]::-webkit-inner-spin-button,
+.moon-input[type=number]::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+}
+
 .moon-input-decorator {
 	&.spotlight {
 		color: @moon-spotlight-text-color;


### PR DESCRIPTION
### Issue
This is new UX requirement for 2017 TV. 
moonstone input set invalid-class and show tooltip with message about invalid value.

### Fix
Moonstone CSS variables is added to change text color in relation to invalid status.
Some published variables is added to set attributes for checking validity and their change handler are also added.
'invalidMessage' can be set to any strings. If it's to set to a falsy value, the tooltip is not shown.
Setting moon.Input's invalid property to true, shows tooltip and adds the invalid-class.

Enyo-DCO-1.1-Signed-off-by: Sangwook Lee <sangwook1203.lee@lge.com>