### PR TITLE
ENYO-3438 : Apply non-latin font in Notification Popup

### DIFF
--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -134,7 +134,8 @@
 	// Light weighted classes
 	.moon-body-text,
 	.moon-superscript,
-	.moon-pre-text {
+	.moon-pre-text,
+	.moon-notification .moon-body-text {
 		font-family: @moon-non-latin-font-family-light;
 	}
 	// Bold weighted classes

--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -61,6 +61,9 @@
 		font-weight: @moon-notification-font-weight;
 		font-style: @moon-notification-font-style;
 		font-size: @moon-notification-font-size;
+		.enyo-locale-non-latin & {
+			font-family: @moon-non-latin-font-family;
+		}
 	}
 	.moon-body-text-control {
 		text-align: inherit;

--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -61,9 +61,6 @@
 		font-weight: @moon-notification-font-weight;
 		font-style: @moon-notification-font-style;
 		font-size: @moon-notification-font-size;
-		.enyo-locale-non-latin & {
-			font-family: @moon-non-latin-font-family;
-		}
 	}
 	.moon-body-text-control {
 		text-align: inherit;


### PR DESCRIPTION
Issue
: When japanese language is selected, non-latin(LG Display) has to applied in Notification Popup's body text.

Fix
: Add optional code for  apply non-latin font.

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>