### PR TITLE
PLAT-21872-Fix portrait specific issue

### DIFF
--- a/src/VideoPlayer/VideoPlayer.less
+++ b/src/VideoPlayer/VideoPlayer.less
@@ -35,8 +35,8 @@
 		display: block !important;
 		margin: 0;
 
-		.moon-video-player-video {
-			position: static;
+		.moon-video-player-container {
+			position: relative;
 		}
 	});
 


### PR DESCRIPTION
Issue: In portrait mode the video is shown in the top of the screen
Cause: position: static property crops the video height.
Issue: The video container is given the relative position property and
the static position is removed from the video
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan Reddy P
rajyavardhan.p@lge.com
