### PR TITLE
Hides number input arrows

### DIFF
--- a/src/Input/Input.less
+++ b/src/Input/Input.less
@@ -23,6 +23,11 @@
 	}
 }
 
+.moon-input[type=number]::-webkit-inner-spin-button,
+.moon-input[type=number]::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+}
+
 .moon-input-decorator {
 	&.spotlight {
 		color: @moon-spotlight-text-color;


### PR DESCRIPTION
### Issue
With newer web engines (i.e. Chromium 44+), the arrows (spinners) are displayed for inputs with `type="number"`.

### Fix
We add some styling to hide the arrows specifically for these types of inputs.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>