### PR TITLE
ENYO-3657: Notification popup message should break line in character for

### DIFF
--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -64,6 +64,11 @@
 		font-style: @moon-notification-font-style;
 		font-size: @moon-notification-font-size;
 		.moon-word-break;
+		.enyo-locale-ja &,
+		.enyo-locale-zh & {
+			word-wrap: normal;
+			word-break: normal;
+		}
 	}
 	.moon-body-text-spacing {
 		margin: 0;


### PR DESCRIPTION
ja zh locale

Notification doing break line in word level. New requirement is break
line in work level for Japaniese Chinese locale.

Enyo-DCO-1.1-Signed-off-by: Kunmyon Choi (kunmyon.choi@lge.com)