### PR TITLE
ENYO-3446: Set margin-right as 9px if locale is right to left

### DIFF
--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -92,6 +92,7 @@
 			margin-right: 0;
 		}
 		.enyo-locale-right-to-left & > :last-child {
+			margin-right: 9px;
 			margin-left: 0;
 		}
 	}


### PR DESCRIPTION
There was a missing code that adding overrides for .enyo-locale-right-to-left
case. If we don't have that overriding prop, gap between buttons is 0.
We don't need to set margin-left as 0 in case of first-child since it's
already 0.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)