### PR TITLE
ENYO-3527: Guard up spotlight if DataList didn't rendered yet

### DIFF
--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -226,37 +226,39 @@ var DataListSpotlightSupport = {
 	* @private
 	*/
 	_spotlightSelect: function (inEvent, inDirection) {
-		var pages = this.delegate.pagesByPosition(this),
-			spottableControl;
+		if (!this.spotlight) {
+			var pages = this.delegate.pagesByPosition(this),
+				spottableControl;
 
-		// If there are no spottable items generated in the current pages, generate the subsequent page(s)
-		// based on the current direction
-		if (!this.getNextSpottableChild(inDirection)) {
-			// Find the next spottable control in the appropriate direction
-			if (inDirection === 1) {
-				spottableControl = this.findSpottableControl(inDirection, pages.firstPage, pages.lastPage.index + 1);
-			} else if (inDirection === -1) {
-				spottableControl = this.findSpottableControl(inDirection, pages.lastPage, pages.firstPage.index - 1);
-			}
+			// If there are no spottable items generated in the current pages, generate the subsequent page(s)
+			// based on the current direction
+			if (!this.getNextSpottableChild(inDirection)) {
+				// Find the next spottable control in the appropriate direction
+				if (inDirection === 1) {
+					spottableControl = this.findSpottableControl(inDirection, pages.firstPage, pages.lastPage.index + 1);
+				} else if (inDirection === -1) {
+					spottableControl = this.findSpottableControl(inDirection, pages.lastPage, pages.firstPage.index - 1);
+				}
 
-			if (spottableControl) {
-				// Explicitly handle spotting of the control we found
-				Spotlight.spot(spottableControl);
-				return true;
-			}
-		} else if (this.needToAdjustPages) {
-			// Sometimes after models added, page adjustment might be required.
-			var pagesForIndex = this.delegate.pageForIndex(this, inEvent.index),
-				pageCount = this.delegate.pageCount(this),
-				lastPageIndex = pages.lastPage.index;
+				if (spottableControl) {
+					// Explicitly handle spotting of the control we found
+					Spotlight.spot(spottableControl);
+					return true;
+				}
+			} else if (this.needToAdjustPages) {
+				// Sometimes after models added, page adjustment might be required.
+				var pagesForIndex = this.delegate.pageForIndex(this, inEvent.index),
+					pageCount = this.delegate.pageCount(this),
+					lastPageIndex = pages.lastPage.index;
 
-			// If current selected index is lastPage and there is no page
-			// then lower bound of scrollThreshold is undefined because it is useless
-			// However after models are added then more pages could be generated
-			// We need to check whether current list's position passes scrollThreshold or not.
-			if (pagesForIndex === lastPageIndex && pageCount -1 !== lastPageIndex) {
-				this.didScroll(this, {scrollBounds: {left: null, top: null, xDir: 1, yDir: 1}});
-				this.needToAdjustPages = false;
+				// If current selected index is lastPage and there is no page
+				// then lower bound of scrollThreshold is undefined because it is useless
+				// However after models are added then more pages could be generated
+				// We need to check whether current list's position passes scrollThreshold or not.
+				if (pagesForIndex === lastPageIndex && pageCount -1 !== lastPageIndex) {
+					this.didScroll(this, {scrollBounds: {left: null, top: null, xDir: 1, yDir: 1}});
+					this.needToAdjustPages = false;
+				}
 			}
 		}
 	},

--- a/src/DataList/DataList.js
+++ b/src/DataList/DataList.js
@@ -226,7 +226,7 @@ var DataListSpotlightSupport = {
 	* @private
 	*/
 	_spotlightSelect: function (inEvent, inDirection) {
-		if (!this.spotlight) {
+		if (this.hasRendered) {
 			var pages = this.delegate.pagesByPosition(this),
 				spottableControl;
 


### PR DESCRIPTION
DataList._spotlightSelect() causes undefined reference on
VerticalDelegate.height().

I added guard code in DataList._spotlightSelect()

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)