### PR TITLE
Fixes ENYO-3281

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1720,8 +1720,6 @@ module.exports = kind(
 			this.$.backgroundScrim.addRemoveClass('visible', this.showing);
 		}
 		if (this.useHandle === true) {
-			if (this.$.appClose) this.$.appClose.set('showing', (this.showing && this.hasCloseButton));
-
 			if (this.showing) {
 				this.unstashHandle();
 				this._show();
@@ -1735,6 +1733,8 @@ module.exports = kind(
 				this._hide();
 			}
 			this.sendShowingChangedEvent(inOldValue);
+
+			if (this.$.appClose) this.$.appClose.set('showing', (this.showing && this.hasCloseButton));
 		}
 		else {
 			Panels.prototype.showingChanged.apply(this, arguments);


### PR DESCRIPTION
If the close button were spotted when the panels are hidden, the
disappear logic would fire causing spotlight to bounce unnecessarily
causing issues for a11y. Shifting the showing update to the end of
Panels.showingChanged prevents this bouncing without any visual change.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)