### PR TITLE
ENYO-3260 : Change read sequence in popup, contexturePopup

### DIFF
--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -26,6 +26,8 @@ var
 	Scrim = require('moonstone/Scrim'),
 	HistorySupport = require('../HistorySupport');
 
+var options = require('enyo/options');
+
 /**
 * Fires when the contextual popup is to be shown.
 *
@@ -656,9 +658,7 @@ module.exports = kind(
 	*/
 	ariaObservers: [
 		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing'], method: function () {
-			this.startJob('alert', function () {
-				this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
-			}, 100);
+			this.updateAriaRole();
 		}}
 	],
 
@@ -666,8 +666,15 @@ module.exports = kind(
 	* @private
 	*/
 	onEnter : function(oSender, oEvent){
-		if (oEvent.originator == this){
-			this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+		if (options.accessibility && oEvent.originator == this) {
+			this.updateAriaRole();
 		}
+	},
+
+	/**
+	* @private
+	*/
+	updateAriaRole: function() {
+		this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
 	}
 });

--- a/src/ContextualPopup/ContextualPopup.js
+++ b/src/ContextualPopup/ContextualPopup.js
@@ -106,7 +106,8 @@ module.exports = kind(
 		onRequestHidePopup: 'requestHide',
 		onActivate: 'decorateActivateEvent',
 		onRequestScrollIntoView: '_preventEventBubble',
-		onSpotlightContainerLeave: 'onLeave'
+		onSpotlightContainerLeave: 'onLeave',
+		onSpotlightContainerEnter: 'onEnter'
 	},
 
 	/**
@@ -659,5 +660,14 @@ module.exports = kind(
 				this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
 			}, 100);
 		}}
-	]
+	],
+
+	/**
+	* @private
+	*/
+	onEnter : function(oSender, oEvent){
+		if (oEvent.originator == this){
+			this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+		}
+	}
 });

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -428,6 +428,7 @@ module.exports = kind(
 	* @public
 	*/
 	hide: function() {
+		this.set('_enableAlert', false);
 		Popup.prototype.hide.apply(this, arguments);
 		this.removeClass('showing');
 	},
@@ -591,11 +592,14 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	_enableAlert: false,
+
+	/**
+	* @private
+	*/
 	ariaObservers: [
-		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing'], method: function () {
-			this.startJob('alert', function () {
-				this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
-			}, 100);
+		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing', '_enableAlert'], method: function () {
+			this.setAriaAttribute('role', this.accessibilityReadAll && (this._enableAlert || this.showing) ? 'alert' : this.accessibilityRole);
 		}}
 	],
 
@@ -604,7 +608,7 @@ module.exports = kind(
 	*/
 	onEnter : function(oSender, oEvent){
 		if (oEvent.originator == this){
-			this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+			this.set('_enableAlert', true);
 		}
 	}
 });

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -22,6 +22,8 @@ var
 	IconButton = require('../IconButton'),
 	HistorySupport = require('../HistorySupport');
 
+var options = require('enyo/options');
+
 /**
 * {@link module:moonstone/Popup~Popup} is an {@link module:enyo/Popup~Popup} that appears at the bottom of the
 * screen and takes up the full screen width.
@@ -592,23 +594,25 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	_enableAlert: false,
-
-	/**
-	* @private
-	*/
 	ariaObservers: [
 		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing', '_enableAlert'], method: function () {
-			this.setAriaAttribute('role', this.accessibilityReadAll && (this._enableAlert || this.showing) ? 'alert' : this.accessibilityRole);
+			this.updateAriaRole();
 		}}
 	],
 
 	/**
 	* @private
 	*/
-	onEnter : function(oSender, oEvent){
-		if (oEvent.originator == this){
-			this.set('_enableAlert', true);
+	onEnter : function(oSender, oEvent) {
+		if (options.accessibility && oEvent.originator == this) {
+			this.updateAriaRole();
 		}
+	},
+
+	/**
+	* @private
+	*/
+	updateAriaRole: function() {
+		this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
 	}
 });

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -430,7 +430,6 @@ module.exports = kind(
 	* @public
 	*/
 	hide: function() {
-		this.set('_enableAlert', false);
 		Popup.prototype.hide.apply(this, arguments);
 		this.removeClass('showing');
 	},
@@ -595,7 +594,7 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing', '_enableAlert'], method: function () {
+		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing'], method: function () {
 			this.updateAriaRole();
 		}}
 	],

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -90,7 +90,8 @@ module.exports = kind(
 	handlers: {
 		onRequestScrollIntoView   : '_preventEventBubble',
 		ontransitionend           : 'animationEnd',
-		onSpotlightSelect         : 'handleSpotlightSelect'
+		onSpotlightSelect         : 'handleSpotlightSelect',
+		onSpotlightContainerEnter : 'onEnter'
 	},
 
 	/**
@@ -596,5 +597,14 @@ module.exports = kind(
 				this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
 			}, 100);
 		}}
-	]
+	],
+
+	/**
+	* @private
+	*/
+	onEnter : function(oSender, oEvent){
+		if (oEvent.originator == this){
+			this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+		}
+	}
 });

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -524,9 +524,7 @@ module.exports = kind(
 	*/
 	ariaObservers: [
 		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing'], method: function () {
-			this.startJob('alert', function () {
-				this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
-			}, 100);
+			this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
 		}}
 	]
 });


### PR DESCRIPTION
In current status, when popup(or contexturePopup) is shown, read "button" + "title" sequence.

But UX guideline in Major MR, "title" + "button" sequence is right.

When onSpotlightContainerEnter is fired, the button in popup is not focused yet.

So, if change role to alert in this handler, "alert" + "dom.focus()" rule is applied and TTS call is not cut off.

Enyo-DCO-1.1-Signed-off-by: Changgi Lee changgi.lee@lge.com
