### PR TITLE
ENYO-3301: Fix order of operations for panel transition.

### DIFF
--- a/src/Panels/Panels.js
+++ b/src/Panels/Panels.js
@@ -1321,7 +1321,7 @@ module.exports = kind(
 	* @public
 	*/
 	setIndex: function (index) {
-		var willAnimate = this.shouldAnimate();
+		var panels, toPanel;
 
 		// Normally this.index cannot be smaller than 0 and larger than panels.length
 		// However, if panels uses handle and there is sequential key input during transition
@@ -1333,8 +1333,6 @@ module.exports = kind(
 		if (index === this.index || this.toIndex != null) {
 			return;
 		}
-
-		var panels, toPanel;
 
 		// Clear before start
 		this.queuedIndex = null;
@@ -1367,7 +1365,7 @@ module.exports = kind(
 		}
 
 		// If panels will move for this index change, kickoff animation. Otherwise skip it.
-		if (willAnimate) {
+		if (this.shouldAnimate()) {
 			Spotlight.mute(this);
 			this.startTransition();
 			this.addClass('transitioning');


### PR DESCRIPTION
### Issue
This is a regression due to a recent change in https://github.com/enyojs/moonstone/pull/2776 to only disable spottability of the close button when necessary (and not fully fixed by https://github.com/enyojs/moonstone/pull/2787), the highly-sequential ordering of operations was modified, as the call to `shouldAnimate` relies on both the assignment of `this._willMove = null` and also `this.fromIndex = this.index` and `this.toIndex = index` to properly determine the return value. As a result, `shouldAnimate` was incorrectly returning `false` for the first transition, which caused the `adjustFirstPanelBeforeTransition` method to incorrectly remove the `first` class before the transition (because `startTransition` was never run, which sets the value of `this.transitioning`). This led to an early shifting of the first panel to the right, before ultimately transitioning off the screen to the right. This did not happen in subsequent transitions, because the value of `this._willMove`, `this.index`, and `this.toIndex` had been set from the previous transition.

### Fix
We have restored the sequence of operations by calling `shouldAnimate` after the initialization of the properties it is dependent on, and also moved the definition of some unrelated vars, because...hoisting.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>