### PR TITLE
ENYO-3616: Support brandTheme option for build time theme change

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,18 @@
 var
 	platform = require('enyo/platform'),
 	dispatcher = require('enyo/dispatcher'),
-	gesture = require('enyo/gesture');
+	gesture = require('enyo/gesture'),
+	dom = require('enyo/dom');
 
-exports = module.exports = require('./src/options');
+var
+	option = require('./src/options');
+
+// Support brand theme
+if (option.brandTheme) {
+	dom.addBodyClass('enyo-brand-theme-' + option.brandTheme);
+}
+
+exports = module.exports = option;
 exports.version = '2.6.4-rc.11';
 
 // Override the default holdpulse config to account for greater delays between keydown and keyup

--- a/src/options.js
+++ b/src/options.js
@@ -15,5 +15,6 @@ module.exports = utils.mixin({
 	accelerate: true,
 	renderOnShow: {
 		expandableListDrawer: true
-	}
+	},
+	brandTheme: null
 }, options, config);


### PR DESCRIPTION
Add brandTheme to moon.config (moonstone option).
Apply 'enyo-brand-theme-xxx' css on body when brandTheme is set on
build time.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)