### PR TITLE
ENYO-4418: Change CheckboxItem to RadioItem in ExpandablePicker

### DIFF
--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -344,12 +344,14 @@ module.exports = kind(
 			}
 		} else {
 			for (i=0;i<controls.length;i++) {
+				var type = typeof controls[i].selected === 'boolean' ? 'selected' : 'checked';
+
 				if(controls[i] === selected) {
-					controls[i].setSelected(true);
+					controls[i].set(type, true);
 					index = i;
-				} else if (controls[i].selected) {
+				} else if (controls[i].get(type)) {
 					controls[i].silence();
-					controls[i].setSelected(false);
+					controls[i].set(type, false);
 					controls[i].unsilence();
 				}
 			}

--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -16,7 +16,8 @@ var
 var
 	BodyText = require('../BodyText'),
 	CheckboxItem = require('../CheckboxItem'),
-	ExpandableListItem = require('../ExpandableListItem');
+	ExpandableListItem = require('../ExpandableListItem'),
+	RadioItem = require('../RadioItem');
 
 /**
 * Fires when the currently selected item changes.
@@ -193,7 +194,7 @@ module.exports = kind(
 	/**
 	* @private
 	*/
-	defaultKind: CheckboxItem,
+	defaultKind: RadioItem,
 
 	/**
 	* @private
@@ -238,6 +239,7 @@ module.exports = kind(
 		if (this.multipleSelection) {
 			this.selected = (this.selected) ? this.selected : [];
 			this.selectedIndex = (this.selectedIndex != -1) ? this.selectedIndex : [];
+			this.defaultKind = CheckboxItem;
 		}
 		// super initialization
 		ExpandableListItem.prototype.create.apply(this, arguments);
@@ -343,11 +345,11 @@ module.exports = kind(
 		} else {
 			for (i=0;i<controls.length;i++) {
 				if(controls[i] === selected) {
-					controls[i].setChecked(true);
+					controls[i].setSelected(true);
 					index = i;
-				} else if (controls[i].checked) {
+				} else if (controls[i].selected) {
 					controls[i].silence();
-					controls[i].setChecked(false);
+					controls[i].setSelected(false);
 					controls[i].unsilence();
 				}
 			}

--- a/src/ExpandablePicker/ExpandablePicker.less
+++ b/src/ExpandablePicker/ExpandablePicker.less
@@ -2,3 +2,10 @@
 .moon-expandable-picker-help-text {
 	color: @moon-help-text-color;
 }
+
+.moon-expandable-picker {
+	.moon-radio-item {
+		display: block;
+		max-width: none;
+	}
+}

--- a/src/RadioItem/RadioItem.js
+++ b/src/RadioItem/RadioItem.js
@@ -51,6 +51,7 @@ module.exports = kind(
 		SelectableItem.prototype.create.apply(this, arguments);
 		this.removeClass('moon-selectable-item');
 		this.addClass('moon-radio-item');
+		this.activeChanged();
 	},
 
 	/**

--- a/src/RadioItem/RadioItem.js
+++ b/src/RadioItem/RadioItem.js
@@ -40,9 +40,25 @@ module.exports = kind(
 	/**
 	* @private
 	*/
+	handlers: {
+		onActivate: 'decorateActivateEvent'
+	},
+
+	/**
+	* @private
+	*/
 	create: function() {
 		SelectableItem.prototype.create.apply(this, arguments);
 		this.removeClass('moon-selectable-item');
 		this.addClass('moon-radio-item');
+	},
+
+	/**
+	* @fires module:moonstone/RadioItem~RadioItem#onActivate
+	* @private
+	*/
+	decorateActivateEvent: function (sender, ev) {
+		ev.toggledControl = this;
+		ev.checked = this.selected;
 	}
 });


### PR DESCRIPTION
When single selection mode, change CheckboxItem to RadioItem in ExpandablePicker.

Enyo-DCO-1.1-Signed-off-by: Changgi Lee <changgi.lee@lge.com>