### PR TITLE
ENYO-3317: Change 'edit box' string in audio guidance

### DIFF
--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -278,12 +278,12 @@ module.exports = kind(
 	// Accessibility
 
 	/**
-	* @default $L('input field')
+	* @default $L('Input field')
 	* @type {String}
 	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityHint
 	* @public
 	*/
-	accessibilityHint: $L('input field'),
+	accessibilityHint: $L('Input field'),
 
 	/**
 	* @private

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -278,12 +278,12 @@ module.exports = kind(
 	// Accessibility
 
 	/**
-	* @default $L('edit box')
+	* @default $L('input field')
 	* @type {String}
 	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityHint
 	* @public
 	*/
-	accessibilityHint: $L('edit box'),
+	accessibilityHint: $L('input field'),
 
 	/**
 	* @private

--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -416,12 +416,12 @@ module.exports = kind(
 			this.set('accessibilityLive', this.focused || !this.spotted ? null : 'polite');
 			if (oInput) {
 				if (oInput instanceof RichText && oInput.hasNode()) {
-					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('input field');
+					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('Input field');
 				} else if (oInput.type == 'password' && oInput.getValue()) {
 					var character = (oInput.getValue().length > 1) ? $L('characters') : $L('character');
-					text = oInput.getValue().length + ' ' + character + ' ' + $L('input field');
+					text = oInput.getValue().length + ' ' + character + ' ' + $L('Input field');
 				} else {
-					text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('input field');
+					text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('Input field');
 				}
 			}
 			this.set('accessibilityLabel', this.spotted && !this.focused ? text : null);

--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -416,12 +416,12 @@ module.exports = kind(
 			this.set('accessibilityLive', this.focused || !this.spotted ? null : 'polite');
 			if (oInput) {
 				if (oInput instanceof RichText && oInput.hasNode()) {
-					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('edit box');
+					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('input field');
 				} else if (oInput.type == 'password' && oInput.getValue()) {
 					var character = (oInput.getValue().length > 1) ? $L('characters') : $L('character');
-					text = oInput.getValue().length + ' ' + character + ' ' + $L('edit box');
+					text = oInput.getValue().length + ' ' + character + ' ' + $L('input field');
 				} else {
-					text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('edit box');
+					text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('input field');
 				}
 			}
 			this.set('accessibilityLabel', this.spotted && !this.focused ? text : null);


### PR DESCRIPTION
According to accessibility UX changes, replace 'edit box' to 'input field'
string.

https://jira2.lgsvl.com/browse/ENYO-3317
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
