### PR TITLE
Knob of ContextualPopup has wrong position when it uses IconButton an…

### DIFF
--- a/src/ContextualPopup/ContextualPopup.less
+++ b/src/ContextualPopup/ContextualPopup.less
@@ -166,8 +166,7 @@
 		}
 		&.left:before,
 		&.left:after {
-			left: auto;
-			right: 10%;
+			right: 20%;
 		}
 	}
 


### PR DESCRIPTION
…d short contents

ENYO-3347 ContextualPopup: knob position is wrong when IconButton is used as ContextualButton
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com