### PR TITLE
ENYO-3239: set close button's spotlight to false when panel is changed

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1295,7 +1295,7 @@ module.exports = kind(
 		// Turn on the close-x so it's ready for the next panel; if hasCloseButton is true
 		// and remove spottability of close button during transitions.
 		if (this.$.appClose) {
-			if (willAnimate) this.$.appClose.customizeCloseButton({'spotlight': false});
+			if (this.hasNode()) this.$.appClose.customizeCloseButton({'spotlight': false});
 			this.$.appClose.set('showing', this.hasCloseButton);
 		}
 		this.notifyPanels('initPanel');


### PR DESCRIPTION
If panels's animate is false and arranger is cardArranger, close button
is always spottable, then close button is spotlight focused when panel is
changed, so TV reads 'exit app' + panle title + focused item.

https://jira2.lgsvl.com/browse/ENYO-3239
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>