### PR TITLE
ENYO-3318: Change audio guidance string in SimplePicker

### DIFF
--- a/src/SimplePicker/SimplePicker.js
+++ b/src/SimplePicker/SimplePicker.js
@@ -177,11 +177,11 @@ module.exports = kind(
 	* @private
 	*/
 	components: [
-		{name: 'buttonLeft',  kind: IconButton, backgroundOpacity: 'transparent', classes: 'moon-simple-picker-button left', icon:'arrowlargeleft', onSpotlightSelect: 'left', ondown: 'downLeft', onholdpulse:'left', defaultSpotlightDisappear: 'buttonRight', accessibilityHint: $L('press ok button to change the value'), accessibilityLabel: ' '}, // note: single space accessibilityLabel used to suppress icon in aria-label
+		{name: 'buttonLeft',  kind: IconButton, backgroundOpacity: 'transparent', classes: 'moon-simple-picker-button left', icon:'arrowlargeleft', onSpotlightSelect: 'left', ondown: 'downLeft', onholdpulse:'left', defaultSpotlightDisappear: 'buttonRight', accessibilityHint: $L('previous item'), accessibilityLabel: ' '}, // note: single space accessibilityLabel used to suppress icon in aria-label
 		{name: 'clientWrapper', kind: Control, classes:'moon-simple-picker-client-wrapper', components: [
 			{name: 'client', kind: Control, classes: 'moon-simple-picker-client', accessibilityRole: 'spinbutton'}
 		]},
-		{name: 'buttonRight', kind: IconButton, backgroundOpacity: 'transparent', classes: 'moon-simple-picker-button right', icon:'arrowlargeright', onSpotlightSelect: 'right', ondown: 'downRight', onholdpulse:'right', defaultSpotlightDisappear: 'buttonLeft', accessibilityHint: $L('press ok button to change the value'), accessibilityLabel: ' '}
+		{name: 'buttonRight', kind: IconButton, backgroundOpacity: 'transparent', classes: 'moon-simple-picker-button right', icon:'arrowlargeright', onSpotlightSelect: 'right', ondown: 'downRight', onholdpulse:'right', defaultSpotlightDisappear: 'buttonLeft', accessibilityHint: $L('next item'), accessibilityLabel: ' '}
 	],
 
 	/**


### PR DESCRIPTION
According to accessibility UX changes, change simplePicker's hint message.

https://jira2.lgsvl.com/browse/ENYO-3318
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>

Change-Id: Ifc28fe881c0ef257702ce80afe3c61db769ea910