### PR TITLE
ENYO-3300: Prevent re-spotting of the same panel.

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1684,7 +1684,8 @@ module.exports = kind(
 	*/
 	finishTransition: function () {
 		var fromIndex = this.fromIndex,
-			toIndex = this.toIndex;
+			toIndex = this.toIndex,
+			active, current;
 
 		this.adjustFirstPanelAfterTransition();
 		this.notifyPanels('transitionFinished');
@@ -1692,8 +1693,11 @@ module.exports = kind(
 		Panels.prototype.finishTransition.apply(this, arguments);
 		this.processPanelsToRemove(fromIndex, toIndex);
 		this.processQueuedKey();
+
 		Spotlight.unmute(this);
-		Spotlight.spot(this.getActive());
+		active = this.getActive();
+		current = Spotlight.getCurrent();
+		if (!current || !current.isDescendantOf(active)) Spotlight.spot(active);
 		this.$.appClose && this.$.appClose.customizeCloseButton({'spotlight': true});  // Restore spotlightability of close button.
 	},
 


### PR DESCRIPTION
### Issue
For panel arrangers that hide (or otherwise cause a disappearance of) panels that are transitioned away from, Spotlight's disappearance logic can cause the destination panel to be spotted, which is followed by the logic in `finishTransition` again spotting the destination panel. This can cause unwanted and repeated accessibility readouts.

### Fix
We detect if the destination panel (or one of its children) has already been spotted, and only spot the destination panel if this is not the case.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>