### PR TITLE
NewDataList: scroll to nearest when it scrolls (enyo)

### DIFF
--- a/src/Scrollable/Scrollable.js
+++ b/src/Scrollable/Scrollable.js
@@ -61,7 +61,7 @@ var Scrollable = {
 	create: kind.inherit(function (sup) {
 		return function () {
 			var opts = {
-				block: 'farthest',
+				block: 'nearest',
 				behavior: 'smooth'
 			};
 


### PR DESCRIPTION
Per our last meeting about polishing VirtualList's spec, it should
scroll to nearest when we move down via 5way key.
(Refer to table in http://collab.lge.com/main/x/x1EsIg)

To improvement UX, I changed default block opt of Scrollable from
'farthest' to 'nearest'.

Enyo-DCO-1.1-Signed-off-by: Yeram Choi (yeram.choi@lge.com)