### PR TITLE
ENYO-3390: Flip start/end compare position on rtl case in moon.input

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -160,8 +160,8 @@ module.exports = kind(
 	* @private
 	*/
 	right: function () {
-		var end = this.rtl ? 0: this.node.value.length;
-		if (!this.hasNode() || this.node.selectionStart == end) {
+		var end = this.rtl ? 0 : this.node.value.length;
+		if (!this.hasNode() || this.node.selectionStart === end) {
 			return false;
 		}
 		return true;

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -149,7 +149,8 @@ module.exports = kind(
 	* @private
 	*/
 	left: function () {
-		if (!this.hasNode() || this.node.selectionStart === 0) {
+		var start = this.rtl ? this.node.value.length : 0;
+		if (!this.hasNode() || this.node.selectionStart === start) {
 			return false;
 		}
 		return true;
@@ -159,7 +160,8 @@ module.exports = kind(
 	* @private
 	*/
 	right: function () {
-		if (!this.hasNode() || this.node.selectionStart == this.node.value.length) {
+		var end = this.rtl ? 0: this.node.value.length;
+		if (!this.hasNode() || this.node.selectionStart == end) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Issue:
When user press left or right key in moon.Input, it compares the cursor
position to 0 or length of text and move spotlight focus to other
control to that direction. Problem happens on rtl character. It compares
start position to 0 but it should compare to length.

Fix:
When rtl character is written in moon.Input, flip the start and end
position of compare. So it can safely move focus to the right direction.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)