### PR TITLE
PLAT-24872: ListActions lists are empty

### DIFF
--- a/src/ListActions/ListActions.less
+++ b/src/ListActions/ListActions.less
@@ -79,6 +79,9 @@
 
 	&.stacked .moon-list-actions-menu {
 		display: block;
+		> [role="listbox"] {
+			min-height: 250px;
+		}
 	}
 }
 .moon-list-actions-drawer-client {


### PR DESCRIPTION
Issue: ListAction component menus are not displaying properly in mobile portrait mode.
Cause: In portrait mode the menu will be stacked and the if the menu items having list and have not set the height will not be displayed as expected.
Fix: For stacked menus, if the child is list. added the css min-height

Enyo-DCO-1.1-Signed-off-by: Anish T D(anish.td@lge.com)
