### PR TITLE
ENYO-3431 Scrim isn't hidden when notification is destroyed in showing

### DIFF
--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -194,14 +194,6 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	destroy: function() {
-		this.showHideScrim(false);
-		Popup.prototype.destroy.apply(this, arguments);
-	},
-
-	/**
-	* @private
-	*/
 	render: function () {
 		this._initialized = true;
 		Popup.prototype.render.apply(this, arguments);

--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -194,6 +194,14 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	destroy: function() {
+		this.showHideScrim(false);
+		Popup.prototype.destroy.apply(this, arguments);
+	},
+
+	/**
+	* @private
+	*/
 	render: function () {
 		this._initialized = true;
 		Popup.prototype.render.apply(this, arguments);

--- a/src/Popup/Popup.js
+++ b/src/Popup/Popup.js
@@ -569,14 +569,6 @@ module.exports = kind(
 	},
 
 	/**
-	* @private
-	*/
-	destroy: function() {
-		this.showHideScrim(false);
-		Popup.prototype.destroy.apply(this, arguments);
-	},
-
-	/**
 	* When `true`, the contents of the popup will be read when shown.
 	*
 	* @default true


### PR DESCRIPTION
### Issue
Scrim is not hidden when notification is destroyed in showing status.

### Fix
When notification is destroyed, showHideScrim is called to hide scrim.

ENYO-3431 Scrim isn't hidden when notification is destroyed in showing
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com