### PR TITLE
ENYO-3354: Guarantee value stay in range on doChange for sliderChange…

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -913,7 +913,8 @@ module.exports = kind(
 		this.throttleJob('sliderChange', function () {
 			this.doChange(data);
 			this.startJob('sliderChangePost', function () {
-				if (this.value !== value) this.doChange({value: this.value});
+				if (this.value !== value)
+					this.doChange({value: this.clampValue(this.min, this.max, this.value)});
 			}, this.changeDelayMS);
 		}, this.changeDelayMS);
 	},


### PR DESCRIPTION
…Post

Issue:
On Slider, there is sliderChangePost job on sendChangeEvent which covers
the case that throttle job suppress event for the final value. The value
can be exceed the range when press and hold 4way key.

Fix:
The value is incremented on key handler and set to value without clamp.
The simple solution can be clamp the value on doChange only for the
case of sliderChangePost job.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)