### PR TITLE
ENYO-4581 String is cut off for 'sinhala' language in Input component.

### DIFF
--- a/src/Input/Input.less
+++ b/src/Input/Input.less
@@ -1,5 +1,8 @@
 /* Input.css */
 .moon-input {
+	line-height: 57px;
+	height: 57px;
+
 	padding: 0;
 	border: 0;
 	cursor: pointer;
@@ -58,27 +61,4 @@
 
 .enyo-locale-right-to-left .moon-input {
 	text-align: right;
-}
-
-.enyo-locale-non-latin {
-	// Languages with combining accent characters
-	&.enyo-locale-th, // Thai - Test Chars: ฟิ้ไััุุ
-	&.enyo-locale-ar, // Arabic
-	&.enyo-locale-fa, // Farsi
-	&.enyo-locale-ur, // Urdu
-	&.enyo-locale-ku, // Kurdish
-	&.enyo-locale-he, // Hebrew
-	&.enyo-locale-hi, // Hindi
-	&.enyo-locale-ta, // Tamil
-	&.enyo-locale-te, // Telugu
-	&.enyo-locale-kn, // Kannada
-	&.enyo-locale-ml, // Malayalam
-	&.enyo-locale-mr, // Marathi
-	&.enyo-locale-bn, // Bengali
-	&.enyo-locale-pa {// Panjabi
-		.moon-input-decorator .moon-input {
-			font-size: 24px;
-			line-height: 48px
-		}
-	}
 }

--- a/src/InputDecorator/InputDecorator.less
+++ b/src/InputDecorator/InputDecorator.less
@@ -30,7 +30,7 @@
 }
 
 .moon-input-decorator:not(.moon-input-header-input-decorator) {
-	padding: 12px 30px;
+	padding: 3px 30px;
 	border-radius: 1008px;
 }
 
@@ -41,30 +41,4 @@
 
 .moon-expandable-input .moon-input-decorator:not(.moon-input-header-input-decorator) {
 	margin: 6px 0;
-}
-
-.enyo-locale-non-latin {
-	.moon-input-decorator:not(.moon-input-header-input-decorator) {
-		padding: 6px 30px 12px;
-	}
-
-	// Languages with combining accent characters
-	&.enyo-locale-th, // Thai
-	&.enyo-locale-ar, // Arabic
-	&.enyo-locale-fa, // Farsi
-	&.enyo-locale-ur, // Urdu
-	&.enyo-locale-ku, // Kurdish
-	&.enyo-locale-he, // Hebrew
-	&.enyo-locale-hi, // Hindi
-	&.enyo-locale-ta, // Tamil
-	&.enyo-locale-te, // Telugu
-	&.enyo-locale-kn, // Kannada
-	&.enyo-locale-ml, // Malayalam
-	&.enyo-locale-mr, // Marathi
-	&.enyo-locale-bn, // Bengali
-	&.enyo-locale-pa {// Panjabi
-		.moon-input-decorator:not(.moon-input-header-input-decorator) {
-			padding: 1px 30px;
-		}
-	}
 }


### PR DESCRIPTION
### Issue
String is cut off for 'sinhala' language in Input component.
We can see this issue when we set locale to latin.

### Fix
It needs to fix for Enyo as Enact was changed. (Migration)
So it's based on https://github.com/enyojs/enact/pull/1134.

ENYO-4581 Input: string is cut off for 'sinhala' language
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com