### PR TITLE
PLAT-21868-slider knob delays to follow when seeking

### DIFF
--- a/src/VideoTransportSlider/VideoTransportSlider.js
+++ b/src/VideoTransportSlider/VideoTransportSlider.js
@@ -731,6 +731,7 @@ module.exports = kind(
 		if (this.tappable && !this.disabled) {
 			val = this.transformToVideo(this.calcKnobPosition(e));
 			this.sendSeekEvent(val);
+			this._updateKnobPosition(val);
 			return true;
 		}
 	},


### PR DESCRIPTION
Issue: This knob doesn't follow the touch.
Cause: The knob functionality is not updated in tap handler
Fix: Knob position is updated in the tap handler
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan Reddy P
rajyavardhan.p@lge.com
