### PR TITLE
ENYO-3430: Preserve acceleration when container control have

### DIFF
--- a/src/ExpandableListItem/ExpandableListItem.js
+++ b/src/ExpandableListItem/ExpandableListItem.js
@@ -175,6 +175,11 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	spotlightPreserveAcceleration: true,
+
+	/**
+	* @private
+	*/
 	defaultKind: Item,
 
 	/**


### PR DESCRIPTION
spotlightPreserveAcceleration property as true.

When spotlight container control have only one spottable item,
just like ExpandableListItem family, it cancel 5way key acceleration.

We add a property which can be given on container control that
is skipping acceleration cancel logic.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)