### PR TITLE
(Enyo) InputHeader: it needs to add exception from 'Input' pre-fix

### DIFF
--- a/src/Header/Header.less
+++ b/src/Header/Header.less
@@ -167,6 +167,7 @@
 				color: inherit;
 				width: 100%;
 				text-overflow: ellipsis;
+				height: inherit;
 
 				.input-placeholder({
 					color: @moon-input-header-placeholder-color;


### PR DESCRIPTION
### Issue
InputHeader is cut off because Input height was changed.

### Fix
InputHeader shouldn't be applied changed height from Input.
So, I added hegiht: inherit; to Header.less to maintain original height size.

ENYO-4862 (Enyo) InputHeader: it needs to add exception from 'Input' pre-fix
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com