### PR TITLE
PLAT-23893: Fix touch issue with NewDataList

### DIFF
--- a/src/NewDataList/NewDataList.js
+++ b/src/NewDataList/NewDataList.js
@@ -16,7 +16,6 @@ module.exports = kind({
 	name: 'moon.NewDataList',
 	kind: NewDataList,
 	scrollControls: [{kind: ScrollControls}],
-	touch: false,
 	mixins: [Scrollable, VDRSpotlightSupport],
 	handlers: {
 		onSpotlightUp: 'guard5way',


### PR DESCRIPTION
Issue: In touch devices, Moonstone NewDataList doesn't scroll with touch.
Cause: By default, touch was disabled in Moonstone NewDataList by setting the code touch: false
Fix: Removed the code touch: false, by default the touch is enable in Enyo NewDataList

Enyo-DCO-1.1-Signed-off-by: Anish T D(anish.td@lge.com)