### PR TITLE
PLAT-29721: Prevents scrolling to boundary when hidden

### DIFF
--- a/src/Scroller/Scroller.js
+++ b/src/Scroller/Scroller.js
@@ -422,19 +422,21 @@ module.exports = kind(
 
 		if (o5WayEvent && (!strategy.isPageControl || !strategy.isPageControl(lastControl))) {
 			this.startJob('scrollToBoundary', function () {
-				switch (o5WayEvent.type) {
-					case 'onSpotlightUp':
-						if (top > 0) strategy.scrollTo(left, 0, animate);
-						break;
-					case 'onSpotlightDown':
-						if (top < b.maxTop) strategy.scrollTo(left, b.maxTop, animate);
-						break;
-					case 'onSpotlightLeft':
-						if (left > 0) strategy.scrollTo(0, top, animate);
-						break;
-					case 'onSpotlightRight':
-							if (left < b.maxLeft) strategy.scrollTo(b.maxLeft, top, animate);
+				if (this.getAbsoluteShowing()) {
+					switch (o5WayEvent.type) {
+						case 'onSpotlightUp':
+							if (top > 0) strategy.scrollTo(left, 0, animate);
 							break;
+						case 'onSpotlightDown':
+							if (top < b.maxTop) strategy.scrollTo(left, b.maxTop, animate);
+							break;
+						case 'onSpotlightLeft':
+							if (left > 0) strategy.scrollTo(0, top, animate);
+							break;
+						case 'onSpotlightRight':
+								if (left < b.maxLeft) strategy.scrollTo(b.maxLeft, top, animate);
+								break;
+					}
 				}
 			}, this.scrollToBoundaryDelay);
 		}


### PR DESCRIPTION
### Issue
When a `Scroller` is placed inside a control that can be hidden via a 5-way keypress, the 5-way keypress can trigger a `scrollToBoundary` which executes with a delay, and causes unnecessary scrolling while hidden. In the case of the `*.s` releases, we are muting Spotlight when scrolling, and thus there is a noticeable "hitch" from when the control is hidden to when the next control is spotted, due to the muting.

### Fix
It seems reasonable to prevent the `scrollToBoundary` job from executing if the control (or any of its ancestors) is hidden - we guard with a call to `getAbsoluteShowing`.

Issue: PLAT-29721
Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>