### PR TITLE
ENYO-3467: Block _spotNearestToPointer while LightPanel is in transition

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -194,6 +194,7 @@ module.exports = kind(
 				current = Spotlight.getCurrent();
 
 			Spotlight.resume();
+			Spotlight.setRecoverNoFocus(false);
 			spotlightPlaceholder.spotlight = false;
 			if (window.PalmSystem && window.PalmSystem.isActivated && Spotlight.isMuted()) {
 				Spotlight.unmute('window.focus');
@@ -202,11 +203,13 @@ module.exports = kind(
 				}
 			}
 			if (!Spotlight.isSpottable(this)) spotlightPlaceholder.spotlight = true;
-			if (!current || current === spotlightPlaceholder) {
-				setTimeout(this.bindSafely(function () {
+
+			setTimeout(this.bindSafely(function () {
+				Spotlight.setRecoverNoFocus(true);
+				if (!current || current === spotlightPlaceholder) {
 					Spotlight.spot(this);
-				}), 0);
-			}
+				}
+			}), 0);
 		}
 	},
 

--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -139,6 +139,7 @@ module.exports = kind(
 	* @public
 	*/
 	preTransition: function () {
+		Spotlight.setRecoverNoFocus(false);
 		LightPanel.prototype.preTransition.apply(this, arguments);
 
 		var current = Spotlight.getCurrent(),
@@ -194,7 +195,6 @@ module.exports = kind(
 				current = Spotlight.getCurrent();
 
 			Spotlight.resume();
-			Spotlight.setRecoverNoFocus(false);
 			spotlightPlaceholder.spotlight = false;
 			if (window.PalmSystem && window.PalmSystem.isActivated && Spotlight.isMuted()) {
 				Spotlight.unmute('window.focus');

--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -139,7 +139,6 @@ module.exports = kind(
 	* @public
 	*/
 	preTransition: function () {
-		Spotlight.setRecoverNoFocus(false);
 		LightPanel.prototype.preTransition.apply(this, arguments);
 
 		var current = Spotlight.getCurrent(),
@@ -195,6 +194,7 @@ module.exports = kind(
 				current = Spotlight.getCurrent();
 
 			Spotlight.resume();
+			Spotlight.setRecoverNoFocus(false);
 			spotlightPlaceholder.spotlight = false;
 			if (window.PalmSystem && window.PalmSystem.isActivated && Spotlight.isMuted()) {
 				Spotlight.unmute('window.focus');


### PR DESCRIPTION
Issue:
LightPanel pause spotlight on preTransition and resume spotlight on
postTransition. And give default focus on active panel in async call.
Spotlight recover focus when pressing 5way key while current focus is
not spottable or when no focus under pointer in pointer mode.
This can lead unexpected focus jump to first control in screen if press
repeated 5way key while panel transitioning.

Fix:
We add an API that blocking _spotNearestToPointer. And, block this
behavior between resume and default spot.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)