### PR TITLE
Use node14 instead of lts for Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-    - "14"
+  - "14"
 cache:
   directories:
   - $HOME/.npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "node"
+    - "14"
 cache:
   directories:
   - $HOME/.npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "14"
+  - "12"
 cache:
   directories:
   - $HOME/.npm


### PR DESCRIPTION
node 16 became LTS version.
Use node14 to prevent Travis test fail
Enact-DCO-1.0-Signed-off-by: Jeonghee Ahn (jeonghee27.ahn@lge.com