### PR TITLE
ENYO-4863: Notification: it needs to match break rule from Enact.

### DIFF
--- a/css/moonstone-text.less
+++ b/css/moonstone-text.less
@@ -118,7 +118,7 @@
 	color: @moon-divider-text-color;
 }
 .moon-word-break {
-	word-wrap: break-word;
+	overflow-wrap: break-word;
 	word-break: keep-all;
 }
 .locale-japanese-line-break {

--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -63,9 +63,9 @@
 		font-weight: @moon-notification-font-weight;
 		font-style: @moon-notification-font-style;
 		font-size: @moon-notification-font-size;
-		word-wrap: break-word;
+		.moon-word-break;
+		.enyo-locale-ja &,
 		.enyo-locale-zh & {
-			word-wrap: normal;
 			word-break: normal;
 		}
 		.locale-japanese-line-break;

--- a/src/Notification/Notification.less
+++ b/src/Notification/Notification.less
@@ -66,6 +66,7 @@
 		.moon-word-break;
 		.enyo-locale-ja &,
 		.enyo-locale-zh & {
+			overflow-wrap: normal;
 			word-break: normal;
 		}
 		.locale-japanese-line-break;


### PR DESCRIPTION
### Issue
Notification: it needs to match break rule from Enact.

### Fix
'moon-word-break' was rolled back to use mixins.
'enyo-locale-ja' was added.
'word-wrap: normal;' was removed to fix overflow issue.

ENYO-4863 Notification: it needs to match break rule from Enact
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com