### PR TITLE
ENYO-3236: set accessibilityHint to null when slider is blur

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -990,7 +990,9 @@ module.exports = kind(
 				this.set('accessibilityRole', 'alert');
 				this.set('accessibilityLive', 'off');
 				this.set('accessibilityHint', hint);
-			} 
+			} else {
+				this.resetAccessibilityProperties();
+			}
 		}},
 		// moonstone/ProgressBar observes accessibilityValueText and the popup label so this kind
 		// need only observe its unique properties for updating aria-valuetext


### PR DESCRIPTION
slider's hint message is set whenever user selects it, but message is not
initialized when slider is blured, so TV read hint message instead of
value when this slider is spotlight focused again.

https://jira2.lgsvl.com/browse/ENYO-3236
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>

Change-Id: I51dd31e366bcc9e5a9f48c908253d03fa6c4bfb5