### PR TITLE
ENYO-2959: Change ListActions to new design using ContextualPopups

### DIFF
--- a/css/moonstone-spacing.less
+++ b/css/moonstone-spacing.less
@@ -22,7 +22,7 @@
 		margin-right: 0;
 	}
 	& > :last-child,
-	& > :last-child.moon-contextual-popup-decorator :first-child  {
+	& > :last-child.moon-contextual-popup-decorator :first-child {
 		margin-right: 0;
 	}
 	.enyo-locale-right-to-left & > :last-child {

--- a/src/Header/Header.js
+++ b/src/Header/Header.js
@@ -275,9 +275,7 @@ module.exports = kind(
 	*/
 	handlers: {
 		oninput: 'handleInput',
-		onchange: 'handleChange',
-		onRequestCreateListActions: 'handleRequestCreateComponents',
-		onListActionOpenChanged: 'handleListActionOpenChanged'
+		onchange: 'handleChange'
 	},
 
 	/**
@@ -408,15 +406,6 @@ module.exports = kind(
 	*/
 	fullBleedBackgroundChanged: function () {
 		this.addRemoveClass('full-bleed', this.fullBleedBackground);
-	},
-
-	/**
-	* @private
-	*/
-	handleRequestCreateComponents: function (inSender, inEvent) {
-		this.controlParent = null;
-		this.createComponents(inEvent.components, {owner: inEvent.originator});
-		this.discoverControlParent();
 	},
 
 	/**
@@ -806,18 +795,5 @@ module.exports = kind(
 	*/
 	handleChange: function (inSender, inEvent) {
 		this.doInputHeaderChange({originalEvent: util.clone(inEvent, true)});
-	},
-
-
-	/**
-	* Enlarges listActionDrawer's height to large type's height.
-	*
-	* @private
-	*/
-	handleListActionOpenChanged: function (inSender, inEvent) {
-		if (!inEvent.open) {
-			return;
-		}
-		inEvent.originator.beforeOpenDrawer(this.standardHeight, this.get('type'));
 	}
 });

--- a/src/ListActions/ListActions.js
+++ b/src/ListActions/ListActions.js
@@ -2,39 +2,26 @@ require('moonstone');
 
 /**
 * Contains the declarations for the {@link module:moonstone/ListActions~ListActions}
-* and {@link module:moonstone/ListActions~ListActionsDrawer} kinds, and the
+* and {@link module:moonstone/ListActions~ListActionsPopup} kinds, and the
 * {@link module:moonstone/ListActions~ListActionActivationSupport} mixin.
 * @module moonstone/ListActions
 */
 
 var
-	kind = require('enyo/kind'),
 	dom = require('enyo/dom'),
-	ri = require('enyo/resolution'),
-	dispatcher = require('enyo/dispatcher'),
-	Control = require('enyo/Control'),
-	EnyoHistory = require('enyo/History'),
-	GroupItem = require('enyo/GroupItem');
+	ri = require('enyo/resolution');
 
 var
-	FittableLayout = require('layout/FittableLayout'),
-	FittableRowsLayout = FittableLayout.Rows;
-
-var
-	Spotlight = require('spotlight');
-
-var
-	$L = require('../i18n'),
-	Scroller = require('../Scroller'),
-	IconButton = require('../IconButton'),
-	HistorySupport = require('../HistorySupport');
+	ContextualPopup = require('moonstone/ContextualPopup'),
+	ContextualPopupDecorator = require('moonstone/ContextualPopupDecorator'),
+	IconButton = require('moonstone/IconButton');
 
 /**
 * An internally-used support mixin added to a {@link module:moonstone/ListActions~ListActions}
 * menu, which decorates `activate` events with the menu's `action` property.
 *
 * @mixin ListActionActivationSupport
-* @protected
+* @private
 */
 var ListActionActivationSupport = {
 
@@ -58,200 +45,100 @@ var ListActionActivationSupport = {
 	}
 };
 
-
 /**
-* Fires when the [ListActionsDrawer]{@link module:moonstone/ListActions~ListActionsDrawer} has completed any
-* setup and/or preparation work, e.g., when animating or initial setup. No event-specific
-* information is sent with this event.
-*
-* @event module:moonstone/ListActions~ListActionsDrawer#onComplete
-* @type {Object}
-* @public
-*/
-
-/**
-* {@link module:moonstone/ListActions~ListActionsDrawer} is a [control]{@link module:enyo/Control~Control} used by
+* {@link module:moonstone/ListActions~ListActionsPopup} is a
+* [control]{@link module:moonstone/ContextualPopup~ContextualPopup} used by
 * {@link module:moonstone/ListActions~ListActions} to house a menu of selectable options.
 *
-* @class ListActionsDrawer
-* @extends module:enyo/Control~Control
+* @class ListActionsPopup
+* @extends module:moonstone/ContextualPopup~ContextualPopup
 * @ui
-* @public
+* @private
 */
-var ListActionsDrawer = kind(
-	/** @lends module:moonstone/ListActions~ListActionsDrawer */ {
+var ListActionsPopup = ContextualPopup.kind(
+	/** @lends module:moonstone/ListActions~ListActionsPopup */ {
 
 	/**
 	* @private
 	*/
-	name: 'moon.ListActionsDrawer',
+	classes: 'moon-list-actions-popup below',
+
+	/**
+	* @see moonstone/ContextualPopup~ContextualPopup#spotlightModal
+	*/
+	spotlightModal: true,
+
+	/**
+	* @see moonstone/ContextualPopup~ContextualPopup#showCloseButton
+	*/
+	showCloseButton: true,
 
 	/**
 	* @private
 	*/
-	kind: Control,
-
-	/**
-	* @private
-	* @lends module:moonstone/ListActions~ListActionsDrawer.prototype
-	*/
-	published: {
-
-		/**
-		* If `true`, the drawer will be in its opened state; otherwise, it will be closed.
-		*
-		* @type {Boolean}
-		* @default false
-		* @public
-		*/
-		open: false
+	resetDirection: function () {
+		this.removeClass('right');
+		this.removeClass('left');
 	},
 
 	/**
+	* Adjust popup direction, anchor to the edge of screen if it goes over, and adjust arrow
+	* positions.
+	*
 	* @private
+	* @override
 	*/
-	handlers: {
-		onPanelOnscreen: 'hideCloseButton'  // Re-evaluate whether ListActions should be open and if the close X should show or not.
-	},
+	alterDirection: function () {
+		if (this.showing) {
+			var clientRect = this.getBoundingRect(this.node),
+				viewPortWidth = dom.getWindowWidth(),
+				offsetWidth = (clientRect.width - this.activatorOffset.width) / 2,
+				popupMargin = ri.scale(24),
+				iconButtonWidth = this.activatorOffset.width + popupMargin,
+				bounds = {top: null, left: null},
+				c;
 
-	/**
-	* @private
-	*/
-	classes: 'moon-list-actions-drawer',
+			this.resetDirection();
 
-	/**
-	* @private
-	*/
-	components: [
-		{name: 'client', kind: Control, classes: 'moon-list-actions-drawer-client moon-neutral', ontransitionend: 'handleTransitionEnd'}
-	],
+			if(this.activatorOffset.left < offsetWidth) {
+				// flip towards right-side
+				this.addClass('right');
 
-	/**
-	* @private
-	*/
-	events: {
-		onComplete: '',
-		onCustomizeCloseButton: ''
-	},
+				// adjust arrow position
+				c = Math.round((this.activatorOffset.left - popupMargin) / iconButtonWidth);
+				this.addClass('list-actions-' + (c + 1) + 'h');
 
-	/**
-	* @fires module:moonstone/ListActions~ListActionsDrawer#onComplete
-	* @private
-	*/
-	rendered: function () {
-		Control.prototype.rendered.apply(this, arguments);
-		// Temporarily disable animation
-		this.applyAnimatedMode(false);
-		// Set the state of the drawer
-		this.openChanged();
-		// Re-enable animation
-		this.applyAnimatedMode(true);
-		// Let any watchers know we've finished our preparation
-		this.doComplete({rendered: true});
-	},
+				// anchor to the far left
+				bounds.left = popupMargin;
+			} else if(viewPortWidth - this.activatorOffset.right < offsetWidth) {
+				// flip towards left-side
+				this.addClass('left');
 
-	/**
-	* @fires module:moonstone/ListActions~ListActionsDrawer#onComplete
-	* @private
-	*/
-	handleTransitionEnd: function (sender, e) {
-		if (e.originator === this.$.client) {
-			this.doComplete();
-			return true;
+				// adjust arrow position
+				c = Math.round((viewPortWidth - this.activatorOffset.right - popupMargin) / iconButtonWidth);
+				this.addClass('list-actions-' + (c + 1) + 'h');
+
+				// anchor to the far right
+				bounds.left = viewPortWidth - clientRect.width - popupMargin;
+			} else {
+				bounds.left = this.activatorOffset.left - offsetWidth;
+			}
+
+			bounds.top = this.activatorOffset.bottom;
+
+			this.setBounds(bounds);
 		}
 	},
 
 	/**
-	* We override `getBubbleTarget()` here so that events emanating from a
-	* [ListActionsDrawer]{@link module:moonstone/ListActions~ListActionsDrawer} instance will bubble to the owner
-	* of the associated [ListActions]{@link module:moonstone/ListActions~ListActions} instance, as expected. This
-	* is necessary because events normally bubble to a control's DOM parent, but we have
-	* sneakily arranged for the DOM parent of a `ListActionsDrawer` instance to be not the
-	* `ListActions` instance, but the containing [Header]{@link module:moonstone/Header~Header} instance.
+	* Prevent waterfalling 'onresize' event to avoid re-rendering {@link module:enyo/DataList~DataList}.
 	*
+	* @method
+	* @override
 	* @private
 	*/
-	getBubbleTarget: function () {
-		return this.owner;
-	},
-
-	/**
-	* @private
-	*/
-	openChanged: function () {
-		// Skip animation before render time
-		if (!this.$.client.hasNode()) { return; }
-		this.$.client.addRemoveClass('open', this.open);
-		this.doCustomizeCloseButton({properties: {showing: !this.open}});
-	},
-
-	/**
-	* @private
-	*/
-	hideCloseButton: function () {
-		// Only hide the button if we're open. Ignore everything else
-		if (this.open) this.doCustomizeCloseButton({properties: {showing: false}});
-	},
-
-	/**
-	* @private
-	*/
-	applyAnimatedMode: function (shouldAnimate) {
-		this.$.client.addRemoveClass('animated', shouldAnimate);
-	}
+	resize: function() {}
 });
-
-/**
-* Fires when the drawer open animation begins. No event-specific data is sent with this event.
-*
-* @event module:moonstone/ListActions~ListActions#onShow
-* @type {Object}
-* @public
-*/
-
-/**
-* Fires when the drawer open animation ends. No event-specific data is sent with this event.
-*
-* @event module:moonstone/ListActions~ListActions#onShown
-* @type {Object}
-* @public
-*/
-
-/**
-* Fires when the drawer close animation begins. No event-specific data is sent with this event.
-*
-* @event module:moonstone/ListActions~ListActions#onHide
-* @type {Object}
-* @public
-*/
-
-/**
-* Fires when the drawer close animation ends. No event-specific data is sent with this event.
-*
-* @event module:moonstone/ListActions~ListActions#onHidden
-* @type {Object}
-* @public
-*/
-
-/**
-* Used internally by [ListActions]{@link module:moonstone/ListActions~ListActions} to ask
-* {@link module:moonstone/Header~Header} to add fitting components to itself. Not intended for use
-* by end-developers.
-*
-* @event module:moonstone/ListActions~ListActions#onRequestCreateListActions
-* @type {Object}
-* @property {Object} components - The drawer components to be created.
-* @private
-*/
-
-/**
-* Fires when when the [open]{@link module:moonstone/ListActions~ListActions#open} state of the drawer has changed.
-*
-* @event module:moonstone/ListActions~ListActions#onListActionOpenChanged
-* @type {Object}
-* @property {Boolean} open - `true` if the drawer is open; otherwise, `false`.
-* @public
-*/
 
 /**
 * {@link module:moonstone/ListActions~ListActions} is a [control]{@link module:enyo/Control~Control} designed to live within a
@@ -263,17 +150,11 @@ var ListActionsDrawer = kind(
 * items.
 *
 * @class ListActions
-* @extends module:enyo/GroupItem~GroupItem
+* @extends module:moonstone/ContextualPopupDecorator~ContextualPopupDecorator
 * @ui
 * @public
 */
-var ListActions = module.exports = kind(
-	/** @lends module:moonstone/ListActions~ListActions.prototype */ {
-
-	/**
-	* @private
-	*/
-	name: 'moon.ListActions',
+var ListActions = ContextualPopupDecorator.kind({
 
 	/**
 	* @private
@@ -281,148 +162,72 @@ var ListActions = module.exports = kind(
 	classes: 'moon-list-actions',
 
 	/**
-	* @private
+	* If `true`, the popup will automatically close when the user selects a menu item.
+	*
+	* @type {Boolean}
+	* @default false
+	* @public
 	*/
-	kind: GroupItem,
+	autoCollapse: false,
+
+	/**
+	* A block of one or more controls to be displayed inside the list actions menu. It should
+	* typically contain a {@link module:moonstone/Divider~Divider} identifying the category and a
+	* {@link module:moonstone/Scroller~Scroller}, containing instances of {@link module:moonstone/CheckboxItem~CheckboxItem},
+	* {@link module:moonstone/ToggleItem~ToggleItem}, or {@link module:moonstone/SelectableItem~SelectableItem} for setting options for
+	* the underlying [panel]{@link module:moonstone/Panel~Panel}. Alternatively, a {@link module:moonstone/DataList~DataList}
+	* may be used for populating a data-bound list of options.
+	*
+	* More than one option group may be added to the `listActions` block, in which options
+	* are laid out horizontally.
+	*
+	* Each group should have a string value set for the `action` property, as this will
+	* be passed in all events that bubble from the `ListActions`, to allow the user to
+	* identify which category changed.
+	*
+	* @type {Object[]}
+	* @default null
+	* @public
+	*/
+	listActions: null,
+
+	/**
+	* Icon name to be used by the activator button (as in {@link module:moonstone/Icon~Icon} and
+	* {@link module:moonstone/IconButton~IconButton}).
+	*
+	* @type {String}
+	* @default ''
+	* @public
+	*/
+	icon: '',
+
+	/**
+	* Source URL for icon image.
+	*
+	* @type {String|module:enyo/resolution#selectSrc~src}
+	* @default ''
+	* @public
+	*/
+	iconSrc: '',
+
+	/**
+	* The background-color opacity of the {@link module:moonstone/ListActions~ListActions}' activator
+	* (which is a {@link module:moonstone/IconButton~IconButton}). Please see the valid values defined by
+	* {@link module:moonstone/Button~Button#backgroundOpacity}.
+	*
+	* @type {String}
+	* @default 'opaque'
+	* @public
+	*/
+	backgroundOpacity: 'opaque',
 
 	/**
 	* @private
 	*/
-	mixins : [HistorySupport],
-
-	/**
-	* @private
-	* @lends module:moonstone/ListActions~ListActions.prototype
-	*/
-	published: {
-
-		/**
-		* If `true`, the drawer is expanded, showing this item's contents.
-		*
-		* @type {Boolean}
-		* @default false
-		* @public
-		*/
-		open: false,
-
-		/**
-		* If `true`, the drawer will automatically close when the user selects a menu item.
-		*
-		* @type {Boolean}
-		* @default false
-		* @public
-		*/
-		autoCollapse: false,
-
-		/**
-		* A block of one or more controls to be displayed inside the list actions menu. By
-		* default, each top-level [ListActions]{@link module:moonstone/ListActions~ListActions} will have a
-		* [defaultKind]{@link module:enyo/Control~Control#defaultKind} of
-		* [FittableRows]{@link module:layout/FittableRows~FittableRows}, and should typically contain a
-		* {@link module:moonstone/Divider~Divider} identifying the category and a {@link module:moonstone/Scroller~Scroller} with
-		* `fit: true` set on it, containing instances of {@link module:moonstone/CheckboxItem~CheckboxItem},
-		* {@link module:moonstone/ToggleItem~ToggleItem}, or {@link module:moonstone/SelectableItem~SelectableItem} for setting options for
-		* the underlying [panel]{@link module:moonstone/Panel~Panel}. Alternatively, a {@link module:moonstone/DataList~DataList}
-		* may be used as the `fit: true` control for populating a data-bound list of options
-		* (see below for limitations on using a `moon.DataList`).
-		*
-		* More than one option group may be added to the `listActions` block, in which options
-		* are laid out horizontally by default, with the height of each `FittableRows` being
-		* constrained to the height of the parent [Header]{@link module:moonstone/Header~Header}. However, a
-		* minimum width (300px) is enforced for each group, and if there are more groups than
-		* will fit in the available horizontal space, all controls will instead be stacked
-		* vertically. In this case, an outer scroller is enabled; the outer scroller scrolls
-		* all groups vertically, and the `FittableRows` are reset to natural size based on
-		* their content, effectively disabling any scrollers contained within, to prevent
-		* nested scrolling.
-		*
-		* Note that the vertical stacking capability poses a limitation on using
-		* `moon.DataList`. Since `moon.DataList` must always be allowed to scroll, it is
-		* not suitable for use in a stacked scenario in which only one outer scroller is
-		* used. As such, it cannot be used within a `ListActions` that may need to stack
-		* vertically.
-		*
-		* Each group should have a string value set for the `action` property, as this will
-		* be passed in all events that bubble from the `ListActions`, to allow the user to
-		* identify which category changed.
-		*
-		* @type {Object[]}
-		* @default null
-		* @public
-		*/
-		listActions: null,
-
-		/**
-		* Source URL for icon image.
-		*
-		* @type {String|module:enyo/resolution#selectSrc~src}
-		* @default ''
-		* @public
-		*/
-		iconSrc: '',
-
-		/**
-		* Icon name to be used by the activator button (as in {@link module:moonstone/Icon~Icon} and
-		* {@link module:moonstone/IconButton~IconButton}).
-		*
-		* @type {String}
-		* @default ''
-		* @public
-		*/
-		icon: '',
-
-		/**
-		* By default, list action menus are 300px wide. Set this to `true` to instead have
-		* the menus be proportionally sized within the available space. Note that a minimum
-		* width of 300px is still respected; if all menus don't fit horizontally, they will
-		* be stacked vertically.
-		*
-		* @type {Boolean}
-		* @default false
-		* @public
-		*/
-		proportionalWidth: false,
-
-		/**
-		* The background-color opacity of the {@link module:moonstone/ListActions~ListActions}' activator
-		* (which is a {@link module:moonstone/IconButton~IconButton}). Please see the valid values defined by
-		* {@link module:moonstone/Button~Button#backgroundOpacity}.
-		*
-		* @type {String}
-		* @default 'opaque'
-		* @public
-		*/
-		backgroundOpacity: 'opaque'
-	},
-
-	/**
-	* @private
-	*/
-	events: {
-		onShow: '',
-		onShown: '',
-		onHide: '',
-		onHidden: '',
-		onRequestCreateListActions: '',
-		onListActionOpenChanged: ''
-	},
-
-	/**
-	* @private
-	*/
-	components:[
-		{name:'activator', kind: IconButton, classes: 'moon-list-actions-activator', ontap: 'expandContract'}
-	],
-
-	/**
-	* @private
-	*/
-	drawerComponents: [
-		{name: 'drawer', spotlightDisabled: true, kind: ListActionsDrawer, classes: 'list-actions-drawer', onComplete: 'drawerAnimationEnd', open: false, spotlight: 'container', spotlightModal:true, components: [
-			{name: 'closeButton', kind: IconButton, icon: 'arrowsmallup', classes: 'moon-popup-close moon-list-actions-close moon-neutral', ontap: 'expandContract', accessibilityLabel: $L('Close'), backgroundOpacity: 'transparent', defaultSpotlightDown:'listActions'},
-			{name: 'listActionsClientContainer', kind: Control, classes: 'enyo-fit moon-list-actions-client-container moon-neutral', components: [
-				{name: 'listActions', kind: Scroller, classes: 'enyo-fit moon-list-actions-scroller', horizontal:'hidden', vertical:'hidden', onActivate: 'optionSelected', defaultSpotlightUp:'closeButton'}
-			]}
+	components: [
+		{name: 'activator', kind: IconButton},
+		{name: 'listActionsPopup', kind: ListActionsPopup, components: [
+			{name: 'listActionsWrapper', classes: 'moon-hspacing top moon-list-actions-scroller', controlClasses: 'moon-list-actions-popup-width', onActivate: 'optionSelected'}
 		]}
 	],
 
@@ -430,7 +235,6 @@ var ListActions = module.exports = kind(
 	* @private
 	*/
 	bindings: [
-		{from: 'open', to: '$.drawer.open'},
 		{from: 'iconSrc', to: '$.activator.src'},
 		{from: 'icon', to: '$.activator.icon'},
 		{from: 'disabled', to: '$.activator.disabled', oneWay: false},
@@ -438,38 +242,12 @@ var ListActions = module.exports = kind(
 	],
 
 	/**
-	* @fires module:moonstone/ListActions~ListActions#onRequestCreateListActions
 	* @private
 	*/
-	create: function () {
-		GroupItem.prototype.create.apply(this, arguments);
-		this.doRequestCreateListActions({components: this.drawerComponents});
-		if (!this.$.drawer) {
-			throw 'moon.ListActions must be created as a child of moon.Header';
-		}
+	create: function() {
+		ContextualPopupDecorator.prototype.create.apply(this, arguments);
 		this.disabledChanged();
 		this.listActionsChanged();
-	},
-
-	/**
-	* @private
-	*/
-	rendered: function () {
-		GroupItem.prototype.rendered.apply(this, arguments);
-		if (this.open) {
-			// Perform post-open work
-			this.drawerOpened(true);
-			// Update stacking
-			this.resizeDrawer();
-		}
-	},
-
-	/**
-	* @private
-	*/
-	destroy: function () {
-		dispatcher.release(this.$.drawer);
-		GroupItem.prototype.destroy.apply(this, arguments);
 	},
 
 	/**
@@ -482,62 +260,21 @@ var ListActions = module.exports = kind(
 	/**
 	* @private
 	*/
-	listActionsChanged: function () {
-		var owner = this.hasOwnProperty('listActions') ? this.getInstanceOwner() : this;
-		this.listActions = this.listActions || [];
-		this.drawerNeedsResize = true;
-		this.renderListActionComponents(owner);
-	},
-
-	/**
-	* @private
-	*/
-	renderListActionComponents: function (owner) {
-		this.noAutoCollapse = true;
-		this.createListActionComponents(owner);
-		this.noAutoCollapse = false;
-	},
-
-	/**
-	* @private
-	*/
-	createListActionComponents: function (owner) {
-		var listAction, i;
-
-		this.listActionComponents = [];
-		this.$.listActions.destroyClientControls();
+	listActionsChanged: function() {
+		var i,
+			listAction;
 
 		for (i = 0; (listAction = this.listActions[i]); i++) {
-			this.listActionComponents.push(this.createListActionComponent(listAction, owner));
-		}
-
-		// Increase width to 100% if there is only one list action
-		if (this.proportionalWidth) {
-			this.$.drawer.addClass('proportional-width');
-			var w = 100 / this.listActionComponents.length;
-			for (i=0; i<this.listActionComponents.length; i++) {
-				this.listActionComponents[i].applyStyle('width', w + '%');
-			}
+			listAction.mixins = this.addListActionMixin(listAction);
+			this.$.listActionsWrapper.createComponent(
+				listAction, {
+					owner: this.hasOwnProperty('listActions') ? this.getInstanceOwner() : this
+				});
 		}
 
 		if (this.hasNode()) {
-			this.$.listActions.render();
+			this.$.listActionsWrapper.render();
 		}
-	},
-
-	/**
-	* Creates a new list action component based on `listAction`.
-	*
-	* @private
-	*/
-	createListActionComponent: function (listAction, owner) {
-		var listActionComponent;
-
-		listAction.mixins = this.addListActionMixin(listAction);
-		listActionComponent = this.$.listActions.createComponent(listAction, {owner: owner, layoutKind: FittableRowsLayout});
-		listActionComponent.addClass('moon-list-actions-menu');
-
-		return listActionComponent;
 	},
 
 	/**
@@ -555,267 +292,33 @@ var ListActions = module.exports = kind(
 	},
 
 	/**
-	* Toggles value of `this.open`.
-	*
 	* @private
 	*/
-	expandContract: function (sender, e) {
-		if (this.disabled) {
-			return true;
-		}
-		var open = !this.getOpen();
-		if (open) {
-			this.doShow();
-		} else {
-			this.doHide();
-		}
-		this.setOpen(open);
-	},
-
-	/**
-	* @private
-	*/
-	beforeOpenDrawer: function (standardHeight, type) {
-		this.standardHeight = standardHeight;
-	},
-
-	//TODO: Remove the onListActionOpenChanged event. It will be deprecated in favor of the onShow/onHide events
-	// once we communicate to SmartShare (the only app we could find that's handling this event).
-	/**
-	* @fires module:moonstone/ListActions~ListActions#onListActionOpenChanged
-	* @private
-	*/
-	openChanged: function () {
-		this.$.drawer.set('spotlightDisabled', !this.getOpen());
-		this.setActive(this.getOpen());
-		this.doListActionOpenChanged({open: this.open});
-
-		if (this.allowBackKey) {
-			if (this.open) this.pushBackHistory();
-			else if (!EnyoHistory.isProcessing()) EnyoHistory.drop();
-		}
-
-		// If opened, show drawer and resize it if needed
-		if (this.open) {
-			if (this.drawerNeedsResize) {
-				this.resizeDrawer();
-				this.drawerNeedsResize = false;
-			}
-			// Capture onSpotlightFocus happening outside the drawer, so that we can prevent focus
-			// from landing in the header beneath the drawer
-			dispatcher.capture(this.$.drawer, {onSpotlightFocus: 'capturedSpotlightFocus'}, this);
-		} else {
-			dispatcher.release(this.$.drawer);
+	optionSelected: function() {
+		if (this.autoCollapse && this.$.listActionsPopup.getAbsoluteShowing()) {
+			this.startJob('hidePopupJob', function() {
+				this.$.listActionsPopup.hide();
+			}, 300);
 		}
 	},
 
 	/**
-	* @fires module:moonstone/TooltipDecorator~TooltipDecorator#onRequestMuteTooltip
-	* @fires module:moonstone/TooltipDecorator~TooltipDecorator#onRequestUnmuteTooltip
+	* @override
 	* @private
 	*/
-	drawerAnimationEnd: function (sender, event) {
-		var rendered = event && event.rendered;
-
-		//on closed, hide drawer and spot _this.$.activator_
-		if (!this.getOpen()) {
-			this.drawerClosed(rendered);
-		}
-		//on open, move top and spot _this.$.closeButton_
-		else {
-			this.drawerOpened(rendered);
-		}
-		return true;
-	},
-
-	/**
-	* @private
-	*/
-	drawerClosed: function (rendered) {
-		this.bubble('onRequestUnmuteTooltip');
-		if (this.generated && !rendered) {
-			Spotlight.spot(this.$.activator);
-		}
-
-		if (!rendered) this.doHidden();
-	},
-
-	/**
-	* @private
-	*/
-	drawerOpened: function (rendered) {
-		if (this.resetScroller) {
-			this.$.listActions.scrollTo(0, 0);
-			this.resetScroller = false;
-		}
-		if (this.generated && !rendered) {
-			Spotlight.spot(this.$.closeButton);
-		}
+	popupShown: function() {
+		ContextualPopupDecorator.prototype.popupShown.apply(this,arguments);
 		this.bubble('onRequestMuteTooltip');
-
-		this.doShown();
 	},
 
 	/**
+	* @override
 	* @private
 	*/
-	updateStacking: function () {
-		if (this.$.drawer.hasNode()) {
-			this.set('stacked', this.shouldStack());
-		}
-	},
-
-	/**
-	* @private
-	*/
-	shouldStack: function () {
-		var i, optionGroup,
-		    nVisibleActions = 0;
-
-		for (i = 0; (optionGroup = this.listActionComponents[i]); i++) {
-			if (optionGroup.showing) {
-				nVisibleActions++;
-			}
-		}
-
-		// Assumption: min-width of all listActionsComponents set to 300px in CSS
-		return this.$.listActions.getBounds().width < (ri.scale(300) * nVisibleActions);
-	},
-
-	/**
-	* @private
-	*/
-	stackedChanged: function () {
-		if (this.stacked) {
-			this.$.drawer.addClass('stacked');
-			this.stackMeUp();
-			// When stacked, always have vertical scroller
-			this.$.listActions.setVertical('scroll');
-		}
-		else {
-			this.$.drawer.removeClass('stacked');
-			this.unStackMeUp();
-			this.$.listActions.setVertical('hidden');
-		}
-
-		this.resetScroller = true;
-		this.$.listActions.resize();
-	},
-
-	/**
-	* @private
-	*/
-	stackMeUp: function () {
-		var optionGroup, i;
-
-		if (this.standardHeight) {
-			this.$.drawer.applyStyle('height', dom.unit( ri.scale(this.standardHeight), 'rem'));
-		}
-
-		for (i = 0; (optionGroup = this.listActionComponents[i]); i++) {
-			// Stacked contols get natural height (which prevents scrolling), such that they stack
-			// within outer scroller which is allowed to scroll all controls; this is a problem for
-			// DataLists, which require an explicit height, making them unsuitable for use in
-			// stacked ListActions
-			optionGroup.applyStyle('height', 'none');
-		}
-	},
-
-	/**
-	* @private
-	*/
-	unStackMeUp: function () {
-		var containerHeight, optionGroup, i;
-		if (this.standardHeight) {
-			this.$.drawer.applyStyle('height', dom.unit( ri.scale(this.standardHeight), 'rem'));
-		}
-		containerHeight = this.getContainerBounds().height;
-
-		for (i = 0; (optionGroup = this.listActionComponents[i]); i++) {
-			optionGroup.applyStyle('height', dom.unit(containerHeight, 'rem'));
-		}
-	},
-
-	/**
-	* @private
-	*/
-	handleResize: function () {
-		this.resetCachedValues();
-
-		// If drawer is collapsed, resize it the next time it is opened
-		if (this.getOpen()) {
-			this.resizeDrawer();
-		} else {
-			this.drawerNeedsResize = true;
-		}
-	},
-
-	/**
-	* @private
-	*/
-	resizeDrawer: function () {
-		this.updateStacking();
-	},
-
-	/**
-	* @private
-	*/
-	optionSelected: function (sender, e) {
-		this.startJob('expandContractJob', 'expandContractJob', 300);
-	},
-
-	expandContractJob: function (sender, e) {
-		if (this.getOpen() && this.autoCollapse && !this.noAutoCollapse) {
-			this.expandContract();
-		}
-	},
-
-	/**
-	* @private
-	*/
-	getContainerBounds: function () {
-		this.containerBounds = this.containerBounds || this.$.listActions.getBounds();
-		return this.containerBounds;
-	},
-
-	/**
-	* @private
-	*/
-	resetCachedValues: function () {
-		this.headerBounds = null;
-		this.clientBounds = null;
-		this.containerBounds = null;
-	},
-
-	/**
-	* @private
-	*/
-	capturedSpotlightFocus: function (sender, e) {
-		// We need to prevent header children below the drawer from being focused
-		if (e.originator.isDescendantOf(this.$.drawer.parent) &&
-			!e.originator.isDescendantOf(this.$.drawer)) {
-			Spotlight.spot(this.$.drawer);
-			return true;
-		}
-	},
-
-	/**
-	* @private
-	*/
-	backKeyHandler: function () {
-		if (this.open) {
-			this.setOpen(false);
-		}
-		return true;
+	popupHidden: function() {
+		ContextualPopupDecorator.prototype.popupHidden.apply(this,arguments);
+		this.bubble('onRequestUnmuteTooltip');
 	}
 });
 
-/**
-* The ListActionActivationSupport mixin
-*/
-ListActions.ListActionActivationSupport = ListActionActivationSupport;
-
-/**
-* The {@link module:moonstone/ListActions~ListActionsDrawer} kind
-*/
-ListActions.ListActionsDrawer = ListActionsDrawer;
+module.exports = ListActions;

--- a/src/ListActions/ListActions.less
+++ b/src/ListActions/ListActions.less
@@ -1,115 +1,38 @@
 /* List Actions */
 .moon-list-actions {
-	position:relative;
-	display:inline-block;
-	overflow:visible;
-
 	.moon-icon-button {
-		margin:0;
+		margin: 0;
 	}
 }
-.list-actions-drawer {
-	position: absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
-}
-.moon-header .list-actions-drawer {
-	top: -@moon-header-border-top-width;
-	bottom: -@moon-header-border-bottom-width;
-}
 
-/* Close button */
-.moon-icon-button.moon-list-actions-close {
-	position: absolute;
-	right: @moon-spotlight-outset;
-	top: @moon-spotlight-outset;
-	z-index: 2;
-}
-.enyo-locale-right-to-left .moon-icon-button.moon-list-actions-close {
-	right: auto;
-	left: @moon-spotlight-outset;
-}
-
-/* Scroller */
-.moon-list-actions-scroller {
-	margin: 18px;
-	margin-right: @moon-icon-button-small-size + 18px;
-	padding: 0px;
-	z-index: 1;
-}
-.enyo-locale-right-to-left .moon-list-actions-scroller {
-	margin-right: 12px;
-	margin-left: @moon-icon-button-small-size + 18px;
-}
-
-/* Action menu */
-.moon-list-actions-menu {
-	display: inline-block;
-	vertical-align: top;
-	width: 300px;		/* Do not change - used in JS */
-	min-width: 300px;	/* Do not change - used in JS */
-	float: right;
-	box-sizing: border-box;
-}
-.enyo-locale-right-to-left .moon-list-actions-menu {
-	float: left;
-}
-
-.moon-list-actions-drawer.proportional-width.stacked .moon-list-actions-menu {
-	width: 100% !important;
-}
-.moon-list-actions-drawer.stacked .moon-list-actions-menu {
-	margin-bottom: 18px;
-	clear: both;
-}
-.moon-list-actions-menu .enyo-scroller {
-	max-width: 100%;
-}
-
-/* Drawer */
-.moon-list-actions-drawer {
-	overflow: hidden;
-	z-index: 50;
-	pointer-events: none;
-	* {
-		pointer-events: auto;
+.moon-list-actions-popup {
+	& .moon-list-actions-popup-width {
+		width: 408px;
 	}
 
-	&.stacked .moon-list-actions-menu {
-		display: block;
+	& .moon-list-actions-scroller {
+		.enyo-scroller,
+		.enyo-data-list {
+			height: 300px;
+		}
 	}
-}
-.moon-list-actions-drawer-client {
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	-webkit-transform: translateZ(0) translateY(100%);
-	transform: translateZ(0) translateY(100%);
 
-	&.open {
-		-webkit-transform: translateZ(0) translateY(0);
-		tranform: translateZ(0) translateY(0);
+	.list-actions-hunits(@property, @n) {
+		&:before,
+		&:after {
+			@{property}: (@moon-icon-button-small-size * (@n - 1)) + (@moon-icon-button-small-size * @n) / 2 - @moon-icon-margin * @n / 2;
+		}
 	}
-	&.animated {
-		-webkit-transition: -webkit-transform .225s cubic-bezier(0.25, 0.1, 0.25, 1);
-		transition: transform .225s cubic-bezier(0.25, 0.1, 0.25, 1);
-	}
-}
-.moon-medium-header .moon-list-actions-drawer-client,
-.moon-small-header .moon-list-actions-drawer-client {
-	-webkit-transform: translateZ(0) translateY(-100%);
-	transform: translateZ(0) translateY(-100%);
 
-	&.open {
-		-webkit-transform: translateZ(0) translateY(0);
-		transform: translateZ(0) translateY(0);
+	.generate-columns(@n, @i: 1) when (@i =< @n) {
+		&.left.list-actions-@{i}h {
+			.list-actions-hunits(right, @i);
+		}
+		&.right.list-actions-@{i}h {
+			.list-actions-hunits(left, @i);
+		}
+		.generate-columns(@n, (@i + 1));
 	}
-}
-.moon-list-actions.stacked .enyo-fittable-rows-layout > * {
-	height: auto !important;
-}
-.moon-panels .moon-header .moon-list-actions-drawer {
-	pointer-events: none;
+
+	.generate-columns(5);
 }


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Remove ListActionDrawer related handlers from Header

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Remove extra margins added to decorators in moon-hspacing

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

Prevent tooltips to appear when popup is shown

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

Apply FittableRowsLayout to listActions block

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Remove FittableLayout and fix defaults for ListActionPopup

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Fix margins for list action icon buttons with tooltip decorator and RTL cases

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Fix CSS class name

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Add more specificity to decorators inside moon-hspacing to get rid of margins

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Update documents and refactor less file

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Fix wrong reference to ContextualPopup documentation

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Put back autoCollapse option

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Fix problems of selected item closing popup instantly

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Remove actionWidthClasses and cleanup less structure

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

ENYO-2959: Set showCloseButton property to true
Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>

Simplify LESS and respect hspacing margin instead of icon buttons'

Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>