### PR TITLE
ENYO-3326: Support accessibilityPreHint

### DIFF
--- a/src/Drawers/Drawers.js
+++ b/src/Drawers/Drawers.js
@@ -517,13 +517,15 @@ module.exports = kind(
 	// Accessibility
 
 	ariaObservers: [
-		{path: ['accessibilityLabel', 'accessibilityHint', '_activated'], method: function() {
+		{path: ['accessibilityLabel', 'accessibilityHint', '_activated', 'accessibilityPreHint'], method: function() {
 			// According to drawer is open or close or handleContainer state, drawers activator label is defined.
 			// In addition, if user add accessibilityLabel, label is determined with accessibilityLabel instead of default string.
 			// However, if user add only accessibilityHint, hint text is appended to default string.
 			var defaultLabel = (this._activated || this.$.handleContainer.getOpen()) ? $L('Close drawer') : $L('Open drawer'),
 				prefix = this.accessibilityLabel || defaultLabel,
-				label = this.accessibilityHint && (prefix + ' ' + this.accessibilityHint) ||
+				label = this.accessibilityPreHint && prefix && this.accessibilityHint && (this.accessibilityPreHint + ' ' + prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint && prefix && (this.accessibilityPreHint + ' ' + prefix) ||
+						this.accessibilityHint && (prefix + ' ' + this.accessibilityHint) ||
 						prefix;
 			this.$.activator.set('accessibilityLabel', label);
 		}}

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -221,6 +221,7 @@ module.exports = kind(
 		// Accessibility
 		{from: 'accessibilityHint', to: '$.header.accessibilityHint'},
 		{from: 'accessibilityLabel', to: '$.header.accessibilityLabel'},
+		{from: 'accessibilityPreHint', to: '$.header.accessibilityPreHint'},
 		{from: 'accessibilityDisabled', to: '$.header.accessibilityDisabled'}
 	],
 
@@ -451,7 +452,7 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['accessibilityLabel', 'accessibilityHint'], method: function () {
+		{path: ['accessibilityLabel', 'accessibilityHint', 'accessibilityPreHint'], method: function () {
 			this.setAriaAttribute('aria-label', null);
 		}}
 	]

--- a/src/GridListImageItem/GridListImageItem.js
+++ b/src/GridListImageItem/GridListImageItem.js
@@ -120,15 +120,15 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['caption', 'subCaption', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+		{path: ['content', 'caption', 'subCaption', 'accessibilityHint', 'accessibilityLabel', 'accessibilityPreHint', 'tabIndex'], method: function () {
 			var content = this.caption + ' ' + this.subCaption,
 				prefix = this.accessibilityLabel || content || null,
-				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
-						this.accessibilityHint ||
+				label = this.accessibilityPreHint && prefix && this.accessibilityHint && (this.accessibilityPreHint + ' ' + prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint && prefix && (this.accessibilityPreHint + ' ' + prefix) ||
+						this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityLabel ||
 						null;
-
-				this.setAriaAttribute('aria-label', label);
+			this.setAriaAttribute('aria-label', label);
 		}}
 	]
 });

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -326,8 +326,11 @@ module.exports = kind(
 	* @private
 	*/	
 	ariaObservers: [
-		{path: ['accessibilityLabel', 'accessibilityHint'], method: function () {
-			var label = this.accessibilityHint && this.accessibilityLabel && (this.accessibilityLabel + ' ' + this.accessibilityHint) ||
+		{path: ['content', 'accessibilityPreHint', 'accessibilityLabel', 'accessibilityHint', 'tabIndex'], method: function () {
+			var label = this.accessibilityPreHint && this.accessibilityLabel && this.accessibilityHint && ( this.accessibilityPreHint + ' ' + this.accessibilityLabel + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint && this.accessibilityLabel && (this.accessibilityPreHint + ' ' + this.accessibilityLabel) ||
+						this.accessibilityLabel && this.accessibilityHint && ( this.accessibilityLabel + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint ||
 						this.accessibilityHint ||
 						this.accessibilityLabel ||
 						null;

--- a/src/ImageItem/ImageItem.js
+++ b/src/ImageItem/ImageItem.js
@@ -139,15 +139,15 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+		{path: ['content', 'label', 'text', 'accessibilityHint', 'accessibilityLabel', 'accessibilityPreHint', 'tabIndex'], method: function () {
 			var content = this.label + ' ' + this.text ,
 				prefix = this.accessibilityLabel || content || null,
-				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
-						this.accessibilityHint ||
+				label = this.accessibilityPreHint && prefix && this.accessibilityHint && (this.accessibilityPreHint + ' ' + prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint && prefix && (this.accessibilityPreHint + ' ' + prefix) ||
+						this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityLabel ||
 						null;
-
-				this.setAriaAttribute('aria-label', label);
+			this.setAriaAttribute('aria-label', label);
 		}}
 	]
 });

--- a/src/LabeledTextItem/LabeledTextItem.js
+++ b/src/LabeledTextItem/LabeledTextItem.js
@@ -117,16 +117,16 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['label', 'text', 'accessibilityHint', 'accessibilityLabel'], method: function () {
+		{path: ['content', 'label', 'text', 'accessibilityHint', 'accessibilityLabel', 'accessibilityPreHint', 'tabIndex'], method: function () {
 			var text = this._accessibilityText ? this._accessibilityText : this.text,
 				content = this.label + ' ' + text ,
 				prefix = this.accessibilityLabel || content || null,
-				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
-						this.accessibilityHint ||
+				label = this.accessibilityPreHint && prefix && this.accessibilityHint && (this.accessibilityPreHint + ' ' + prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint && prefix && (this.accessibilityPreHint + ' ' + prefix) ||
+						this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
 						this.accessibilityLabel ||
 						null;
-
-				this.setAriaAttribute('aria-label', label);
+			this.setAriaAttribute('aria-label', label);
 		}}
 	]
 });

--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -235,10 +235,13 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['title', 'accessibilityLabel', 'accessibilityHint'], method: function () {
-			var content = this.title,
-				prefix = this.accessibilityLabel || content || null,
-				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+		{path: ['title', 'accessibilityLabel', 'accessibilityHint', 'accessibilityPreHint'], method: function () {
+			var prefix = this.accessibilityLabel || this.title || null,
+				label = this.accessibilityPreHint && prefix && this.accessibilityHint && (this.accessibilityPreHint + ' ' + prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint && prefix && (this.accessibilityPreHint + ' ' + prefix) ||
+						this.accessibilityPreHint && this.accessibilityHint && (this.accessibilityPreHint + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint ||
 						this.accessibilityHint ||
 						this.accessibilityLabel ||
 						prefix ||

--- a/src/Panel/Panel.js
+++ b/src/Panel/Panel.js
@@ -810,10 +810,13 @@ module.exports = kind(
 	* @private
 	*/
 	ariaObservers: [
-		{path: ['title', 'accessibilityLabel', 'accessibilityHint'], method: function () {
-			var content = this.title,
-				prefix = this.accessibilityLabel || content || null,
-				label = this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+		{path: ['title', 'accessibilityLabel', 'accessibilityHint', 'accessibilityPreHint'], method: function () {
+			var prefix = this.accessibilityLabel || this.title || null,
+				label = this.accessibilityPreHint && prefix && this.accessibilityHint && (this.accessibilityPreHint + ' ' + prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint && prefix && (this.accessibilityPreHint + ' ' + prefix) ||
+						this.accessibilityPreHint && this.accessibilityHint && (this.accessibilityPreHint + ' ' + this.accessibilityHint) ||
+						this.accessibilityHint && prefix && (prefix + ' ' + this.accessibilityHint) ||
+						this.accessibilityPreHint ||
 						this.accessibilityHint ||
 						this.accessibilityLabel ||
 						prefix ||


### PR DESCRIPTION
According to TV UX requirements, TV should support to reading a
hint message before reading control's content or aria-label, so
accessibilityPreHint API is added in enyo AccessibilitySupport,
we also applied it to Moonstone components.

https://jira2.lgsvl.com/browse/ENYO-3326
Enyo-DCO-1.1-Signed-off-by: Bongsub Kim <bongsub.kim@lgepartner.com>

Change-Id: I71cc0d9fe117009d5cd31c8c96aff2cd9b1b6e59