### PR TITLE
ENYO-3363 : Initial focus is not shown in light panel

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -195,6 +195,12 @@ module.exports = kind(
 
 			Spotlight.resume();
 			spotlightPlaceholder.spotlight = false;
+			if(window.PalmSystem && window.PalmSystem.isActivated && Spotlight.isMuted()){
+				Spotlight.unmute('window.focus');
+				if (window.PalmSystem.cursor) {
+                    Spotlight.setPointerMode( window.PalmSystem.cursor.visibility );
+                }
+			}
 			if (!Spotlight.isSpottable(this)) spotlightPlaceholder.spotlight = true;
 			if (!current || current === spotlightPlaceholder) {
 				setTimeout(this.bindSafely(function () {

--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -195,11 +195,11 @@ module.exports = kind(
 
 			Spotlight.resume();
 			spotlightPlaceholder.spotlight = false;
-			if(window.PalmSystem && window.PalmSystem.isActivated && Spotlight.isMuted()){
+			if (window.PalmSystem && window.PalmSystem.isActivated && Spotlight.isMuted()) {
 				Spotlight.unmute('window.focus');
 				if (window.PalmSystem.cursor) {
-                    Spotlight.setPointerMode( window.PalmSystem.cursor.visibility );
-                }
+					Spotlight.setPointerMode(window.PalmSystem.cursor.visibility);
+				}
 			}
 			if (!Spotlight.isSpottable(this)) spotlightPlaceholder.spotlight = true;
 			if (!current || current === spotlightPlaceholder) {


### PR DESCRIPTION
Issue:
window.focus is bypass during light panel transition.

Fix:
unmute and udpate pointer status in postTransition handler

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>