### PR TITLE
ENYO-3317: Change 'edit box' string in audio guidance

### DIFF
--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -278,12 +278,12 @@ module.exports = kind(
 	// Accessibility
 
 	/**
-	* @default $L('edit box')
+	* @default $L('Input field')
 	* @type {String}
 	* @see enyo/AccessibilitySupport~AccessibilitySupport#accessibilityHint
 	* @public
 	*/
-	accessibilityHint: $L('edit box'),
+	accessibilityHint: $L('Input field'),
 
 	/**
 	* @private

--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -408,12 +408,12 @@ module.exports = kind(
 			this.set('accessibilityLive', this.focused || !this.spotted ? null : 'polite');
 			if (oInput) {
 				if (oInput instanceof RichText && oInput.hasNode()) {
-					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('edit box');
+					text = (oInput.hasNode().innerText || oInput.getPlaceholder()) + ' ' + $L('Input field');
 				} else if (oInput.type == 'password' && oInput.getValue()) {
 					var character = (oInput.getValue().length > 1) ? $L('characters') : $L('character');
-					text = oInput.getValue().length + ' ' + character + ' ' + $L('edit box');
+					text = oInput.getValue().length + ' ' + character + ' ' + $L('Input field');
 				} else {
-					text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('edit box');
+					text = (oInput.getValue() || oInput.getPlaceholder()) + ' ' + $L('Input field');
 				}
 			}
 			this.set('accessibilityLabel', this.spotted && !this.focused ? text : null);


### PR DESCRIPTION
Change 'edit box' string to 'Input field' base on UX request

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>