### PR TITLE
ENYO-3427 : Button label did not read when Notification Popup is shown.

### DIFF
--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -21,7 +21,8 @@ var
 	BodyText = require('../BodyText'),
 	HistorySupport = require('../HistorySupport');
 
-var options = require('enyo/options');
+var
+	options = require('enyo/options');
 
 /**
 * {@link module:moonstone/Notification~Notification} is a toast-like minimal popup that comes up
@@ -426,7 +427,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	onEnter : function(oSender, oEvent) {
+	onEnter: function (oSender, oEvent) {
 		if (options.accessibility && oEvent.originator == this) {
 			this.updateAriaRole();
 		}
@@ -435,7 +436,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	updateAriaRole: function() {
+	updateAriaRole: function () {
 		this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
 	}
 });

--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -21,6 +21,8 @@ var
 	BodyText = require('../BodyText'),
 	HistorySupport = require('../HistorySupport');
 
+var options = require('enyo/options');
+
 /**
 * {@link module:moonstone/Notification~Notification} is a toast-like minimal popup that comes up
 * from the bottom of the screen. It requires a button to be provided and present to close it.
@@ -417,9 +419,23 @@ module.exports = kind(
 	*/
 	ariaObservers: [
 		{path: ['accessibilityReadAll', 'accessibilityRole', 'showing'], method: function () {
-			this.startJob('alert', function () {
-				this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
-			}, 100);
+			this.updateAriaRole();
 		}}
-	]
+	],
+
+	/**
+	* @private
+	*/
+	onEnter : function(oSender, oEvent) {
+		if (options.accessibility && oEvent.originator == this) {
+			this.updateAriaRole();
+		}
+	},
+
+	/**
+	* @private
+	*/
+	updateAriaRole: function() {
+		this.setAriaAttribute('role', this.accessibilityReadAll && this.showing ? 'alert' : this.accessibilityRole);
+	}
 });


### PR DESCRIPTION
Issue
:When Notification Popup is opened,
Button focus is called straightly, but Alert is called after 100ms.
So, Alert message is cut off button's tts audio guidance.

Fix
:Change Alert called timing to onSpotlightContainerEnter event handler

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>