### PR TITLE
ENYO-3366 Accessibility: aria-label is set to uppercased string

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -291,5 +291,19 @@ module.exports = kind(
 		if (opacity == 'translucent' || opacity == 'transparent') {
 			this.addClass(opacity);
 		}
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['content'], method: function () {
+			if (!this.accessibilityLabel) {
+				var content = this.content;
+				this.$.client.setAriaAttribute('aria-label', content);
+			}
+		}}
+	]
 });

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -238,6 +238,12 @@ module.exports = kind(
 	},
 
 	ariaObservers: [
+		{from: 'title', method: function () {
+			if (!this.accessibilityLabel) {
+				var content = this.getTitle();
+				this.$.title.set('accessibilityLabel', content);
+			}
+		}},
 		{from: 'generated', method: function () {
 			if (!this.generated) return;
 

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -102,7 +102,21 @@ var TooltipContent = kind({
 	*/
 	uppercaseChanged: function (was, is) {
 		this.contentChanged();
-	}
+	},
+
+	// Accessibility
+
+	/**
+	* @private
+	*/
+	ariaObservers: [
+		{path: ['content'], method: function () {
+			if (!this.accessibilityLabel) {
+				var content = this._content;
+				this.setAriaAttribute('aria-label', content);
+			}
+		}}
+	]
 });
 
 /**


### PR DESCRIPTION
### Issue
In the moonstone button case, it has not aria-label. So, aria-label is set to upper-cased string.
If uppercased content is read from TTS engine, it's pronounciation can be wrong.
For example, you can see this sentence ("Reset a device").
In this case, 'a' is article grammartically, not captial 'A'.

### Fix
It is to fix issue about above accessibility.
I modified button, tooltip and dialog for setting 'aria-label' from origin content.

ENYO-3366 Accessibility: aria-label is set to uppercased string
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com