### PR TITLE
When an item is selected in ExpandableDataPickerSample, it falls into…

### DIFF
--- a/src/ExpandablePicker/ExpandablePicker.js
+++ b/src/ExpandablePicker/ExpandablePicker.js
@@ -247,11 +247,6 @@ module.exports = kind(
 		this.selectedIndexChanged();
 		this.helpTextChanged();
 		this.createChrome(this.tools);
-
-		var controls = this.getCheckboxControls();
-		for (var i=0; i < controls.length; i++) {
-			if (controls[i].initSelected) controls[i].initSelected();
-		}
 	},
 
 	/**

--- a/src/RadioItem/RadioItem.js
+++ b/src/RadioItem/RadioItem.js
@@ -51,6 +51,9 @@ module.exports = kind(
 		SelectableItem.prototype.create.apply(this, arguments);
 		this.removeClass('moon-selectable-item');
 		this.addClass('moon-radio-item');
+		if (this.active) {
+			this.activeChanged();
+		}
 	},
 
 	/**
@@ -60,9 +63,5 @@ module.exports = kind(
 	decorateActivateEvent: function (sender, ev) {
 		ev.toggledControl = this;
 		ev.checked = this.selected;
-	},
-
-	initSelected: function() {
-		if (this.active) this.setSelected(this.active);
 	}
 });

--- a/src/SelectableItem/SelectableItem.js
+++ b/src/SelectableItem/SelectableItem.js
@@ -47,19 +47,19 @@ module.exports = kind(
 	* @private
 	*/
 	kind: Item,
-	
+
 	/**
 	* @private
 	*/
 	classes: 'moon-selectable-item',
-	
+
 	/**
 	* @private
 	*/
 	events: {
 		onActivate: ''
 	},
-	
+
 	/**
 	* @private
 	*/
@@ -95,7 +95,7 @@ module.exports = kind(
 		* @public
 		*/
 		active: false,
-		
+
 		/**
 		* If used as the base control within a {@link module:moonstone/DataList~DataList} or {@glossary subkind},
 		* this should be set to `false` so that selection support can be synchronized to the
@@ -107,7 +107,7 @@ module.exports = kind(
 		*/
 		handleTapEvent: true
 	},
-	
+
 	/**
 	* @method
 	* @private
@@ -140,7 +140,7 @@ module.exports = kind(
 		if (this.disabled) {
 			return true;
 		}
-		if (this.handleTapEvent) {
+		if (this.handleTapEvent && !(this.selected && this.active)) {
 			this.setActive(!this.getActive());
 			this.bubble('onchange');
 		}
@@ -185,7 +185,9 @@ module.exports = kind(
 		this.active = utils.isTrue(this.active);
 		this.setSelected(this.active);
 		this.resetMarquee();
-		this.bubble('onActivate');
+		if (this.active) {
+			this.bubble('onActivate');
+		}
 	},
 
 	// Accessibility


### PR DESCRIPTION
### Issue
When an item is selected in ExpandableDataPickerSample, it falls into an infinite loop.
So, application is stopped.

### Fix
Modified activateChanged handler is called when this.active is equeal to `true`.
Changed tap event handler of SelectableItem to be called when both 'selected' and 'active' are equal to `true`.

ENYO-4657 Enyo: when an item is selected in ExpandableDataPicker, it falls into an infinite loop
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com