### PR TITLE
ENYO-3486: Notification popup client overflow when position adjust

### DIFF
--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -193,7 +193,7 @@ module.exports = kind(
 	*/
 	components: [
 		{name: 'message', kind: BodyText},
-		{name: 'client', kind: Control, classes: 'enyo-fill client moon-hspacing'}
+		{name: 'client', kind: Control, classes: 'client moon-hspacing'}
 	],
 
 	/**


### PR DESCRIPTION
routine sets explicit height

Notification popup have a enyo-fill class on client area. But, it
doesn't actually affect layout.

When applied post size adjust feature to fix floating point position
problem, popup get specific width or height. And this makes enyo-fill
calculate its height as 100% popup height in relative position. As a
result, client area overflow popup area.

To fix this problem, we can simply remove enyo-fill from client.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)