### PR TITLE
Fixes ENYO-3238 send the onPanelsHidden event synchronously

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1183,7 +1183,7 @@ module.exports = kind(
 			this.set('isHandleFocused', false);
 			if (!Spotlight.getPointerMode()) {
 				if (!this.showing) {
-					this.panelsHiddenAsync();
+					this.sendPanelsHiddenSignal();
 				}
 			}
 		}
@@ -1196,8 +1196,8 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	panelsHiddenAsync: function () {
-		util.asyncMethod(Signals, 'send', 'onPanelsHidden', {panels: this});
+	sendPanelsHiddenSignal: function () {
+		Signals.send('onPanelsHidden', {panels: this});
 	},
 
 	/**
@@ -1749,7 +1749,7 @@ module.exports = kind(
 		}
 		this.$.showHideHandle.removeClass('right');
 		this.applyHideAnimation();
-		this.panelsHiddenAsync();
+		this.sendPanelsHiddenSignal();
 	},
 
 	/**


### PR DESCRIPTION
Reverts some async logic from 8f3f98a3, 688b9e02, and fb1d836e which
is no longer necessary. The original dual-spotlight issues no longer
appear (for reasons unknown).

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)