### PR TITLE
ENYO-3444: respotActivator only if popup is rendered

### DIFF
--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -249,10 +249,12 @@ module.exports = kind(
 	* @private
 	*/
 	beforeHide: function (sender, ev) {
-		this.respotActivator();
+		if (this._initialized) {
+			this.respotActivator();
 
-		if (this._initialized && this.allowBackKey && !EnyoHistory.isProcessing()) {
-			EnyoHistory.drop();
+			if (this.allowBackKey && !EnyoHistory.isProcessing()) {
+				EnyoHistory.drop();
+			}
 		}
 	},
 


### PR DESCRIPTION
Issue:
ShowingTransitionSupport is calling showingChanged from create. The
showingChanged is set initial css state and call timing methods like
hiding, hidden, showing, shown. Problem happens when create Notification
dynamically because hidingMethod is called on create and try to re-spot
on activator but activator is null (cached on showingMethod). And if
user destroy popup without hide, then hidingMethod is not even called.

Fix:
Call respotActivator only if initialized (rendered) on beforeHide.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)