### PR TITLE
ENYO-3546: Marquee doesn't show text after stop

### DIFF
--- a/src/Marquee/Marquee.js
+++ b/src/Marquee/Marquee.js
@@ -1017,6 +1017,9 @@ var MarqueeItem = {
 	*/
 	_marquee_addAnimationStyles: function (distance) {
 		if (!this.$.marqueeText) return;
+
+		clearTimeout(this._removeAnimationTimer);
+
 		var duration = this._marquee_calcDuration(distance);
 
 		this.$.marqueeText.addClass('animate-marquee');
@@ -1031,7 +1034,7 @@ var MarqueeItem = {
 		}
 
 		// Need this timeout for FF!
-		setTimeout(this.bindSafely(function () {
+		this._addAnimationTimer = setTimeout(this.bindSafely(function () {
 			if (options.accelerate) {
 				dom.transform(this.$.marqueeText, {translateX: this._marquee_adjustDistanceForRTL(distance) + 'px'});
 			} else {
@@ -1047,6 +1050,8 @@ var MarqueeItem = {
 		if (!this.$.marqueeText) {
 			return;
 		}
+		
+		clearTimeout(this._addAnimationTimer);
 
 		this.$.marqueeText.applyStyle('transition-duration', '0s');
 		this.$.marqueeText.applyStyle('-webkit-transition-duration', '0s');
@@ -1055,7 +1060,7 @@ var MarqueeItem = {
 		/**
 		* @private
 		*/
-		setTimeout(this.bindSafely(function () {
+		this._removeAnimationTimer = setTimeout(this.bindSafely(function () {
 			this.$.marqueeText.removeClass('animate-marquee');
 			if (options.accelerate) {
 				dom.transform(this.$.marqueeText, {translateX: null, translateZ: null});


### PR DESCRIPTION
Issue:
startMarquee and stopMarquee with marqueeDelay 0 will cause marquee text
dissapear. This happens because _marquee_addAnimationStyles have 16ms
delay for set translateX position. If _marquee_removeAnimationStyles is
called between the 16ms gap, _marquee_addAnimationStyles can set value
for translateX after remove animate-marquee and set duration as 0.
This will make marquee stop but also translateX for some amount of
distance (hidden).

Fix:
Clear setTimeout timer before apply style.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)