### PR TITLE
ENYO-3379: Set ExpandableListItem spotlight property as false

### DIFF
--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -170,7 +170,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	spotlight: 'container',
+	spotlight: false,
 
 	/**
 	* @private

--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -170,7 +170,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	spotlight: false,
+	spotlight: 'container',
 
 	/**
 	* @private

--- a/src/ScrollStrategy/ScrollStrategy.js
+++ b/src/ScrollStrategy/ScrollStrategy.js
@@ -1030,7 +1030,12 @@ var MoonScrollStrategy = module.exports = kind(
 	* @private
 	*/
 	at5WayLimit: function (control, direction) {
-		return !Spotlight.NearestNeighbor.getNearestNeighbor(direction, control, {root: Spotlight.getParent(control)});
+		// Find parent control which is having more than 1 children
+		var parent = Spotlight.getParent(control);
+		while (parent != this && Spotlight.getChildren(parent).length <= 1) {
+			parent = Spotlight.getParent(parent);
+		}
+		return !Spotlight.NearestNeighbor.getNearestNeighbor(direction, control, {root: parent});
 	},
 
 	/**

--- a/src/ScrollStrategy/ScrollStrategy.js
+++ b/src/ScrollStrategy/ScrollStrategy.js
@@ -1032,7 +1032,7 @@ var MoonScrollStrategy = module.exports = kind(
 	at5WayLimit: function (control, direction) {
 		// Find parent control which is having more than 1 children
 		var parent = Spotlight.getParent(control);
-		while (parent != this && Spotlight.getChildren(parent).length <= 1) {
+		while (parent !== this && Spotlight.getChildren(parent).length <= 1) {
 			parent = Spotlight.getParent(parent);
 		}
 		return !Spotlight.NearestNeighbor.getNearestNeighbor(direction, control, {root: parent});


### PR DESCRIPTION
Issue:
We added Scroll to boundary feature on ScrollStrategy which is checking
5way limit with its first spottable parent. When spotlight container
control is used in scroller with spottable child inside, it is detect
there is no nearest neighbor from the child and try to jump scroll.

This behavior is okay with other case but it is not when child items are
small number like ExpandableListItem Header case. It is try to jump
scroll for every 5way key.

Fix:
Set nearest neighbor root as focusable parent that is having more than
1 children.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)