### PR TITLE
ENYO-4896 Header: Title below is truncated on si-LK locale

### DIFF
--- a/css/moonstone-variables.less
+++ b/css/moonstone-variables.less
@@ -117,7 +117,7 @@
 @moon-non-latin-divider-font-size:      27px;
 @moon-non-latin-button-large-font-size: 36px;
 @moon-non-latin-button-small-font-size: 27px;
-@moon-non-latin-header-font-size:       102px;
+@moon-non-latin-header-font-size:       96px;
 @moon-non-latin-expandable-client-item-font-size: 27px;
 
 

--- a/src/Header/Header.less
+++ b/src/Header/Header.less
@@ -82,7 +82,7 @@
 
 		.moon-header-title-below,
 		.moon-header-sub-title-below {
-			line-height: 39px;
+			line-height: 45px;
 		}
 	}
 


### PR DESCRIPTION
### Issue
Title below is truncated on si-LK locale.
### Fix
I changed non-latin-header-font-size from '102px' to '96px'.
Also, I changed line-height value from '39px' to '45px'.
If font size is 22px, we have to guarantee about 30px.
Because it needs space for text area and some gap area by below formula.
(22px * 1.36 = 29.92 (about 30px))

ENYO-4896 Header: Title below is truncated on si-LK locale
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com