### PR TITLE
ENYO-3163: Fix Panels breadcrumb spotlight issue

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1585,7 +1585,7 @@ module.exports = kind(
 		var end = this.toIndex,
 			start = end - this.getBreadcrumbs().length,
 			range = {start: start, end: end},
-			control, info;
+			control, info, i;
 
 		for (i=range.start; i<range.end; i++) {
 			control = this.getBreadcrumbForIndex(i);

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1413,12 +1413,13 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	getBreadcrumbPositionInfo: function (bounds, containerBounds) {
-		var right = bounds ? bounds.right : null,
-			left = bounds ? bounds.left : null,
-			panelEdge = containerBounds ? containerBounds.right : null;
-
-		return {isOffscreen: (right == null || left == null || panelEdge == null || right <= 0 || left >= panelEdge)};
+	getBreadcrumbPositionInfo: function (inBreadcrumbIndex) {
+		var to = (this.toIndex || this.toIndex === 0) ? this.toIndex : this.index;
+		return {
+			isOffscreen: this.pattern == 'activity' ? 
+				(to % 2) == Math.abs(inBreadcrumbIndex % 2) :
+				!((inBreadcrumbIndex < to) && (inBreadcrumbIndex >= (to - this.getBreadcrumbMax()) && inBreadcrumbIndex >= 0))
+		};
 	},
 
 	/**
@@ -1581,13 +1582,14 @@ module.exports = kind(
 	notifyBreadcrumbs: function (method) {
 		if (this.pattern == 'none' || !this.$.breadcrumbs) return;
 
-		var range = this.getBreadcrumbRange(),
-			containerBounds = this.$.breadcrumbs.getAbsoluteBounds(),
-			control, bounds, info, i;
+		var end = this.toIndex,
+			start = end - this.getBreadcrumbs().length,
+			range = {start: start, end: end},
+			control, info;
+
 		for (i=range.start; i<range.end; i++) {
 			control = this.getBreadcrumbForIndex(i);
-			bounds = control.getAbsoluteBounds();
-			info = this.getBreadcrumbPositionInfo(bounds, containerBounds);
+			info = this.getBreadcrumbPositionInfo(i);
 			if (control[method]) {
 				control[method](info);
 			}


### PR DESCRIPTION
### Issue
When setting the index of a Panels control (in create time) to > 1, spotlight cannot focus on breadcrumbs, until you transition to another panel.

### Fix
Previous method required the breadcrumbs and their container to be rendered to calculate if they were spottable. We can use an alternate method - since we know how many breadcrumbs there are and how many can fit on the screen at a given time, we can calculate which breadcrumbs are spottable.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>