### PR TITLE
ENYO-3233: Prevent event bubbling when close button is tapped

### DIFF
--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -458,6 +458,7 @@ module.exports = kind(
 		this.$.closeButton.removeClass('pressed');
 		this.hide();
 		Spotlight.spot(this.activator);
+		return true;
 	},
 
 	/**


### PR DESCRIPTION
Issue
---
`TooltipDecorator` hides tooltip when it receives `tap` event. When close button is tapped in `ContextualPopup` that is wrapped in a `TooltipDecorator`, the `tap` event to close the `ContextualPopup` will bubble up the chain and gets handled by the `TooltipDecorator`.

Fix
---
Consume tap event on `ContextualPopup` and prevent bubbling further.

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>