### PR TITLE
PLAT-20930: Prevent reading a invalid tooltip message.

### DIFF
--- a/src/InputDecorator/InputDecorator.js
+++ b/src/InputDecorator/InputDecorator.js
@@ -130,7 +130,7 @@ module.exports = kind(
 	* @private
 	*/
 	tools: [
-		{name: 'tooltip', kind: Tooltip, floating: false, position: 'right top'}
+		{name: 'tooltip', kind: Tooltip, floating: false, position: 'right top', accessibilityDisabled: true}
 	],
 
 	/**


### PR DESCRIPTION
Prevent reading a invalid message when tooltip is shown in range input.
Tooltip is popup type component, so TV reads tooltip content when tooltip is appeared.
According to UX team, TV should not read this tooltip message.

https://jira2.lgsvl.com/browse/PLAT-20930
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim bongsub.kim@lgepartner.com
