### PR TITLE
ENYO-3447: Define .moon-word-break and use it in Notification

### DIFF
--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -116,6 +116,10 @@
 	font-size: @moon-divider-font-size;
 	color: @moon-divider-text-color;
 }
+.moon-word-break {
+	word-wrap: break-word;
+	word-break: keep-all;
+}
 
 .enyo-locale-non-latin {
 	// Medium weighted classes

--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -61,6 +61,7 @@
 		font-weight: @moon-notification-font-weight;
 		font-style: @moon-notification-font-style;
 		font-size: @moon-notification-font-size;
+		.moon-word-break;
 	}
 	.moon-body-text-control {
 		text-align: inherit;


### PR DESCRIPTION
It's better to have word-break option to display context in various locales.
At this moment, we only applied it to BodyText in Notification.
For the expandability of word-break style, we separate it as an individual
css prop to use it in other controls.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)