### PR TITLE
ENYO-3389: Set overflow as hidden to client control

### DIFF
--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -70,7 +70,10 @@
 	}
 
 	// Applying the margin to the children allows for the case of no children without needing removing the margin
-	.client > * {
-		margin-top: 24px;
+	.client {
+		overflow: hidden;
+		& > * {
+			margin-top: 24px;
+		}
 	}
 }


### PR DESCRIPTION
Many buttons can cause overflow on Notification control.
We guard this by setting overflow as hidden to client per UX requirement.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)