### PR TITLE
ENYO-3435: Apply new style for Progress control under neutral class

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -20,6 +20,9 @@
 @moon-neutral-button-disabled-text-color: #cdcdcd;
 @moon-neutral-button-disabled-bg-color: #686868;
 @moon-neutral-thumb-bg-color: rgba(50, 50, 50, 0.8);
+@moon-neutral-progress-bar-bg-color: #bbbbbb;
+@moon-neutral-progress-bg-bar-bg-color: #909090;
+@moon-neutral-progress-bar-bar-bg-color: @moon-dark-gray;
 
 
 // Icon Font

--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -20,7 +20,7 @@
 @moon-neutral-button-disabled-text-color: #cdcdcd;
 @moon-neutral-button-disabled-bg-color: #686868;
 @moon-neutral-thumb-bg-color: rgba(50, 50, 50, 0.8);
-@moon-neutral-progress-bar-bg-color: #bbbbbb;
+@moon-neutral-progress-bg-color: #bbbbbb;
 @moon-neutral-progress-bg-bar-bg-color: #909090;
 @moon-neutral-progress-bar-bar-bg-color: @moon-dark-gray;
 

--- a/src/ProgressBar/ProgressBar.less
+++ b/src/ProgressBar/ProgressBar.less
@@ -5,7 +5,7 @@
 	direction: ltr;
 
 	.moon-neutral & {
-		background-color: @moon-neutral-progress-bar-bg-color;
+		background-color: @moon-neutral-progress-bg-color;
 
 		.moon-progress-bg-bar {
 			background-color: @moon-neutral-progress-bg-bar-bg-color;

--- a/src/ProgressBar/ProgressBar.less
+++ b/src/ProgressBar/ProgressBar.less
@@ -4,6 +4,18 @@
 	background-color: @moon-progress-bg-color;
 	direction: ltr;
 
+	.moon-neutral & {
+		background-color: @moon-neutral-progress-bar-bg-color;
+
+		.moon-progress-bg-bar {
+			background-color: @moon-neutral-progress-bg-bar-bg-color;
+		}
+
+		.moon-progress-bar-bar {
+			background-color: @moon-neutral-progress-bar-bar-bg-color;
+		}
+	}
+
 	.moon-progress-bg-bar,
 	.moon-progress-bar-bar {
 		position: absolute;


### PR DESCRIPTION
There was a missing spec for Progress control when it displayed under
neutral class.
Dev/GUI team discussed about it and finalize spec as followings..

@moon-neutral-progress-bar-bg-color: #bbbbbb;
@moon-neutral-progress-bg-bar-bg-color: #909090;
@moon-neutral-progress-bar-bar-bg-color: @moon-dark-gray;

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)