### PR TITLE
ENYO-3412: Assign allowHtml as true by default

### DIFF
--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -125,6 +125,16 @@ module.exports = kind(
 		animate: true,
 
 		/**
+		*
+		* When `true`, HTML tags are allowed in the control's content.
+		*
+		* @type {Boolean}
+		* @default true
+		* @public
+		*/
+		allowHtml: true,
+
+		/**
 		* The message that will be displayed in the notification's text area.
 		*
 		* @type {String}


### PR DESCRIPTION
Previously, Dialog supported allowHtml as true by default.
It was caused by not binding Dialog's allowHtml to BodyText.

In case of Notification we binded its allowHtml to BodyText and it caused
settings BodyText's prop to false by unexpectation.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)