### PR TITLE
ENYO-3436: Set whole transition prop instead of setting transition-du…

### DIFF
--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -206,9 +206,9 @@ module.exports = kind(
 		var dur = (this.animate && this.showHideDuration) ? this.showHideDuration : 0;
 		this.set('showingDuration', dur);
 		this.set('hidingDuration', dur);
-		this.applyStyle('-webkit-transition-duration', dur + 'ms');
-		this.applyStyle('-moz-transition-duration', dur + 'ms');
-		this.applyStyle('transition-duration', dur + 'ms');
+		this.applyStyle('-webkit-transition', '-webkit-transform ' + dur + 'ms cubic-bezier(0,1.5,.75,1)');
+		this.applyStyle('-moz-transition', '-moz-transform ' + dur + 'ms cubic-bezier(0,1.5,.75,1)');
+		this.applyStyle('transition', 'transform ' + dur + 'ms cubic-bezier(0,1.5,.75,1)');
 	},
 
 	/**


### PR DESCRIPTION
…ration only

In our webOS TV, setting transition-duration caused rest of transition props to default.
To avoid this, we set whole transition props explicitly.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)