### PR TITLE
ENYO-3456: Set filter as blur(0) to avoid chromium bug

### DIFF
--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -15,6 +15,7 @@
 	text-align: center;
 	border-radius: @moon-notification-border-radius;
 	background-color: fade(@moon-neutral-bg-color, @moon-notification-background-opacity);
+	-webkit-filter: blur(0);
 	-webkit-transform: translate3d(-50%, 100%, 0);
 	-moz-transform:    translate3d(-50%, 100%, 0);
 	-ms-transform:     translate3d(-50%, 100%, 0);


### PR DESCRIPTION
There was a bug on chromium side that set blur to font forcefully in
case of div's position is odd number.
To avoid this, we set blur(0) to -webkit-filter prop.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)