### PR TITLE
PLAT-16501: Adding input validation.

### DIFF
--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -6,6 +6,7 @@
 @moon-black:       #000;
 @moon-accent:      #cf0652;
 @moon-white:       #fff;
+@moon-red:         #ff0000;
 
 @moon-background-color:               @moon-black;
 @moon-text-color:                     @moon-gray;

--- a/css/moonstone-variables-light.less
+++ b/css/moonstone-variables-light.less
@@ -6,6 +6,7 @@
 @moon-black: #000000;
 @moon-accent: #cf0652;
 @moon-white: #ffffff;
+@moon-red: #ff0000;
 
 @moon-background-color: @moon-light-gray;
 @moon-text-color: @moon-dark-gray;

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -184,6 +184,8 @@
 
 @accordion-sub-menu-line-height: 1.7em;
 
+@moon-invalid-text-color: @moon-red;
+
 // Popup
 // ---------------------------------------
 @moon-popup-padding: 39px;

--- a/src/Input/Input.less
+++ b/src/Input/Input.less
@@ -23,9 +23,18 @@
 	}
 }
 
+.moon-input[type=number]::-webkit-inner-spin-button,
+.moon-input[type=number]::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+}
+
 .moon-input-decorator {
 	&.spotlight {
 		color: @moon-spotlight-text-color;
+	}
+
+	&.moon-invalid .moon-input {
+		color: @moon-invalid-text-color;
 	}
 
 	.moon-focused .moon-input {

--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -16,7 +16,8 @@ var
 	$L = require('../i18n'),
 	Input = require('../Input'),
 	RichText = require('../RichText'),
-	TextArea = require('../TextArea');
+	TextArea = require('../TextArea'),
+	Tooltip = require('../Tooltip');
 
 /**
 * {@link module:moonstone/InputDecorator~InputDecorator} is a control that provides input styling. Any controls
@@ -76,6 +77,25 @@ module.exports = kind(
 	kind: ToolDecorator,
 
 	/**
+	* When `true`, the message tooltip is shown if it exists.
+	*
+	* @type {Boolean}
+	* @default false
+	* @public
+	*/
+	invalid: false,
+
+	/**
+	* The tooltip text to be displayed when the contents of the input are invalid. If this value is
+	* falsy, the tooltip will not be shown.
+	*
+	* @type {String}
+	* @default ''
+	* @public
+	*/
+	invalidMessage: '',
+
+	/**
 	* @private
 	*/
 	tag: 'label',
@@ -105,6 +125,20 @@ module.exports = kind(
 		onSpotlightUp       : 'spotlightUpHandler',
 		onSpotlightDown     : 'spotlightDownHandler'
 	},
+
+	/**
+	* @private
+	*/
+	tools: [
+		{name: 'tooltip', kind: Tooltip, floating: false, position: 'right top'}
+	],
+
+	/**
+	* @private
+	*/
+	observers: [
+		{path: ['invalid', 'invalidMessage'], method: 'updateValidity'}
+	],
 
 	/**
 	* @private
@@ -157,22 +191,26 @@ module.exports = kind(
 		if (this._oInputControl instanceof TextArea || this._oInputControl instanceof RichText) {
 			this.addClass('moon-divider-text moon-textarea-decorator');
 		}
+
+		this.updateValidity();
 	},
 
 	/**
 	* @private
 	*/
 	createComponent: function () {
-		ToolDecorator.prototype.createComponent.apply(this, arguments);
+		var ret = ToolDecorator.prototype.createComponent.apply(this, arguments);
 		this._oInputControl = this._findInputControl();
+		return ret;
 	},
 
 	/**
 	* @private
 	*/
 	createComponents: function () {
-		ToolDecorator.prototype.createComponents.apply(this, arguments);
+		var ret = ToolDecorator.prototype.createComponents.apply(this, arguments);
 		this._oInputControl = this._findInputControl();
+		return ret;
 	},
 
 	/**
@@ -324,6 +362,33 @@ module.exports = kind(
 				this.blur();
 				oInput.blur();
 			}
+		}
+	},
+
+	// Change handlers
+
+	/**
+	* @private
+	*/
+	updateValidity: function () {
+		var comps, length, i;
+		// we want the ability to add the 'moon-invalid' class even if there is no invalid message
+		this.addRemoveClass('moon-invalid', this.invalid);
+		if (this.invalid && this.invalidMessage) {
+			if (!this.$.tooltip) { // lazy creation of tooltip
+				comps = this.createComponents(this.tools);
+				if (this.hasNode()) {
+					// rendering only the created tools, to prevent loss of focus on the input
+					for (i = 0, length = comps.length; i < length; i++) {
+						comps[i].render();
+					}
+				}
+				this.$.tooltip.activator = this;
+			}
+			this.$.tooltip.set('content', this.invalidMessage);
+			this.$.tooltip.set('showing', true);
+		} else if (this.$.tooltip) {
+			this.$.tooltip.set('showing', false);
 		}
 	},
 

--- a/src/InputDecorator/InputDecorator.less
+++ b/src/InputDecorator/InputDecorator.less
@@ -23,6 +23,7 @@
 
 .moon-input-decorator,
 .moon-textarea-decorator {
+	position: relative;
 	&.moon-disabled {
 		opacity: @moon-disabled-opacity;
 	}

--- a/src/TextArea/TextArea.less
+++ b/src/TextArea/TextArea.less
@@ -41,6 +41,12 @@
 	.moon-disabled .moon-richtext {
 		cursor: default;
 	}
+
+	&.moon-invalid {
+		.moon-textarea, .moon-richtext {
+			color: @moon-invalid-text-color;
+		}
+	}
 }
 
 .enyo-locale-right-to-left .moon-textarea {


### PR DESCRIPTION
Adding an input validation messaging feature, which gives apps control over whether or not the "invalid" message appears via a tooltip. It seemed to make sense to effectively have `InputDecorator` own this functionality, as the "invalid" message tooltip would be decorating the input. The only APIs added to `Input` control the `min` and `max` properties, as those are input-specific, while the APIs added to `InputDecorator` control validity state and messaging. Additionally, because it would be heavy-handed to pre-create the tooltip for all `InputDecorator`s, we lazily create the tooltip. Lastly, had to make a tweak to the positioning of `InputDecorator` so that the tooltip can be properly positioned.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>