### PR TITLE
ENYO-3490: Skip read when restore focus on same data list item

### DIFF
--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -66,7 +66,7 @@ var DataListSpotlightSupport = {
 	/**
 	* @private
 	*/
-	focusOnIndex: function (inIndex, inSubChild) {
+	focusOnIndex: function (inIndex, inSubChild, ext) {
 		var c = this.collection,
 			child,
 			subChild;
@@ -78,8 +78,8 @@ var DataListSpotlightSupport = {
 				child = this.childForIndex(inIndex);
 			}
 			subChild = inSubChild ? Spotlight.getChildren(child)[inSubChild] : child;
-			Spotlight.spot(subChild) || 
-				Spotlight.spot(this) || 
+			Spotlight.spot(subChild, ext) ||
+				Spotlight.spot(this, ext) ||
 				this.restoreStateOnRender && Spotlight.isPaused() && // For safe guard
 				this.bubble('onRequestSetLastFocusedChild', {type: 'onRequestSetLastFocusedChild', last: subChild});
 		} else {
@@ -445,6 +445,10 @@ var DataListSpotlightSupport = {
 			focusedItem = this.getItemFromChild(current);
 			this._indexToFocus = focusedItem.index;
 			this._subChildToFocus = focusedItem === current ? null : Spotlight.getChildren(focusedItem).indexOf(current);
+			// Remember additional key only when getKeyFromItem is given
+			if (this.primaryKey) {
+				this._focusedKey = (focusedItem.model && focusedItem.model.get(this.primaryKey)) || null;
+			}
 			return true;
 		}
 	},
@@ -456,6 +460,7 @@ var DataListSpotlightSupport = {
 		this._indexToFocus = -1;
 		this._maxVisibleIndex = -1;
 		this._subChildToFocus = null;
+		this._focusedKey = null;
 	},
 
 	/**
@@ -466,7 +471,7 @@ var DataListSpotlightSupport = {
 			maxVisibleIndex = this._maxVisibleIndex,
 			subChild = this._subChildToFocus,
 			c = this.collection,
-			callback;
+			callback, model, indexFromKey, bSkip = false;
 		if (c && c.length && (index > -1 || maxVisibleIndex > -1)) {
 			// If there's a valid maxVisibleIndex, we've saved a scroll position so we need to
 			// restore it and then update spotlight.
@@ -483,7 +488,21 @@ var DataListSpotlightSupport = {
 			}
 			// If we aren't restoring scroll position, we just need to update spotlight
 			else {
-				this.focusOnIndex(index, subChild);
+				// Restore focus based on key only when getIndexFromKey is given
+				if (this.primaryKey && this._focusedKey !== null) {
+					model = c.find(function (o) {
+						return o.get(this.primaryKey) == this._focusedKey;
+					}.bind(this));
+					indexFromKey = model && c.indexOf(model);
+					// If followFocusOnUpdate true, move focus to item that having the same key
+					if (this.followFocusOnUpdate) {
+						bSkip = !!model;
+						index = bSkip ? indexFromKey : index;
+					} else {
+						bSkip = indexFromKey === index;
+					}
+				}
+				this.focusOnIndex(index, subChild, {skipRead: bSkip});
 			}
 			this.clearState();
 		}

--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -49,7 +49,27 @@ var DataListSpotlightSupport = {
 		* @default false
 		* @public
 		*/
-		restoreStateOnRender: false
+		restoreStateOnRender: false,
+
+		/**
+		* A name of a property that can be used as a unique key. When set, 
+		* DataLists will try to follow focus on restore state.
+		*
+		* @type {String}
+		* @default null
+		* @public
+		*/
+		focusKey: null,
+
+		/**
+		* A name of a property that can be used to decide whether to read or not
+		* to read after update list.
+		*
+		* @type {String}
+		* @default null
+		* @public
+		*/
+		accessibilityKey: null
 	},
 
 	/**


### PR DESCRIPTION
Issue:
When data list update its list while item focused, data list remember
last focused item index on remove and restore it on add. When restore
focus, item content can be the same or different because it find item
based on index not content. When item restore focus on the item that
have the same content, TTS will read content. Problem happens when
update list frequently because it will read everytime it update.

Fix:
We add a property like 'primaryKey' just like collection, and skip read
when the key is the same.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)