### PR TITLE
ENYO-3425: Nearest neighbor compare position with first child when

### DIFF
--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -258,7 +258,11 @@ module.exports = kind(
 	*/
 	afterHide: function (sender, ev) {
 		// Make all contained containers forget last focused child
-		this.waterfall('requestClearLastFocus', {type: 'requestClearLastFocus', originator: this});
+		this.waterfall('onRequestSetLastFocusedChild', {
+			type: 'onRequestSetLastFocusedChild',
+			originator: this,
+			last: null
+		});
 	},
 
 	/**

--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -76,11 +76,6 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	spotlightRememberFocus: false,
-
-	/**
-	* @private
-	*/
 	activator: null,
 
 	/**
@@ -92,6 +87,11 @@ module.exports = kind(
 	* @private
 	*/
 	hidingMethod: 'beforeHide',
+
+	/**
+	* @private
+	*/
+	hiddenMethod: 'afterHide',
 
 	/**
 	* @private
@@ -251,6 +251,14 @@ module.exports = kind(
 		if (this._initialized && this.allowBackKey && !EnyoHistory.isProcessing()) {
 			EnyoHistory.drop();
 		}
+	},
+
+	/**
+	* @private
+	*/
+	afterHide: function (sender, ev) {
+		// Make all contained containers forget last focused child
+		this.waterfall('requestClearLastFocus', {type: 'requestClearLastFocus', originator: this});
 	},
 
 	/**

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -79,11 +79,6 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	spotlightRememberFocus: false,
-
-	/**
-	* @private
-	*/
 	allowDefault: true,
 
 	/**
@@ -379,6 +374,8 @@ module.exports = kind(
 					if (ev.originator === this) {
 						// Delay inherited until animationEnd
 						Popup.prototype.showingChanged.apply(this, args);
+						// Make all contained containers forget last focused child
+						this.waterfall('requestClearLastFocus', {type: 'requestClearLastFocus', originator: this});
 						this.animationEnd = util.nop;
 						this.isAnimatingHide = false;
 					}

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -375,7 +375,11 @@ module.exports = kind(
 						// Delay inherited until animationEnd
 						Popup.prototype.showingChanged.apply(this, args);
 						// Make all contained containers forget last focused child
-						this.waterfall('requestClearLastFocus', {type: 'requestClearLastFocus', originator: this});
+						this.waterfall('onRequestSetLastFocusedChild', {
+							type: 'onRequestSetLastFocusedChild',
+							originator: this,
+							last: null
+						});
 						this.animationEnd = util.nop;
 						this.isAnimatingHide = false;
 					}


### PR DESCRIPTION
spotlightRememberFocus is false

Remove spotlightRememberFocus on Popup and Notification.
Calling requestClearLastFocus event so container can forget last focus
on hide.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)