### PR TITLE
Japanese multi-line text blocks line-break in the wrong places.

### DIFF
--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -66,6 +66,7 @@
 	a:visited {color: @moon-spotlight-color; text-decoration:none;}
 	a:hover {color: @moon-spotlight-color; text-decoration:none;}
 	a:active {color: @moon-spotlight-color; text-decoration:none;}
+	.locale-japanese-line-break;
 }
 .moon-body-large-text {
 	font-size: @moon-body-font-size + 3;
@@ -119,6 +120,11 @@
 .moon-word-break {
 	word-wrap: break-word;
 	word-break: keep-all;
+}
+.locale-japanese-line-break {
+	.enyo-locale-ja & {
+		line-break: strict;
+	}
 }
 
 .enyo-locale-non-latin {

--- a/src/Item/Item.less
+++ b/src/Item/Item.less
@@ -26,6 +26,9 @@
 	> .moon-icon:first-child, > .moon-icon:last-child {
 		.moon-item-icon-tap-area-adjust;
 	}
+
+	word-wrap: break-word;
+	.locale-japanese-line-break;
 }
 
 .enyo-locale-non-latin .moon-item {

--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -63,12 +63,12 @@
 		font-weight: @moon-notification-font-weight;
 		font-style: @moon-notification-font-style;
 		font-size: @moon-notification-font-size;
-		.moon-word-break;
-		.enyo-locale-ja &,
+		word-wrap: break-word;
 		.enyo-locale-zh & {
 			word-wrap: normal;
 			word-break: normal;
 		}
+		.locale-japanese-line-break;
 	}
 	.moon-body-text-spacing {
 		margin: 0;

--- a/src/Popup/Popup.less
+++ b/src/Popup/Popup.less
@@ -28,6 +28,8 @@
 	&.moon-neutral {
 		background-color: fadeout(@moon-neutral-bg-color, 5%);
 	}
+	word-wrap: break-word;
+	.locale-japanese-line-break;
 }
 
 .moon-popup-close {

--- a/src/Tooltip/Tooltip.less
+++ b/src/Tooltip/Tooltip.less
@@ -8,11 +8,13 @@
 .moon-tooltip-label {
 	.moon-small-button-text;
 	line-height: @moon-tooltip-label-height;
-	white-space: nowrap;
 	color: @moon-tooltip-text-color;
 	padding: 12px (@moon-button-h-padding + 2);
 	background-color: @moon-tooltip-bg-color;
 	border-radius: (@moon-tooltip-height / 2);
+
+	word-wrap: break-word;
+	.locale-japanese-line-break;
 
 	.moon-tooltip.right-arrow & { text-align: right; }
 	.moon-tooltip.left-arrow & {


### PR DESCRIPTION
### Issue Resolved / Feature Added

Japanese multi-line text blocks line-break in the wrong places.

### Resolution

Added a Japanese language mixin to apply the correct line-break rules to the following multiline components: moonstone/BodyText, moonstone/Dialog, moonstone/Notification, moonstone/Popup, and moonstone/Tooltip