### PR TITLE
ENYO-3377: Scroller doesn't scroll on page up when focused item is not visible on viewport

### DIFF
--- a/src/Scroller/Scroller.js
+++ b/src/Scroller/Scroller.js
@@ -507,7 +507,7 @@ if (platform.touch) {
 								NearestNeighbor.
 								getNearestPointerNeighbor(this, rDirection.toUpperCase(), oEndPoint.x, oEndPoint.y);
 				}
-				if (oControl !== oSpotControl) {
+				if (oControl != null && oControl !== oSpotControl) {
 					Spotlight.spot(oControl);
 				} else {
 					pageKeyCtr.sendPaginateEvent();


### PR DESCRIPTION
Issue:
Scroller can handling page up/down key. When nearest neighbor control
exist from the last focused control, it spot on it. When the nearest
neighbor control is same as last focus control, it send paging event to
scroller. Problem happens when nearest neighbor control is null. It is
trying to spot on null which doesn't do any movement.

Fix:
Adding check for null case and send paging event to scroller.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)