### PR TITLE
ENYO-3590: Tooltip shows gap between rounded box and arrow when

### DIFF
--- a/src/Tooltip/Tooltip.less
+++ b/src/Tooltip/Tooltip.less
@@ -47,7 +47,7 @@
 		}
 		&.right-arrow {
 			.moon-tooltip-point {
-				transform: translate(100%,100%) rotate(90deg);
+				transform: translateY(-1px) translate(100%,100%) rotate(90deg);
 				bottom: 0;
 				right: 0;
 			}
@@ -68,7 +68,7 @@
 		}
 		&.right-arrow {
 			.moon-tooltip-point {
-				transform: translateX(100%) rotate(-90deg) scaleY(-1);
+				transform: translateY(1px) translateX(100%) rotate(-90deg) scaleY(-1);
 				right: 0;
 			}
 			.moon-tooltip-label {


### PR DESCRIPTION
positioned in floating point number

Issue:
Tooltip arrow is positioned by rotation and translate and use
single svg image. When Activator position and width make tooltip
position in floating point number. Rotation produce floating
calculation error.

Fix:
We make 1px overlap between tooltip and arrow for easy fix.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)