### PR TITLE
ENYO-3332: Switch order of set disabled to avoid focus jump

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -630,8 +630,13 @@ module.exports = kind(
 	*/
 	updateButtonStatus: function () {
 		if (this.enableJumpIncrement) {
-			this.$.buttonLeft.set('disabled', this.disabled || this.value <= this.min);
-			this.$.buttonRight.set('disabled', this.disabled || this.value >= this.max);
+			if (this.$.buttonRight.get('disabled')) {
+				this.$.buttonRight.set('disabled', this.disabled || this.value >= this.max);
+				this.$.buttonLeft.set('disabled', this.disabled || this.value <= this.min);
+			} else {
+				this.$.buttonLeft.set('disabled', this.disabled || this.value <= this.min);
+				this.$.buttonRight.set('disabled', this.disabled || this.value >= this.max);
+			}
 		}
 	},
 


### PR DESCRIPTION
Issue:
Slider have updateButtonStatus function that is set disabled
property for left/right buttons based on the value range.
When value is set from outside of control and focus is on one
of the left/right buttons, then it can trigger spotlight disappear
routine to find next focus control. But, it fails workaround focus
when next control is still disabled. Because, the sequence of
disabling controls is fixed as left to right.

Fix:
We switch disableing order by checking current disabled status.
Right button is disabled -> set disabled from right to left.
Left button is disabled -> set disabled from left to right.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)