### PR TITLE
ENYO-3572: Marquee doesn't flow on first set content

### DIFF
--- a/src/Marquee/Marquee.js
+++ b/src/Marquee/Marquee.js
@@ -856,11 +856,12 @@ var MarqueeItem = {
 	* @private
 	*/
 	_marquee_requestMarquee: function (sender, ev) {
+		this._marquee_puppetMaster = ev.originator;
+		
 		if (!ev || !this.showing || this._marquee_fits) {
 			return;
 		}
 
-		this._marquee_puppetMaster = ev.originator;
 		ev.originator.addMarqueeItem(this);
 
 		this.marqueePause = ev.marqueePause || 1000;


### PR DESCRIPTION
Issue:
Marquee is not remember puppet master when text fits content or it was
hidden when requested marquee.

Fix:
Remember puppetMaster regardless of adding Marquee item to wait list
or not.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)