### PR TITLE
ENYO-4921 Spinner: it doesn't set transparent property

### DIFF
--- a/src/Spinner/Spinner.less
+++ b/src/Spinner/Spinner.less
@@ -156,6 +156,9 @@
 		.moon-neutral & > * {
 			color: @moon-spinner-transparent-text-color;
 		}
+		.moon-spinner-ball-decorator {
+			background-color: transparent;
+		}
 	}
 	&.content {
 		padding: ((@moon-button-height - @moon-spinner-size) / 2);


### PR DESCRIPTION
### Issue
I found that this issue occurs since 2.6.4-rc.15 by investigating when this occurred. The reason why this problem occurs is that {{background-color}} isn't changed to {{transparent}} even if transparent property is set.

### Fix
ball-decorator needs to be set background-color to 'transparent' when the spinner has transparent property.

ENYO-4921 Spinner: it doesn't set transparent property
Enyo-DCO-1.1-Signed-off-by: Sangwook Lee sangwook1203.lee@lge.com