### PR TITLE
ENYO-3331: Apply incremental option to popup animation

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -539,6 +539,16 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	calcPopupLabel: kind.inherit(function (sup) {
+		return function (val) {
+			val = (this.increment) ? this.calcIncrement(val) : val;
+			return sup.apply(this, arguments);
+		};
+	}),
+
+	/**
+	* @private
+	*/
 	updateValues: function (value) {
 		if (this.lockBar) {
 			this.setProgress(value);


### PR DESCRIPTION
Although there is an incremental option popup still shows unexpecting point number.
To resolve this, I override calcPopupLabel() to make corresponding values.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi yeram.choi@lge.com