### PR TITLE
ENYO-3373: Call ariaValue() explictly at the end of TimePicker creation

### DIFF
--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -210,6 +210,7 @@ var HourMinutePickerBase = kind(
 		IntegerPicker.prototype.create.apply(this, arguments);
 		// Create ilib Date object used for formatting hours
 		this.date = dateFactory();
+		this.ariaValue();
 	},
 
 	/**


### PR DESCRIPTION
Due to earliness of ariaObserver, date and range weren't set as our expectation.
To resolve this scenario, we put ariaValue() at the end of TimePicker creation time.