### PR TITLE
ENYO-3093: Fix-up slider knob issues

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -358,6 +358,7 @@
 @moon-video-player-side-padding:                   72px;
 @moon-video-player-transport-slider-knob-size:     48px;
 @moon-video-player-transport-slider-height:        84px;
+@moon-video-player-transport-slider-tap-area:      81px;
 @moon-icon-playpause-font-size:                    216px;
 @moon-icon-main-control-font-size:                 192px;
 @moon-icon-arrowextendshrink-font-size:            108px;

--- a/src/VideoTransportSlider/VideoTransportSlider.less
+++ b/src/VideoTransportSlider/VideoTransportSlider.less
@@ -23,7 +23,6 @@
 		border-top-left-radius: 0;
 		border-top-right-radius: 0;
 		background-color: #fff;
-		pointer-events: none;
 		display: none;
 		-webkit-transform-origin: top;
 		transform-origin: top;
@@ -36,16 +35,26 @@
 			-webkit-transition: -webkit-transform @activate-transition-function 0.2s, left @slide-transition-function 0.2s;
 			transition:                 transform @activate-transition-function 0.2s, left @slide-transition-function 0.2s;
 		}
+
+		.moon-taparea( -(@moon-video-player-transport-slider-knob-size) ); // The end result of this should be a knob taparea that's the same height as the slider's tap area
+		// This allows the tap area to extend past the edge of the screen, for when the cursor moves
+		// past the end of the slider, and into the little gap that separates the edge of the
+		// normally square tap area, to the edge of the screen. This code widens the taparea so
+		// there's no gap, and the knob still receives the click event.
+		&::before {
+			left: (-(@moon-video-player-side-padding * 2));
+			right: (-(@moon-video-player-side-padding * 2));
+		}
 	}
 	&.visible {
 		.knob {
 			display: block;
 		}
-		&.pressed {
-			.knob {
-				-webkit-transform: translateZ(0) translateX(-50%) scale(0.75);
-				transform:         translateZ(0) translateX(-50%) scale(0.75);
-			}
+	}
+	&.pressed {
+		.knob {
+			-webkit-transform: translateZ(0) translateX(-50%) scale(0.75);
+			transform:         translateZ(0) translateX(-50%) scale(0.75);
 		}
 	}
 
@@ -135,9 +144,13 @@
 		color: @moon-indicator-text-color;	//#ffffff, @moon-white
 	}
 
-	// Disable the slider taparea since video slider is big enough for tapping on its own
-	&:before {
-		content: none;
+	// Reassign video-player specific sizing to the slider's tap-area
+	&::before {
+		top: (@moon-video-player-transport-slider-height / 2) - (@moon-video-player-transport-slider-tap-area / 2);
+		right: -@moon-video-player-side-padding;
+		bottom: auto;
+		left: -@moon-video-player-side-padding;
+		height: @moon-video-player-transport-slider-tap-area;
 	}
 }
 


### PR DESCRIPTION
### Issue
There are myriad issues with the slider knob, including thrown exceptions if pressing and holding or pressing and dragging the knob when the controls disappear, and unnecessary handling of an `Infinity` time value. Additionally, the pressed state is not always cleaned-up.

### Fix
To fix the pressed state issues, we have effectively cherry-picked the changes from https://github.com/enyojs/moonstone-extra/pull/191. To fix some of the other issues, such as the progress being set to the end, after dragging and holding with the controls hiding, we now "complete" any in-progress drags when the controls are hidden. This prevents any undesired changing of the progress while the controls are hidden, and resolves the edge case with the `Infinity` time value. We have also fixed the setting of an `Infinity` time value at a lower level via https://github.com/enyojs/enyo/pull/1428 for added safety.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>