### PR TITLE
ENYO-3455: Adjust dialog title and button area for no title case

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -16,6 +16,7 @@ var
 	Popup = require('../Popup'),
 	IconButton = require('../IconButton'),
 	BodyText = require('../BodyText'),
+	Divider = require('../Divider'),
 	HistorySupport = require('../HistorySupport'),
 	Marquee = require('../Marquee'),
 	MarqueeText = Marquee.Text,
@@ -152,13 +153,14 @@ module.exports = kind(
 	*/
 	tools: [
 		{name: 'closeButton', kind: IconButton, icon: 'closex', classes: 'moon-popup-close', ontap: 'closePopup', accessibilityLabel: $L('Close'), backgroundOpacity: 'transparent', showing: false},
-		{kind: Control, classes: 'moon-dialog-client-wrapper', components: [
+		{kind: Control, components: [
 			{name: 'client', kind: Control, classes: 'moon-hspacing moon-dialog-client'},
 			{name: 'titleWrapper', classes: 'moon-dialog-title-wrapper', components: [
 				{name: 'title', kind: MarqueeText, classes: 'moon-popup-header-text moon-dialog-title'},
 				{name: 'subTitle', kind: Control, classes: 'moon-dialog-sub-title'}
 			]}
 		]},
+		{name: 'divider', kind: Divider, classes: 'moon-dialog-divider'},
 		{name: 'message'},
 		{name: 'spotlightDummy', kind: Control, spotlight: false}
 	],
@@ -193,12 +195,11 @@ module.exports = kind(
 	titleChanged: function () {
 		var title = this.get('title');
 		// Logic so we don't show the divider and an empty title
+		this.addRemoveClass('no-title', !title);
 		if (!title) {
 			this.$.title.hide();
-			this.$.titleWrapper.removeClass('use-divider');
 		} else {
 			this.$.title.show();
-			this.useDividerChanged();
 			this.$.title.set('content', this.get('uppercase') ? util.toUpperCase(title) : title );
 		}
 	},
@@ -235,7 +236,7 @@ module.exports = kind(
 	* @private
 	*/
 	useDividerChanged: function () {
-		this.$.titleWrapper.addRemoveClass('use-divider', this.get('useDivider'));
+		this.$.divider.set('showing', this.get('useDivider'));
 	},
 
 	/**

--- a/src/Dialog/Dialog.less
+++ b/src/Dialog/Dialog.less
@@ -5,18 +5,17 @@
 	.moon-dialog-content {
 		margin: 0;
 	}
-	.moon-dialog-client-wrapper {
-		min-height: 108px;
-	}
 	.moon-dialog-title-wrapper {
-		&.use-divider {
-			padding-bottom: 18px;
-			margin: 0 0 18px;
-			border-bottom-width: 3px;
-			border-bottom-style: solid;
+		min-height: 108px;
+		.no-title& {
+			min-height: 60px;
 		}
 	}
-
+	.moon-dialog-divider {
+		padding-bottom: 0;
+		border-bottom-width: 3px;
+		margin: 18px 0 18px;
+	}
 	.moon-dialog-title {
 		line-height: @moon-small-header-line-height;
 		margin-bottom: 6px;
@@ -25,6 +24,9 @@
 	// Client is the button area
 	.moon-dialog-client {
 		padding: 24px 0 0;
+		.no-title& {
+			padding: 0;
+		}
 		float: right;
 		> * {
 			margin-left: @moon-grid-gutter-width;


### PR DESCRIPTION
Issue:
GUI use dialog with no title and use small button for this case.
When there is no title, button have too much top margin and title area
have too much space on bottom.

Fix:
We conditionally change margin and min-height for no title case.

enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)