### PR TITLE
ENYO-3309: Change undefined less variable to real value

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -192,7 +192,7 @@
 
 // Notification
 // ---------------------------------------
-@moon-notification-font-family: @moon-font-family-small;
+@moon-notification-font-family: "MuseoSans 500";
 @moon-notification-font-weight: normal;
 @moon-notification-font-style: normal;
 @moon-notification-background-opacity: 95%;


### PR DESCRIPTION
moon-font-family-small wasn't defined in moonstone but moonstone-extra.
It caused less compile fail. So I changed that variable to real value temporally.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi yeram.choi@lge.com