### PR TITLE
ENYO-3467: Unexpected focus jump if pressing 5way while transitioning

### DIFF
--- a/src/LightPanels/LightPanel.js
+++ b/src/LightPanels/LightPanel.js
@@ -105,7 +105,7 @@ module.exports = kind(
 	components: [
 		{kind: Header, name: 'header', type: 'medium', marqueeOnRenderDelay: 1000},
 		{name: 'client', classes: 'client', spotlight: 'container'},
-		{name: 'spotlightPlaceholder', spotlight: false, style: 'width:0;height:0;'}
+		{name: 'spotlightPlaceholder', spotlight: false, accessibilityDisabled: true, skipLastFocusUpdate: true, style: 'width:0;height:0;'}
 	],
 
 	/**
@@ -201,8 +201,9 @@ module.exports = kind(
 					Spotlight.setPointerMode(window.PalmSystem.cursor.visibility);
 				}
 			}
-			if (!Spotlight.isSpottable(this)) spotlightPlaceholder.spotlight = true;
+			if (!Spotlight.isSpottable(this, true)) spotlightPlaceholder.spotlight = true;
 			if (!current || current === spotlightPlaceholder) {
+				Spotlight.spot(spotlightPlaceholder);
 				setTimeout(this.bindSafely(function () {
 					Spotlight.spot(this);
 				}), 0);


### PR DESCRIPTION
lightPanels

Issue:
1) LightPanel pause spotlight on preTransition and resume spotlight on
postTransition. And give default focus on active panel in async call.
2) Spotlight recover focus when pressing 5way key while current focus is
not spottable or when no focus under pointer in pointer mode.
But, 2) can lead unexpected focus jump to first control in screen if press
repeated 5way key while panel transitioning.

Fix:
  Focus recover routine works only when current focus is not spottable
(null). So, we give focus to placeholder temporary between call
checkSpottability and setTimeout. We skip updating last focus of panel
when placeholder get focused to make setTimeout can give focus to actual
last focused child but not placeholder.
  If app give default focus by itself just after checkSpottability and
before setTimeout works, spotlight will safely move focus to specified
default control. And disableSpotlightPlaceholder will set spotlight
false on placeholder. Then setTimeout will give focus to panel and it
will convey focus to the specified default control again.
  The isSpottable return true when panel have spotlight container control.
And this will make placeholder spotlight false. This kind of situation
can happens when panel have scroller but not items in it. Panel will not
set spotlight true on placeholder in this case. The isSpottable have
second parameter that is skipping container control. By adding this, we
can set spotlight true on placeholder.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)
