### PR TITLE
ENYO-3238: Prevent handle readout when sender is appCloseButton

### DIFF
--- a/src/ApplicationCloseButton/ApplicationCloseButton.less
+++ b/src/ApplicationCloseButton/ApplicationCloseButton.less
@@ -21,4 +21,8 @@
 		left: (@moon-spotlight-outset * 2);
 		right: auto;
 	}
+
+	&.hidden {
+		display: none;
+	}
 }

--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1720,7 +1720,7 @@ module.exports = kind(
 			this.$.backgroundScrim.addRemoveClass('visible', this.showing);
 		}
 		if (this.useHandle === true) {
-			if (this.$.appClose) this.$.appClose.set('showing', (this.showing && this.hasCloseButton));
+			if (this.$.appClose) this.$.appClose.addRemoveClass('hidden', !(this.showing && this.hasCloseButton));
 
 			if (this.showing) {
 				this.unstashHandle();


### PR DESCRIPTION
If we left key prees from appCloseButton, panels handle is spotlight focused, so TV reads its label.
When appCloseButton is hidden, next spotlight target is panels handle. 

https://jira2.lgsvl.com/browse/ENYO-3238
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
