### PR TITLE
PLAT-17664: Add accessibilityLabel to read breadcrumb label

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -157,6 +157,11 @@ var Breadcrumb = kind(
 	/**
 	* @private
 	*/
+	accessibilityLabel: $L('go to previous'),
+
+	/**
+	* @private
+	*/
 	handlers: {
 		ontap: 'tapHandler',
 		onSpotlightRight: 'rightHandler'


### PR DESCRIPTION
According to TV UX guideline, TV should read 'go to previous' when
BreadCrumb is spotlight focused, so set to this string using accessibilityLabel

https://jira2.lgsvl.com/browse/PLAT-17664
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>