### PR TITLE
ENYO-3441 DayPicker: Support special separator for fa-IR locale

### DIFF
--- a/src/DayPicker/DayPicker.js
+++ b/src/DayPicker/DayPicker.js
@@ -208,7 +208,7 @@ module.exports = kind(
 	*/
 	multiSelectCurrentValue: function () {
 		var str = this.getRepresentativeString(),
-			comma = this.initCommaValue();
+			delimiter = this.initDelimiterValue();
 		if (str) {
 			return str;
 		}
@@ -217,7 +217,7 @@ module.exports = kind(
 			if (!str) {
 				str = this.days[this.selectedIndex[i]];
 			} else {
-				str = str + comma + ' ' + this.days[this.selectedIndex[i]];
+				str = str + delimiter + ' ' + this.days[this.selectedIndex[i]];
 			}
 		}
 
@@ -227,12 +227,12 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	initCommaValue: function() {
-		var comma = ',';
+	initDelimiterValue: function() {
+		var delimiter = ',';
 		if (window.PalmSystem && window.PalmSystem.locale === 'fa-IR') {
-			comma = '\u060c';
+			delimiter = '\u060c';
 		}
-		return comma;
+		return delimiter;
 	},
 
 	/**

--- a/src/DayPicker/DayPicker.js
+++ b/src/DayPicker/DayPicker.js
@@ -207,7 +207,8 @@ module.exports = kind(
 	* @private
 	*/
 	multiSelectCurrentValue: function () {
-		var str = this.getRepresentativeString();
+		var str = this.getRepresentativeString(),
+			comma = this.initCommaValue();
 		if (str) {
 			return str;
 		}
@@ -216,10 +217,22 @@ module.exports = kind(
 			if (!str) {
 				str = this.days[this.selectedIndex[i]];
 			} else {
-				str = str + ', ' + this.days[this.selectedIndex[i]];
+				str = str + comma + ' ' + this.days[this.selectedIndex[i]];
 			}
 		}
+
 		return str || this.getNoneText();
+	},
+
+	/**
+	* @private
+	*/
+	initCommaValue: function() {
+		var comma = ',';
+		if (window.PalmSystem && window.PalmSystem.locale === 'fa-IR') {
+			comma = '\u060c';
+		}
+		return comma;
 	},
 
 	/**


### PR DESCRIPTION
### Issue
This is requirement from 'Gold Iran'.
They want to support special separator to moon.DayPicker.

### Fix
Add method for getting separator(,) depands on Locales.

ENYO-3441 DayPicker: Support special separator for fa-IR locale
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com