### PR TITLE
[ENYO-3441] DayPicker: Support special separator for fa-IR locale

### DIFF
--- a/src/DayPicker/DayPicker.js
+++ b/src/DayPicker/DayPicker.js
@@ -131,13 +131,6 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	tools: [
-		{kind: Signals, onlocalechange: 'handleLocaleChangeEvent'}
-	],
-
-	/**
-	* @private
-	*/
 	daysComponents: [
 		{content: 'Sunday'},
 		{content: 'Monday'},
@@ -160,7 +153,6 @@ module.exports = kind(
 		return function() {
 			// super initialization
 			sup.apply(this, arguments);
-			this.createChrome(this.tools);
 			this.initILib();
 			this.createComponents(this.daysComponents);
 		};
@@ -198,6 +190,7 @@ module.exports = kind(
 	*/
 	handleLocaleChangeEvent: function () {
 		this.destroyClientControls();
+		this.updateDelimiter();
 		this.initILib();
 		this.createComponents(this.daysComponents);
 		this.render();
@@ -216,7 +209,7 @@ module.exports = kind(
 			if (!str) {
 				str = this.days[this.selectedIndex[i]];
 			} else {
-				str = str + ', ' + this.days[this.selectedIndex[i]];
+				str = str + this.delimiter + this.days[this.selectedIndex[i]];
 			}
 		}
 		return str || this.getNoneText();

--- a/src/DayPicker/DayPicker.js
+++ b/src/DayPicker/DayPicker.js
@@ -6,8 +6,7 @@
 require('moonstone');
 
 var
-	kind = require('enyo/kind'),
-	Signals = require('enyo/Signals');
+	kind = require('enyo/kind');
 
 var
 	ilib = require('enyo-ilib'),

--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -7,9 +7,11 @@ require('moonstone');
 
 var
 	kind = require('enyo/kind'),
+	Signals = require('enyo/Signals'),
 	Component = require('enyo/Component'),
 	Group = require('enyo/Group'),
-	options = require('enyo/options');
+	options = require('enyo/options'),
+	ilib = require('enyo-ilib');
 
 var
 	BodyText = require('../BodyText'),
@@ -201,6 +203,18 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	delimiter: ', ',
+
+	/**
+	* @private
+	*/
+	tools: [
+		{kind: Signals, onlocalechange: 'handleLocaleChangeEvent'}
+	],
+
+	/**
+	* @private
+	*/
 	drawerComponents: [
 		{name: 'client', tag: null, kind: Group, onActivate: 'activated', highlander: true},
 		{name: 'helpText', kind: BodyText, canGenerate: false, classes: 'moon-expandable-picker-help-text'}
@@ -227,9 +241,10 @@ module.exports = kind(
 		}
 		// super initialization
 		ExpandableListItem.prototype.create.apply(this, arguments);
-
+		this.updateDelimiter();
 		this.selectedIndexChanged();
 		this.helpTextChanged();
+		this.createChrome(this.tools);
 	},
 
 	/**
@@ -258,13 +273,28 @@ module.exports = kind(
 			if (!str) {
 				str = controls[this.selectedIndex[i]].get('content');
 			} else {
-				str = str + ', ' + controls[this.selectedIndex[i]].get('content');
+				str = str + this.delimiter + controls[this.selectedIndex[i]].get('content');
 			}
 		}
 		if (!str) {
 			str = this.getNoneText();
 		}
 		return str;
+	},
+
+	/**
+	* @private
+	*/
+	updateDelimiter: function() {
+		this.delimiter =  (typeof ilib !== 'undefined' && ilib.getLocale() === 'fa-IR') ? '\u060c ' : ', ';
+	},
+
+	/**
+	* @private
+	*/
+	handleLocaleChangeEvent: function () {
+		this.updateDelimiter();
+		this.notify('currentValueText');
 	},
 
 	/**


### PR DESCRIPTION
This is requirement from 'Gold Iran'.
They want to support special delimiter to moon.DayPicker.

Add method for getting delimiter(,) depands on Locales.

ENYO-3441 DayPicker: Support special separator for fa-IR locale
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com