### PR TITLE
ENYO-3093: Check absolute showing on dragfinish to avoid invalid bounds

### DIFF
--- a/src/VideoTransportSlider/VideoTransportSlider.js
+++ b/src/VideoTransportSlider/VideoTransportSlider.js
@@ -832,20 +832,22 @@ module.exports = kind(
 		if (this.disabled) {
 			return;
 		}
-		var v = this.calcKnobPosition(e);
-		v = this.transformToVideo(v);
-		var z = this.elasticTo;
-		if (this.constrainToBgProgress === true) {
-			z = (this.increment) ? this.calcConstrainedIncrement(z) : z;
-			this.animateTo(this.elasticFrom, z);
-			v = z;
-		} else {
-			v = (this.increment) ? this.calcIncrement(v) : v;
-			this._setValue(v);
-		}
 		e.preventTap();
-		// this.hideKnobStatus();
-		this.doSeekFinish({value: v});
+		if (this.getAbsoluteShowing()) {
+			var v = this.calcKnobPosition(e);
+			v = this.transformToVideo(v);
+			var z = this.elasticTo;
+			if (this.constrainToBgProgress === true) {
+				z = (this.increment) ? this.calcConstrainedIncrement(z) : z;
+				this.animateTo(this.elasticFrom, z);
+				v = z;
+			} else {
+				v = (this.increment) ? this.calcIncrement(v) : v;
+				this._setValue(v);
+			}
+			// this.hideKnobStatus();
+			this.doSeekFinish({value: v});
+		}
 		Spotlight.unfreeze();
 
 		this.$.knob.removeClass('active');

--- a/src/VideoTransportSlider/VideoTransportSlider.js
+++ b/src/VideoTransportSlider/VideoTransportSlider.js
@@ -8,6 +8,7 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	dom = require('enyo/dom'),
+	gesture = require('enyo/gesture'),
 	ri = require('enyo/resolution'),
 	Control = require('enyo/Control'),
 	Popup = require('enyo/Popup');
@@ -450,7 +451,7 @@ module.exports = kind(
 	* @private
 	*/
 	spotBlur: function () {
-		this.cleanUpFocus();
+		this.cleanUpHold();
 		//fires enyo.VideoTransportSlider#onLeaveTapArea
 		this.doLeaveTapArea();
 	},
@@ -458,7 +459,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	cleanUpFocus: function () {
+	cleanUpHold: function () {
 		this.set('_enterEnable', false);
 		this.selected = false;
 		this.removeClass('visible');
@@ -855,7 +856,8 @@ module.exports = kind(
 			// this.hideKnobStatus();
 			this.doSeekFinish({value: v});
 		} else {
-			this.cleanUpFocus();
+			this.cleanUpHold();
+			this.removeClass('pressed');
 		}
 		Spotlight.unfreeze();
 

--- a/src/VideoTransportSlider/VideoTransportSlider.js
+++ b/src/VideoTransportSlider/VideoTransportSlider.js
@@ -8,7 +8,6 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	dom = require('enyo/dom'),
-	gesture = require('enyo/gesture'),
 	ri = require('enyo/resolution'),
 	Control = require('enyo/Control'),
 	Popup = require('enyo/Popup');

--- a/src/VideoTransportSlider/VideoTransportSlider.js
+++ b/src/VideoTransportSlider/VideoTransportSlider.js
@@ -450,12 +450,19 @@ module.exports = kind(
 	* @private
 	*/
 	spotBlur: function () {
+		this.cleanUpFocus();
+		//fires enyo.VideoTransportSlider#onLeaveTapArea
+		this.doLeaveTapArea();
+	},
+
+	/**
+	* @private
+	*/
+	cleanUpFocus: function () {
 		this.set('_enterEnable', false);
 		this.selected = false;
 		this.removeClass('visible');
 		this.endPreview();
-		//fires enyo.VideoTransportSlider#onLeaveTapArea
-		this.doLeaveTapArea();
 	},
 
 	/**
@@ -847,6 +854,8 @@ module.exports = kind(
 			}
 			// this.hideKnobStatus();
 			this.doSeekFinish({value: v});
+		} else {
+			this.cleanUpFocus();
 		}
 		Spotlight.unfreeze();
 


### PR DESCRIPTION
Issue:
When drag and hold video transport slider and wait for timeout,
slider hide itself and dragfinish handler get client bounds as 0.
This leads to set Infinity value on slider.

Fix:
Add check of getAbsoluteBounds before change value of slider on
dragfinish handler.

enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
