### PR TITLE
ENYO-3433 : FormCheckbox's check mark is not shown.

### DIFF
--- a/css/moonstone-variables-dark.less
+++ b/css/moonstone-variables-dark.less
@@ -111,6 +111,7 @@
 @moon-gridlist-item-selection-color: #404040;
 
 @moon-form-checkbox-bg-color: #404040;
+@moon-form-checkbox-icon-color: @moon-white;
 
 @moon-help-text-color: @moon-sub-header-text-color;
 @moon-expandable-picker-text-color: @moon-sub-header-text-color;

--- a/css/moonstone-variables-light.less
+++ b/css/moonstone-variables-light.less
@@ -108,6 +108,7 @@
 @moon-gridlist-item-selection-color: #404040;
 
 @moon-form-checkbox-bg-color: @moon-white;
+@moon-form-checkbox-icon-color: @moon-dark-gray;
 
 @moon-help-text-color: gray;
 @moon-expandable-picker-text-color: #4B4B4B;

--- a/src/FormCheckbox/FormCheckbox.less
+++ b/src/FormCheckbox/FormCheckbox.less
@@ -29,6 +29,9 @@
 
 		.moon-icon {
 			padding-bottom: 3px;
+			.moon-neutral & {
+				color: @moon-form-checkbox-icon-color;
+			}
 		}
 	}
 


### PR DESCRIPTION
Issue
:netural css property effect to color. So mark color similar to background.

Fix
: Change mark color

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>