### PR TITLE
ENYO-3507: Adjust transparent icon button neutral text color

### DIFF
--- a/src/IconButton/IconButton.less
+++ b/src/IconButton/IconButton.less
@@ -101,7 +101,7 @@
 			background-color: transparent;
 
 			.moon-neutral & {
-				color: @moon-neutral-button-text-color;
+				color: @moon-neutral-text-color;
 			}
 		}
 	}


### PR DESCRIPTION
Issue:
Neutral text color of icon button is white on active. And this
is not recognizable on white background.

Fix:
Adjust color of transparent icon button text from white to dark gray.
Don't need to modify translucent or opaque because it have dark
background.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)