### PR TITLE
ENYO-3457: Last focused item of data list is different when move back to

### DIFF
--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -78,7 +78,10 @@ var DataListSpotlightSupport = {
 				child = this.childForIndex(inIndex);
 			}
 			subChild = inSubChild ? Spotlight.getChildren(child)[inSubChild] : child;
-			Spotlight.spot(subChild) || Spotlight.spot(this);
+			Spotlight.spot(subChild) || 
+				Spotlight.spot(this) || 
+				this.restoreStateOnRender && Spotlight.isPaused() && // For safe guard
+				this.bubble('onRequestSetLastFocusedChild', {type: 'onRequestSetLastFocusedChild', last: subChild});
 		} else {
 			this._indexToFocus = inIndex;
 			this._subChildToFocus = inSubChild;


### PR DESCRIPTION
previous on LightPanels

Issue:
We remember last scroll position and focused item index on DataList when
teardown, then restore it on render if cached. The id of items are
different from previous render, so we refocus last focused item by
index.
We paused spotlight when LightPanels is transitioning to block any
unwanted focus change and resume it after render panel client.
But, this makes restoreState fails give focus on last focused item.

Fix:
We reset last focused child of panel when focusOnItem try to focus while
paused. So, that panel can safely remember last focused child and give
focus when it got focus after resume by checkSpottability.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)