### PR TITLE
PLAT-21870-touch issue with ExpandableInput

### DIFF
--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -221,8 +221,13 @@ module.exports = kind(
 		var touchSupport, checkNode, mousePointerSupport;
 		if (this.open && Spotlight.getPointerMode()) {
 			eventType = Spotlight.getLastEvent().type;
-			checkNode = Spotlight.getLastEvent().originator.isDescendantOf(this);
-			touchSupport = (eventType === 'onSpotlightFocus' && !checkNode);
+			
+			//this is a guard code for touch support, to handle unnecessary events because of touch.
+			if(platform.touch) {
+				checkNode = Spotlight.getLastEvent().originator.isDescendantOf(this);
+				touchSupport = (eventType === 'onSpotlightFocus' && !checkNode);
+			}
+			
 			mousePointerSupport = (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover');
 			if (mousePointerSupport || touchSupport) {
 				this.closeDrawerAndHighlightHeader();
@@ -245,7 +250,7 @@ module.exports = kind(
 	*/
 	headerDown: function (sender, ev) {
 		Spotlight.unfreeze();
-		if(platform.touch && event.type == 'touchstart') {
+		if(event.type == 'touchstart') {
 			ev.preventDefault();
 		}
 	},

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -6,7 +6,8 @@ require('moonstone');
 */
 
 var
-	kind = require('enyo/kind');
+	kind = require('enyo/kind'),
+	platform = require('enyo/platform');
 
 var
 	Spotlight = require('spotlight');
@@ -244,7 +245,7 @@ module.exports = kind(
 	*/
 	headerDown: function (sender, ev) {
 		Spotlight.unfreeze();
-		if(event.type == 'touchstart') {
+		if(platform.touch && event.type == 'touchstart') {
 			ev.preventDefault();
 		}
 	},

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -217,9 +217,13 @@ module.exports = kind(
 	*/
 	inputSpotBlurred: function (inSender, inEvent) {
 		var eventType;
+		var touchSupport, checkNode, mousePointerSupport;
 		if (this.open && Spotlight.getPointerMode()) {
 			eventType = Spotlight.getLastEvent().type;
-			if (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover') {
+			checkNode = Spotlight.getLastEvent().originator.isDescendantOf(this);
+			touchSupport = (eventType === 'onSpotlightFocus' && !checkNode);
+			mousePointerSupport = (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover');
+			if (mousePointerSupport || touchSupport) {
 				this.closeDrawerAndHighlightHeader();
 			}
 		}
@@ -238,8 +242,11 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	headerDown: function () {
+	headerDown: function (sender, ev) {
 		Spotlight.unfreeze();
+		if(event.type == 'touchstart') {
+			ev.preventDefault();
+		}
 	},
 
 	/**

--- a/src/ExpandableInput/ExpandableInput.js
+++ b/src/ExpandableInput/ExpandableInput.js
@@ -217,19 +217,20 @@ module.exports = kind(
 	* @private
 	*/
 	inputSpotBlurred: function (inSender, inEvent) {
-		var eventType;
-		var touchSupport, checkNode, mousePointerSupport;
+		var eventType, lastEvent;
+		var shouldCloseByTouch, eventFromDescendant, shouldCloseByPointer;
 		if (this.open && Spotlight.getPointerMode()) {
-			eventType = Spotlight.getLastEvent().type;
+			lastEvent = Spotlight.getLastEvent();
+			eventType = lastEvent.type;
 			
 			//this is a guard code for touch support, to handle unnecessary events because of touch.
-			if(platform.touch) {
-				checkNode = Spotlight.getLastEvent().originator.isDescendantOf(this);
-				touchSupport = (eventType === 'onSpotlightFocus' && !checkNode);
+			if (platform.touch) {
+				eventFromDescendant = lastEvent.originator.isDescendantOf(this);
+				shouldCloseByTouch = (eventType === 'onSpotlightFocus' && !eventFromDescendant);
 			}
 			
-			mousePointerSupport = (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover');
-			if (mousePointerSupport || touchSupport) {
+			shouldCloseByPointer = (eventType !== 'onSpotlightFocus' && eventType !== 'mouseover');
+			if (shouldCloseByPointer || shouldCloseByTouch) {
 				this.closeDrawerAndHighlightHeader();
 			}
 		}
@@ -250,7 +251,7 @@ module.exports = kind(
 	*/
 	headerDown: function (sender, ev) {
 		Spotlight.unfreeze();
-		if(event.type == 'touchstart') {
+		if (event.type == 'touchstart') {
 			ev.preventDefault();
 		}
 	},


### PR DESCRIPTION
Issue: Expandable Input doesn't expand when touched.
Cause: touch is generated with a mousedown event. tap event makes the
input to expand and the following mousedown will make the expandable
input to collapse
Fix: When the event is triggered from touch, the default event
(mousedown) is prevented.
Enyo-DCO-1.1-Signed-off-by: Rajyavardhan Reddy P
<rajyavardhan.p@lge.com>