### PR TITLE
ENYO-3271: Account borders when calculating left position for right tooltips

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -443,7 +443,7 @@ module.exports = kind(
 					relLeft = -(b.width + defaultMargin + (floating ? 0 : acBorders.left));
 				} else if ((lr == 'right' && !rtl) || (lr == 'left' && rtl)) {
 					this.addClass('left-arrow');
-					relLeft = acNode.clientWidth + defaultMargin + (floating ? 0 : acBorders.right);
+					relLeft = acNode.clientWidth + defaultMargin + (floating ? acBounds.width - acNode.clientWidth : acBorders.right);
 				}
 
 				if (floating) {


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Stephen Choi <stephen.choi@lge.com>