### PR TITLE
ENYO-3391 : Marquee is not working when reflow is happen

### DIFF
--- a/src/Marquee/Marquee.js
+++ b/src/Marquee/Marquee.js
@@ -305,6 +305,17 @@ var MarqueeSupport = {
 	* @method
 	* @private
 	*/
+	reflow: kind.inherit(function (sup) {
+		return function () {
+			this.resetMarquee();
+			sup.apply(this, arguments);
+		};
+	}),
+
+	/**
+	* @method
+	* @private
+	*/
 	teardownRender: kind.inherit(function (sup) {
 		return function (caching) {
 			if (caching && this._marquee_active) {
@@ -740,7 +751,6 @@ var MarqueeItem = {
 			sup.apply(this, arguments);
 			this._marquee_invalidateMetrics();
 			this._marquee_calcDistance();
-			this._marquee_reset();
 		};
 	}),
 

--- a/src/Marquee/Marquee.js
+++ b/src/Marquee/Marquee.js
@@ -740,6 +740,7 @@ var MarqueeItem = {
 			sup.apply(this, arguments);
 			this._marquee_invalidateMetrics();
 			this._marquee_calcDistance();
+			this._marquee_reset();
 		};
 	}),
 


### PR DESCRIPTION
Issue
:Marquee status change to ellipse but animation is not working

Fix
:Call marquee reset func in reflow handler

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>