### PR TITLE
ENYO-3344: add isChrome options when creating tools

### DIFF
--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -199,7 +199,7 @@ module.exports = kind(
 	* @private
 	*/
 	initComponents: function() {
-		this.createComponents(this.tools, {owner: this});
+		this.createComponents(this.tools, {owner: this, isChrome: true});
 		Popup.prototype.initComponents.apply(this, arguments);
 	},
 


### PR DESCRIPTION
We didn't expect client, closeButton as returns of getClientControls().
To get corresponding return, we added isChrome option when creating tools.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi yeram.choi@lge.com