### PR TITLE
ENYO-3244: Use generic setters and enhance guards.

### DIFF
--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -641,8 +641,8 @@ module.exports = kind(
 			content = this.getPopupContent();
 			this._popupContent = this.get('uppercase') ? util.toUpperCase(content) : content;
 			// != null allows 0 but avoids undefined and null
-			if (this._popupContent != null) {
-				this.$.popupLabel.setContent(this._popupContent);
+			if (this._popupContent != null && this._popupContent !== '') {
+				this.$.popupLabel.set('content', this._popupContent);
 			}
 		}
 	},
@@ -672,7 +672,9 @@ module.exports = kind(
 		var label;
 		if (this.popup) {
 			label = this._popupContent || this.calcPopupLabel(val);
-			this.$.popupLabel.setContent(label);
+			if (label != null && label !== '') {
+				this.$.popupLabel.set('content', label);
+			}
 		}
 	},
 


### PR DESCRIPTION
### Issue
When changing from a falsy value to another falsy value, the deprecated `setContent` was using a standard equality check that prevented the content from updated (i.e. from the empty string `''` to `0`).

### Fix
We utilize the generic setter, which will update the content in these cases. Also, in `popupContentChanged`, we are guarding against setting a `null` or `undefined` value for the popup content. We update this guard to prevent setting of empty string content, and have also added this guard to `updatePopupLabel` for consistency.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>