### PR TITLE
ENYO-3243: Allow for popup value updating during knob dragging, fixing some latent bugs.

### DIFF
--- a/src/ProgressBar/ProgressBar.js
+++ b/src/ProgressBar/ProgressBar.js
@@ -381,7 +381,7 @@ module.exports = kind(
 	* @private
 	*/
 	popupSideChanged: function () {
-		this.updatePopup();
+		this.updatePopup(this.progress);
 	},
 
 	/**
@@ -424,7 +424,7 @@ module.exports = kind(
 	* @private
 	*/
 	showPercentageChanged: function () {
-		this.updatePopup(this.value);
+		this.updatePopup(this.progress);
 	},
 
 	/**
@@ -515,7 +515,7 @@ module.exports = kind(
 		if (this.popup) {
 			usePercentage = this.showPercentage && this.popupContent === null;
 			percent = this.calcPercent(val);
-			popupLabel = usePercentage ? percent : this.progress;
+			popupLabel = usePercentage ? percent : val;
 			flip = (this.get('orientation') == 'vertical') ? (this.get('popupSide') == 'left') : percent > 50;
 
 			this.updatePopupPosition(percent);

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -561,6 +561,22 @@ module.exports = kind(
 	}),
 
 	/**
+	* @override
+	* @private
+	*/
+	showPercentageChanged: function () {
+		this.updatePopup(this.value);
+	},
+
+	/**
+	* @override
+	* @private
+	*/
+	popupSideChanged: function () {
+		this.updatePopup(this.value);
+	},
+
+	/**
 	* @private
 	*/
 	valueChanged: function (was, is) {


### PR DESCRIPTION
### Issue
When `lockBar` is set to `false`, dragging the knob does not result in updated popup values. Additionally, there were some latent bugs, such as setting the `showPercentage` property resulting in non-sensical popup value, and similarly when setting the `popupSide` property. A lot of this stems from a mismatch between `ProgressBar` and `Slider`, as the former relies on the value of `progress`, while the latter relies on the `value` property. 

### Fix
Instead of using `this.progress` when updating the popup, we now use the passed-in value. I didn't see any issues with this, as the value passed from `updateValues` is already clamped, and the calls to `updatePopup` in other instances are either a result of user interaction, which would pass valid values, or programmatic calls that are just passing along the current value or progress. This was also necessary to resolve the non-sensical popup values. For the issue with changing the `showPercentage` property, we actually pass a value to `updatePopup` that is either the value of progress for `ProgressBar`, or the `value` property for `Slider` via an overridden `showPercentageChanged` method. For the `popupSide` property, we do something similar with the `popupSideChanged` method.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>