### PR TITLE
ENYO-3330: Darkened Popup's buttons

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -17,7 +17,7 @@
 @moon-neutral-icon-color: @moon-dark-gray;
 @moon-neutral-button-text-color: @moon-white;
 @moon-neutral-button-bg-color: #686868;
-@moon-neutral-button-disabled-text-color: @moon-light-gray;
+@moon-neutral-button-disabled-text-color: #cdcdcd;
 @moon-neutral-button-disabled-bg-color: #686868;
 @moon-neutral-thumb-bg-color: rgba(50, 50, 50, 0.8);
 

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -15,10 +15,10 @@
 @moon-neutral-scroller-icon: url(../images/LightTheme_Icons/scroller_icon.png);
 @moon-neutral-border-color: @moon-dark-gray;
 @moon-neutral-icon-color: @moon-dark-gray;
-@moon-neutral-button-text-color: @moon-dark-gray;
-@moon-neutral-button-bg-color: @moon-white;
-@moon-neutral-button-disabled-text-color: @moon-dark-gray;
-@moon-neutral-button-disabled-bg-color: @moon-white;
+@moon-neutral-button-text-color: @moon-white;
+@moon-neutral-button-bg-color: #686868;
+@moon-neutral-button-disabled-text-color: @moon-light-gray;
+@moon-neutral-button-disabled-bg-color: #686868;
 @moon-neutral-thumb-bg-color: rgba(50, 50, 50, 0.8);
 
 

--- a/src/Button/Button.less
+++ b/src/Button/Button.less
@@ -148,6 +148,15 @@
 		color: inherit;
 	}
 
+	&.translucent {
+		background-color: fade(@moon-button-background-color, @moon-button-translucent-opacity);
+	}
+
+	&.transparent {
+		color: @moon-neutral-button-bg-color;
+		background-color: transparent;
+	}
+
 	&[disabled] {
 		color: @moon-neutral-button-disabled-text-color;
 		background-color: @moon-neutral-button-disabled-bg-color;

--- a/src/IconButton/IconButton.less
+++ b/src/IconButton/IconButton.less
@@ -46,6 +46,7 @@
 		}
 
 		&.transparent {
+			color: @moon-neutral-button-bg-color;
 			background-color: transparent;
 		}
 

--- a/src/Popup/Popup.less
+++ b/src/Popup/Popup.less
@@ -24,6 +24,10 @@
 	&.reserve-close {
 		padding-right: @moon-spotlight-outset + @moon-icon-button-small-size + @moon-spotlight-outset;
 	}
+
+	&.moon-neutral {
+		background-color: fadeout(@moon-neutral-bg-color, 5%);
+	}
 }
 
 .moon-popup-close {


### PR DESCRIPTION
Added translucent&transparent visual states to Button, to match IconButton
Assigned darker color value to transparent neutral buttons (so it's not white on off-white)

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>