### PR TITLE
ENYO-3348: Read full string for current value on DayPicker

### DIFF
--- a/src/DayPicker/DayPicker.js
+++ b/src/DayPicker/DayPicker.js
@@ -225,6 +225,19 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	multiSelectCurrentAccesibilityLabel: kind.inherit(function (sup) {
+		return function() {
+			var str = this.getRepresentativeString();
+			if (str) {
+				return str;
+			}
+			return sup.apply(this, arguments);
+		};
+	}),
+
+	/**
+	* @private
+	*/
 	getRepresentativeString: function () {
 		var bWeekEndStart = false,
 			bWeekEndEnd = false,

--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -209,7 +209,7 @@ module.exports = kind(
 		{from: 'selected.content', to: 'selectedText'},
 
 		// Accessibility
-		{from: 'selected.accessibilityLabel', to: '$.header._accessibilityText'}
+		{from: 'accessibilityText', to: '$.header._accessibilityText'}
 	],
 
 	computed: {
@@ -241,7 +241,8 @@ module.exports = kind(
 	},
 
 	/**
-	*  'multiSelectCurrentValue()' can be overridden by subkinds, such as moon.DayPicker
+	*  'multiSelectCurrentValue()' can be overridden by subkinds, such as moon.DayPicker.
+	*  Returns label for selected items by concatenate content of each items.
 	*
 	* @protected
 	*/
@@ -258,6 +259,30 @@ module.exports = kind(
 			} else {
 				str = str + ', ' + controls[this.selectedIndex[i]].getContent();
 			}
+		}
+		if (!str) {
+			str = this.getNoneText();
+		}
+		return str;
+	},
+
+	/**
+	*  'multiSelectCurrentAccesibilityLabel()' can be overridden by subkinds, such as moon.DayPicker.
+	*  Returns accessibilityLabel for selected items by concatenate accessibilityLabel of each items.
+	*
+	* @protected
+	*/
+	multiSelectCurrentAccesibilityLabel: function () {
+		if (!this.multipleSelection) {
+			return;
+		}
+		var controls = this.getCheckboxControls(), control = null;
+		var str = '', content = '';
+		this.selectedIndex.sort();
+		for (var i=0; i < this.selectedIndex.length; i++) {
+			control = controls[this.selectedIndex[i]];
+			content = control.get('accessibilityLabel') || control.getContent();
+			str = !str ? content : str + ', ' + content;
 		}
 		if (!str) {
 			str = this.getNoneText();
@@ -343,6 +368,15 @@ module.exports = kind(
 			return sel.get('content');
 		}
 		return this.noneText;
+	},
+
+	/**
+	* Update header accessibilityLabel whenever currentValueText changed.
+	*
+	* @private
+	*/
+	currentValueTextChanged: function () {
+		this.set('accessibilityText', this.multiSelectCurrentAccesibilityLabel());
 	},
 
 	/**

--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -8,7 +8,8 @@ require('moonstone');
 var
 	kind = require('enyo/kind'),
 	Component = require('enyo/Component'),
-	Group = require('enyo/Group');
+	Group = require('enyo/Group'),
+	options = require('enyo/options');
 
 var
 	BodyText = require('../BodyText'),
@@ -209,7 +210,7 @@ module.exports = kind(
 		{from: 'selected.content', to: 'selectedText'},
 
 		// Accessibility
-		{from: 'accessibilityText', to: '$.header._accessibilityText'}
+		{from: '_accessibilityText', to: '$.header._accessibilityText'}
 	],
 
 	computed: {
@@ -255,9 +256,9 @@ module.exports = kind(
 		this.selectedIndex.sort();
 		for (var i=0; i < this.selectedIndex.length; i++) {
 			if (!str) {
-				str = controls[this.selectedIndex[i]].getContent();
+				str = controls[this.selectedIndex[i]].get('content');
 			} else {
-				str = str + ', ' + controls[this.selectedIndex[i]].getContent();
+				str = str + ', ' + controls[this.selectedIndex[i]].get('content');
 			}
 		}
 		if (!str) {
@@ -281,7 +282,7 @@ module.exports = kind(
 		this.selectedIndex.sort();
 		for (var i=0; i < this.selectedIndex.length; i++) {
 			control = controls[this.selectedIndex[i]];
-			content = control.get('accessibilityLabel') || control.getContent();
+			content = control.get('accessibilityLabel') || control.get('content');
 			str = !str ? content : str + ', ' + content;
 		}
 		if (!str) {
@@ -376,7 +377,20 @@ module.exports = kind(
 	* @private
 	*/
 	currentValueTextChanged: function () {
-		this.set('accessibilityText', this.multiSelectCurrentAccesibilityLabel());
+		if (!options.accessibility) return;
+
+		var multi = this.multipleSelection,
+			sel = this.get('selected'),
+			selIdx = this.get('selectedIndex'),
+			text = this.noneText;
+
+		if (multi && sel.length && selIdx.length) {
+			text = this.multiSelectCurrentAccesibilityLabel();
+		}
+		else if (!multi && sel && selIdx !== -1) {
+			text = sel.get('accessibilityLabel') || sel.get('content');
+		}
+		this.set('_accessibilityText', text);
 	},
 
 	/**


### PR DESCRIPTION
### Issue:
Current value of DayPicker is showing abbreviation even when each item
is showing full string. This is to show as many days as possible in
small control space. When current value is 'Mon, Tue, Thu, Sat', it
reads 'Day Picker Mon, Tuesday, Thursday, Sat'.

### Fix:
We bind accessibilityText to accessibilityLabel of header. Update
accessibilityText by concatenate content of each items whenever
currentValue changes. Also, it concatenate accessibilityLabel for
item when specified. This also fix the problem of read current
value of ExpandablePicker when multipleSelection is true. (ENYO-3355)

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)